### PR TITLE
クロスオリジンに対応(現状http://localhost:8080のみ)

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-xorm/xorm"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo-contrib/session"
+	"github.com/labstack/echo/middleware"
 	"github.com/srinathgs/mysqlstore"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/router"
@@ -54,6 +55,10 @@ func main() {
 	}
 
 	e := echo.New()
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins:     []string{"http://localhost:8080"},
+		AllowCredentials: true,
+	}))
 	e.Use(session.Middleware(store))
 	e.HTTPErrorHandler = router.CustomHTTPErrorHandler
 


### PR DESCRIPTION
Close #57 
クロスオリジンでのAPI呼び出しに対応しました。
多分クライアント側でwithCredentialsオプションをつけることになると思うんですが、その場合スキーマ・ドメイン・ポートすべてが指定されていないとだめなので現状はhttp://localhost:8080のみの指定になっています。
もし追加が必要であれば適宜追加していきます。