### PR TITLE
FileのAPIの実装

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -933,6 +933,122 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
+  /file:
+    post:
+      tags:
+        - file
+      description: ファイルをアップロードします
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/UploadFile"
+      responses:
+        "201":
+          description: |+
+            正常にファイルが追加されました
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+
+  /file/{fileID}:
+    parameters:
+      - $ref: "#/components/parameters/fileIdInPath"
+    get:
+      tags:
+        - file
+      description: 指定したファイルの中身を取得します。
+      responses:
+        "200":
+          description: |+
+            正常に取得できました。
+            fileのbinaryを返します
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: |+
+            取得できませんでした。
+            指定されたスタンプは存在しません。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+    delete:
+      tags:
+        - file
+      description: 指定したメッセージを削除します。
+      responses:
+        "204":
+          description: |+
+            正常に削除できました。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+        "403":
+          description: |+
+            削除できませんでした。
+            指定されたファイルを削除する権限がありません。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+        "404":
+          description: |+
+            削除できませんでした。
+            指定されたファイルは存在しないか、自分のスコープ内にありません。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+
+  /file/{fileID}/meta:
+    parameters:
+      - $ref: "#/components/parameters/fileIdInPath"
+    get:
+      tags:
+        - file
+      description: 指定したファイルのメタデータを取得します
+      responses:
+        "200":
+          description: |+
+            正常に取得できました。
+            メタデータを返します。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileInfo"
+        "404":
+          description: |+
+            取得できませんでした。
+            指定されたファイルは存在しません。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NoContent"
+
+  /file/{fileID}/thumnail:
+    parameters:
+      - $ref: "#/components/parameters/fileIdInPath"
+    get:
+      tags:
+        - file
+      description: 指定したファイルのサムネイルを取得します
+      responses:
+        "200":
+          description: |+
+            正常に取得できました。
+            サムネイルを返します。
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+
   /messages/{messageID}:
     parameters:
       - $ref: "#/components/parameters/messageIdInPath"
@@ -1193,7 +1309,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
-  /notification:
+ /notification:
     get:
       tags:
         - notification
@@ -1228,6 +1344,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NoContent"
+
 
 components:
   parameters:
@@ -1271,6 +1388,13 @@ components:
       schema:
         type: string
         format: uuid
+    fileIdInPath:
+      name: fileID
+      description: 操作の対象となるファイルID
+      in: path
+      required: true
+      schema:
+        type: string
   schemas:
     Channel:
       type: object
@@ -1423,6 +1547,29 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Stamp"
+
+    UploadFile:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+
+    FileInfo:
+      type: object
+      properties:
+        fileId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        mime:
+          type: string
+        size:
+          type: integer
+        dateTime:
+          type: string
+          format: date-time
 
     UnreadList:
       type: array

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -933,7 +933,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
-  /file:
+  /files:
     post:
       tags:
         - file
@@ -953,7 +953,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FileInfo"
 
-  /file/{fileID}:
+  /files/{fileID}:
     parameters:
       - $ref: "#/components/parameters/fileIdInPath"
     get:
@@ -1008,7 +1008,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
-  /file/{fileID}/meta:
+  /files/{fileID}/meta:
     parameters:
       - $ref: "#/components/parameters/fileIdInPath"
     get:
@@ -1033,7 +1033,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
-  /file/{fileID}/thumnail:
+  /files/{fileID}/thumnail:
     parameters:
       - $ref: "#/components/parameters/fileIdInPath"
     get:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -947,10 +947,11 @@ paths:
         "201":
           description: |+
             正常にファイルが追加されました
+            メタデータを返します。
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NoContent"
+                $ref: "#/components/schemas/FileInfo"
 
   /file/{fileID}:
     parameters:
@@ -963,7 +964,8 @@ paths:
         "200":
           description: |+
             正常に取得できました。
-            fileのbinaryを返します
+            fileのbinaryを返します。
+            application/octet-streamで返すことになっていますが、ファイルの形式によっては変わります。
           content:
             application/octet-stream:
               schema:

--- a/main.go
+++ b/main.go
@@ -127,6 +127,12 @@ func main() {
 	api.GET("/channels/:channelID/notification", router.GetNotificationStatus)
 	api.PUT("/channels/:channelID/notification", router.PutNotificationStatus)
 
+	// Tag: file
+	api.POST("/files", router.PostFile)
+	api.GET("/files/:fileID", router.GetFileByID)
+	api.DELETE("/files/:fileID", router.DeleteFileByID)
+	api.GET("/files/:fileID/meta", router.GetMetaDataByFileID)
+
 	// init notification
 	notification.Start()
 

--- a/model/files.go
+++ b/model/files.go
@@ -138,10 +138,10 @@ func (fm *devFileManager) OpenFileByID(ID string) (*os.File, error) {
 	return reader, nil
 }
 
-// WriteByID /img/nameにデータを書き込みます
+// WriteByID srcの内容をIDで指定されたファイルに書き込みます
 func (fm *devFileManager) WriteByID(src io.Reader, ID string) error {
 	if _, err := os.Stat(dirName); err != nil {
-		if err = os.Mkdir(dirName, 0666); err != nil {
+		if err = os.Mkdir(dirName, 0700); err != nil {
 			return fmt.Errorf("Can't create directory: %v", err)
 		}
 	}

--- a/model/files.go
+++ b/model/files.go
@@ -1,0 +1,159 @@
+package model
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileWriter ファイルに書き込むインターフェース
+type FileWriter interface {
+	//*io.Readerのデータをstringで指定された名前で保存する
+	WriteByID(io.Reader, string) error
+}
+
+// FileReader ファイルを読み込むインターフェース
+type FileReader interface {
+	//stringで指定された名前のファイルを取り出す
+	ReadByID(string) ([]byte, error)
+}
+
+// File DBに格納するファイルの構造体
+type File struct {
+	ID        string    `xorm:"char(36) pk"`
+	Name      string    `xorm:"text not null"`
+	Mime      string    `xorm:"text not null"`
+	Size      int64     `xomr:"bigint not null"`
+	CreatorID string    `xorm:"char(36) not null"`
+	IsDeleted bool      `xorm:"bool not null"`
+	Hash      string    `xorm:"char(32) not null"`
+	CreatedAt time.Time `xorm:"created not null"`
+}
+
+// TableName dbのtableの名前を返します
+func (f *File) TableName() string {
+	return "files"
+}
+
+// Create file構造体を作ります
+func (f *File) Create(src io.Reader) error {
+	if f.Name == "" {
+		return fmt.Errorf("file name is empty")
+	}
+	if f.Size == 0 {
+		return fmt.Errorf("file size is 0")
+	}
+	if f.CreatorID == "" {
+		return fmt.Errorf("file creatorID is empty")
+	}
+
+	f.ID = CreateUUID()
+	f.IsDeleted = false
+	f.Mime = filepath.Ext(f.Name)
+
+	var writer FileWriter
+	writer = &devFileManager{} //dependent on dev environment
+	if err := writer.WriteByID(src, f.ID); err != nil {
+		return fmt.Errorf("Failed to write data into file: %v", err)
+	}
+
+	hash, err := calcMD5(src)
+	if err != nil {
+		return err
+	}
+	f.Hash = hash
+
+	if _, err := db.Insert(f); err != nil {
+		return fmt.Errorf("Failed to create file")
+	}
+	return nil
+}
+
+// Delete file構造体をDBから消去します
+func (f *File) Delete() error {
+	f.IsDeleted = true
+	if _, err := db.ID(f.ID).UseBool().Update(f); err != nil {
+		return fmt.Errorf("Failed to make Isdeleted true")
+	}
+	return nil
+}
+
+// GetFileByID ファイルを取得します
+func GetFileByID(ID string) ([]byte, error) {
+	//TODO: テストコード
+	var reader FileReader
+	reader = &devFileManager{} //dependent on dev environment
+	return reader.ReadByID(ID)
+}
+
+// GetMetaFileDataByID ファイルのメタデータを取得します
+func GetMetaFileDataByID(FileID string) (*File, error) {
+	f := &File{}
+
+	has, err := db.ID(FileID).Get(f)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to find file")
+	}
+	if !has {
+		return nil, fmt.Errorf("The file doesn't exist")
+	}
+
+	return f, nil
+}
+
+// 与えられたデータに対してMD5によるハッシュ値を計算します
+func calcMD5(src io.Reader) (string, error) {
+	h := md5.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", fmt.Errorf("Failed to calc md5")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// 以下、開発環境用
+
+var (
+	dirName = "../resources"
+)
+
+type devFileManager struct{}
+
+//ReadByID ファイルを取得します
+func (fm *devFileManager) ReadByID(ID string) ([]byte, error) {
+	fileName := dirName + "/" + ID
+	if _, err := os.Stat(fileName); err != nil {
+		return nil, fmt.Errorf("Invalid ID: %s", ID)
+	}
+
+	b, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read file: %v", err)
+	}
+
+	return b, nil
+}
+
+// WriteByID /img/nameにデータを書き込みます
+func (fm *devFileManager) WriteByID(src io.Reader, ID string) error {
+	if _, err := os.Stat(dirName); err != nil {
+		if err = os.Mkdir(dirName, 0666); err != nil {
+			return fmt.Errorf("Can't create directory: %v", err)
+		}
+	}
+
+	file, err := os.Create(dirName + "/" + ID)
+	if err != nil {
+		return fmt.Errorf("Failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, src); err != nil {
+		return fmt.Errorf("Failed to write into file %v", err)
+	}
+	return nil
+}

--- a/model/files_test.go
+++ b/model/files_test.go
@@ -46,10 +46,16 @@ func TestGetFileByID(t *testing.T) {
 	beforeTest(t)
 	assert := assert.New(t)
 
-	file := mustMakeFile(t)
-	b, err := GetFileByID(file.ID)
+	f := mustMakeFile(t)
+	file, err := OpenFileByID(f.ID)
+	assert.NoError(err)
+	defer file.Close()
+
+	buf := make([]byte, 512)
+	n, err := file.Read(buf)
+
 	if assert.NoError(err) {
-		assert.Equal("test message", string(b))
+		assert.Equal("test message", string(buf[:n]))
 	}
 }
 

--- a/model/files_test.go
+++ b/model/files_test.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFile_TableName(t *testing.T) {
+	assert.Equal(t, "files", (&File{}).TableName())
+}
+
+func TestFile_Create(t *testing.T) {
+	beforeTest(t)
+	assert := assert.New(t)
+	writeData := bytes.NewReader(([]byte)("test message"))
+
+	assert.Error((&File{}).Create(writeData))
+	assert.Error((&File{ID: CreateUUID()}).Create(writeData))
+
+	file := &File{
+		Name:      "testFile.txt",
+		Size:      writeData.Size(),
+		CreatorID: testUserID,
+	}
+	if assert.NoError(file.Create(writeData)) {
+		assert.NotEmpty(file.ID)
+		_, err := os.Stat(dirName + "/" + file.ID)
+		assert.NoError(err)
+	}
+}
+
+func TestFile_Delete(t *testing.T) {
+	beforeTest(t)
+	assert := assert.New(t)
+
+	file := mustMakeFile(t)
+	file.IsDeleted = true
+
+	assert.NoError(file.Delete())
+}
+
+func TestGetFileByID(t *testing.T) {
+	beforeTest(t)
+	assert := assert.New(t)
+
+	file := mustMakeFile(t)
+	b, err := GetFileByID(file.ID)
+	if assert.NoError(err) {
+		assert.Equal("test message", string(b))
+	}
+}
+
+func TestGetMetaFileDataByID(t *testing.T) {
+	beforeTest(t)
+	assert := assert.New(t)
+
+	file := mustMakeFile(t)
+	result, err := GetMetaFileDataByID(file.ID)
+	if assert.NoError(err) {
+		assert.Equal(file.ID, result.ID)
+	}
+
+	_, err = GetMetaFileDataByID("wrongID")
+	assert.Error(err)
+}

--- a/model/utils.go
+++ b/model/utils.go
@@ -35,6 +35,10 @@ func SyncSchema() error {
 		return fmt.Errorf("Failed to sync Table schema: %v", err)
 	}
 
+	if err := db.Sync(&File{}); err != nil {
+		return fmt.Errorf("failed to sync files Table: %v", err)
+	}
+
 	traq := &User{
 		Name:  "traq",
 		Email: "trap.titech@gmail.com",

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"testing"
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 	}
 	defer engine.Close()
 	engine.ShowSQL(false)
-	engine.DropTables("sessions", "channels", "users_private_channels", "messages", "users", "clips", "stars", "users_tags", "tags", "unreads", "devices", "users_subscribe_channels")
+	engine.DropTables("sessions", "channels", "users_private_channels", "messages", "users", "clips", "stars", "users_tags", "tags", "unreads", "devices", "users_subscribe_channels", "files")
 
 	engine.SetMapper(core.GonicMapper{})
 	SetXORMEngine(engine)
@@ -53,11 +54,12 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	code := m.Run()
+	os.RemoveAll(dirName)
 	os.Exit(code)
 }
 
 func beforeTest(t *testing.T) {
-	require.NoError(t, engine.DropTables("sessions", "channels", "users_private_channels", "messages", "users", "clips", "stars", "users_tags", "tags", "unreads", "devices", "users_subscribe_channels"))
+	require.NoError(t, engine.DropTables("sessions", "channels", "users_private_channels", "messages", "users", "clips", "stars", "users_tags", "tags", "unreads", "devices", "users_subscribe_channels", "files"))
 	require.NoError(t, SyncSchema())
 }
 
@@ -99,6 +101,16 @@ func mustMakeUser(t *testing.T, userName string) *User {
 	require.NoError(t, user.SetPassword(password))
 	require.NoError(t, user.Create())
 	return user
+}
+
+func mustMakeFile(t *testing.T) *File {
+	file := &File{
+		Name:      "test.txt",
+		Size:      90,
+		CreatorID: testUserID,
+	}
+	require.NoError(t, file.Create(bytes.NewBufferString("test message")))
+	return file
 }
 
 func checkEmptyField(user *User) error {

--- a/router/files.go
+++ b/router/files.go
@@ -1,0 +1,96 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/traPtitech/traQ/model"
+)
+
+// FileForResponse クライアントに返すファイル構造体
+type FileForResponse struct {
+	ID       string `json:"fileID"`
+	Name     string `json:"name"`
+	Mime     string `json:"mime"`
+	Size     int64  `json:"size"`
+	DateTime string `json:"datetime"`
+}
+
+// PostFile POST /file のハンドラ
+func PostFile(c echo.Context) error {
+	userID := c.Get("user").(*model.User).ID
+
+	uploadedFile, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Failed to upload file: %v", err))
+	}
+
+	file := &model.File{
+		Name:      uploadedFile.Filename,
+		Size:      uploadedFile.Size,
+		CreatorID: userID,
+	}
+
+	src, err := uploadedFile.Open()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Failed to open file")
+	}
+
+	if err := file.Create(src); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create file")
+	}
+	return c.NoContent(http.StatusCreated)
+}
+
+// GetFileByID GET /file/{fileID}
+func GetFileByID(c echo.Context) error {
+	ID := c.Param("fileID")
+
+	b, err := model.GetFileByID(ID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get file")
+	}
+
+	// TODO: conent-typeをどうするか考える
+	return c.Blob(http.StatusOK, "application/octet-stream", b)
+}
+
+// DeleteFileByID DELETE /file/{fileID}
+func DeleteFileByID(c echo.Context) error {
+	ID := c.Param("fileID")
+
+	file, err := model.GetMetaFileDataByID(ID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("fileID is wrong: %s", ID))
+	}
+
+	if err := file.Delete(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete data")
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// GetMetaDataByFileID GET /file/{fileID}/meta
+func GetMetaDataByFileID(c echo.Context) error {
+	ID := c.Param("fileID")
+
+	file, err := model.GetMetaFileDataByID(ID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "fileID is wrong")
+	}
+	return c.JSON(http.StatusOK, formatFile(file))
+}
+
+// TODO: そのうち実装
+// GetThumnailByID GET /file/{fileID}/thumnail
+
+func formatFile(f *model.File) *FileForResponse {
+	return &FileForResponse{
+		ID:       f.ID,
+		Name:     f.Name,
+		Mime:     f.Mime,
+		Size:     f.Size,
+		DateTime: f.CreatedAt.String(),
+	}
+}

--- a/router/files_test.go
+++ b/router/files_test.go
@@ -1,0 +1,93 @@
+package router
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostFile(t *testing.T) {
+	e, cookie, mw := beforeTest(t)
+	assert := assert.New(t)
+
+	body := createFormFile(t)
+
+	req := httptest.NewRequest("POST", "http://test", body)
+	req.Header.Set("Content-Type", "multipart/form-data")
+	rec := request(e, t, mw(PostFile), cookie, req)
+
+	assert.Equal(http.StatusCreated, rec.Code, rec.Body.String())
+}
+
+func TestGetFileByID(t *testing.T) {
+	e, cookie, mw := beforeTest(t)
+
+	file := mustMakeFile(t)
+
+	c, rec := getContext(e, t, cookie, nil)
+	c.SetPath("/:fileID")
+	c.SetParamNames("fileID")
+	c.SetParamValues(file.ID)
+
+	requestWithContext(t, mw(GetFileByID), c)
+	if assert.EqualValues(t, http.StatusOK, rec.Code) {
+		assert.Equal(t, "test message", rec.Body.String())
+	}
+}
+func TestDeleteFileByID(t *testing.T) {
+	e, cookie, mw := beforeTest(t)
+
+	file := mustMakeFile(t)
+
+	c, rec := getContext(e, t, cookie, nil)
+	c.SetPath("/:fileID")
+	c.SetParamNames("fileID")
+	c.SetParamValues(file.ID)
+
+	requestWithContext(t, mw(DeleteFileByID), c)
+	if assert.EqualValues(t, http.StatusNoContent, rec.Code, rec.Body.String()) {
+		t.Log(rec.Body.String())
+	}
+
+}
+func TestGetMetaDataByFileID(t *testing.T) {
+	e, cookie, mw := beforeTest(t)
+
+	file := mustMakeFile(t)
+
+	c, rec := getContext(e, t, cookie, nil)
+	c.SetPath("/:fileID")
+	c.SetParamNames("fileID")
+	c.SetParamValues(file.ID)
+
+	requestWithContext(t, mw(GetMetaDataByFileID), c)
+	if assert.EqualValues(t, http.StatusOK, rec.Code, rec.Body.String()) {
+		t.Log(rec.Body.String())
+	}
+}
+
+func createFormFile(t *testing.T) *bytes.Buffer {
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+
+	fileWriter, err := bodyWriter.CreateFormFile("file", "test.txt")
+	require.NoError(t, err)
+
+	fh, err := os.Open("../LICENSE")
+	require.NoError(t, err)
+	defer fh.Close()
+
+	_, err = io.Copy(fileWriter, fh)
+	require.NoError(t, err)
+
+	bodyWriter.Close()
+	return bodyBuf
+}


### PR DESCRIPTION
#18 のサムネイルの実装以外を行いました。
やったこととかを適当にまとめておきます。

## lintに注意された点の修正
作業中にlintがいろいろ吐いてくるので内容を変えないで修正しました

## swaggerの追記
+ file関係のAPIを追記しました
+ 細かいところは独断で決めたので意見があればほしいです

## model
+ interfaceとしてFileWriterとFileReaderを定義しました
+ mimeには拡張子らしきものが入っています
+ 作業環境では`./resources`以下にファイルを格納するようにしました

## router
+ PostFileのテストコードが通らないです。お手上げなのでとりあえずpushしました
+ ファイルを送るときのContent-Typeがすべて`application/octet-stream`になるようになってます

ファイル本体関係の関数が結構不安です。
明日も時間を見つけてやろうと思いますが、何かあればコメントください。