### PR TITLE
fix: docs/swagger.yaml

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1144,10 +1144,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/NoContent"
 
-  /messages/{messageID}/pin:
-    parameters:
-      - $ref: "#/components/parameters/messageIdInPath"
-
   /messages/search:
     get:
       tags:


### PR DESCRIPTION
`/messages/{messageID}/pin`というエンドポイントの残骸が残っていたので消した