### PR TITLE
fix #141

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -165,7 +165,7 @@ paths:
     put:
       tags:
         - channel
-      description: チャンネル名を変更します。
+      description: チャンネルの情報を変更します。
       requestBody:
         content:
           application/json:
@@ -178,6 +178,15 @@ paths:
                   type: string
                   description: チャンネル名
                   example: gps
+                parent:
+                  type: string
+                  format: uuid
+                  description: 変更後の親のID。
+                  example: xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
+                visibility:
+                  type: boolean
+                  description: 変更後のvisibility
+                  example: true
       responses:
         "200":
           description: |+

--- a/model/users_private_channels_test.go
+++ b/model/users_private_channels_test.go
@@ -29,12 +29,12 @@ func TestMakePrivateChannel(t *testing.T) {
 		require.NoError(usersPrivateChannel.Create())
 	}
 
-	channelList, err := GetChannels(user.ID)
+	channelList, err := GetChannelList(user.ID)
 	if assert.NoError(err) {
 		assert.Len(channelList, 1+1)
 	}
 
-	channelList, err = GetChannels(CreateUUID())
+	channelList, err = GetChannelList(CreateUUID())
 	if assert.NoError(err) {
 		assert.Len(channelList, 0+1)
 	}

--- a/model/utils.go
+++ b/model/utils.go
@@ -155,7 +155,7 @@ func InitCache() error {
 		return err
 	}
 	for _, v := range channels {
-		path, err := v.GetPath()
+		path, err := v.Path()
 		if err != nil {
 			return err
 		}

--- a/router/channels.go
+++ b/router/channels.go
@@ -151,7 +151,9 @@ func PutChannelsByChannelID(c echo.Context) error {
 	userID := c.Get("user").(*model.User).ID
 
 	req := struct {
-		Name string `json:"name"`
+		Name       string `json:"name"`
+		Parent     string `json:"parent"`
+		Visibility bool   `json:"visibility"`
 	}{}
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to bind request body.")
@@ -168,6 +170,8 @@ func PutChannelsByChannelID(c echo.Context) error {
 	}
 
 	channel.Name = req.Name
+	channel.ParentID = req.Parent
+	channel.IsVisible = req.Visibility
 	channel.UpdaterID = userID
 
 	if err := channel.Update(); err != nil {

--- a/router/channels_test.go
+++ b/router/channels_test.go
@@ -22,8 +22,8 @@ func TestGetChannels(t *testing.T) {
 	rec := request(e, t, mw(GetChannels), cookie, nil)
 
 	if assert.EqualValues(http.StatusOK, rec.Code, rec.Body.String()) {
-		var responseBody []ChannelForResponse
-		assert.NoError(json.Unmarshal(rec.Body.Bytes(), &responseBody))
+		var res []ChannelForResponse
+		assert.NoError(json.Unmarshal(rec.Body.Bytes(), &res))
 	}
 }
 
@@ -41,7 +41,7 @@ func TestPostChannels(t *testing.T) {
 	req := httptest.NewRequest("POST", "http://test", bytes.NewReader(body))
 	rec := request(e, t, mw(PostChannels), cookie, req)
 
-	channelList, err := model.GetChannels(testUser.ID)
+	channelList, err := model.GetChannelList(testUser.ID)
 	if assert.NoError(err) {
 		if assert.EqualValues(http.StatusCreated, rec.Code, rec.Body.String()) {
 			assert.Len(channelList, 1)
@@ -59,7 +59,7 @@ func TestPostChannels(t *testing.T) {
 	req = httptest.NewRequest("POST", "http://test", bytes.NewReader(body))
 	rec = request(e, t, mw(PostChannels), cookie, req)
 
-	channelList, err = model.GetChannels(testUser.ID)
+	channelList, err = model.GetChannelList(testUser.ID)
 	if assert.NoError(err) {
 		if assert.EqualValues(http.StatusCreated, rec.Code, rec.Body.String()) {
 			assert.Len(channelList, 2)
@@ -81,12 +81,12 @@ func TestPostChannels(t *testing.T) {
 	req = httptest.NewRequest("POST", "http://test", bytes.NewReader(body))
 	request(e, t, mw(PostChannels), cookie, req)
 
-	channelList, err = model.GetChannels(testUser.ID)
+	channelList, err = model.GetChannelList(testUser.ID)
 	if assert.NoError(err) {
 		assert.Len(channelList, 3)
 	}
 
-	channelList, err = model.GetChannels(model.CreateUUID())
+	channelList, err = model.GetChannelList(model.CreateUUID())
 	if assert.NoError(err) {
 		assert.Len(channelList, 2)
 	}
@@ -108,42 +108,42 @@ func TestGetChannelsByChannelID(t *testing.T) {
 
 func TestPutChannelsByChannelID(t *testing.T) {
 	e, cookie, mw, assert, require := beforeTest(t)
-	channel := mustMakeChannel(t, testUser.ID, "test", true)
+	ch := mustMakeChannel(t, testUser.ID, "test", true)
 
 	req := httptest.NewRequest("PUT", "http://test", strings.NewReader(`{"name": "renamed"}`))
 	c, rec := getContext(e, t, cookie, req)
 	c.SetPath("/:channelID")
 	c.SetParamNames("channelID")
-	c.SetParamValues(channel.ID)
+	c.SetParamValues(ch.ID)
 	requestWithContext(t, mw(PutChannelsByChannelID), c)
 
 	require.EqualValues(http.StatusOK, rec.Code, rec.Body.String())
 
-	channel, err := model.GetChannelByID(testUser.ID, channel.ID)
+	ch, err := model.GetChannelByID(testUser.ID, ch.ID)
 	if assert.NoError(err) {
-		assert.Equal("renamed", channel.Name)
-		assert.Equal(testUser.ID, channel.UpdaterID)
+		assert.Equal("renamed", ch.Name)
+		assert.Equal(testUser.ID, ch.UpdaterID)
 	}
 }
 
 func TestDeleteChannelsByChannelID(t *testing.T) {
 	e, cookie, mw, assert, require := beforeTest(t)
 
-	channel := mustMakeChannel(t, testUser.ID, "test", true)
+	ch := mustMakeChannel(t, testUser.ID, "test", true)
 
 	req := httptest.NewRequest("DELETE", "http://test", strings.NewReader(`{"confirm": true}`))
 	c, _ := getContext(e, t, cookie, req)
 	c.SetPath("/:channelID")
 	c.SetParamNames("channelID")
-	c.SetParamValues(channel.ID)
+	c.SetParamValues(ch.ID)
 	requestWithContext(t, mw(DeleteChannelsByChannelID), c)
 
-	channel, err := model.GetChannelByID(testUser.ID, channel.ID)
+	ch, err := model.GetChannelByID(testUser.ID, ch.ID)
 	require.Error(err)
 
 	// ""で削除されていても取得できるようにするそれでちゃんと削除されているか確認する
 
-	channelList, err := model.GetChannels(testUser.ID)
+	channelList, err := model.GetChannelList(testUser.ID)
 	if assert.NoError(err) {
 		assert.Len(channelList, 0)
 	}


### PR DESCRIPTION
名前の他にparentとvisibilityを変更できるようにしました。

あとchannelのリファクタリングをしました。
 + エラー文は小文字初めのほうが良いらしいので(lintのレベルを上げると出るらしい)そのように変更。クライアントに投げるエラーは大文字のままにしてあります
 + メソッドと関数が入り混じっていたので入れ替えたりしました
 + テストコードが書かれていないものに対してテストコードを追加しました
 + 変数・関数の名前とテストケースを少し変更しました
 + 公開する関数のコメントの表記をほかのものと統一しました