### PR TITLE
IDの検証

### DIFF
--- a/model/files.go
+++ b/model/files.go
@@ -74,6 +74,14 @@ func (f *File) Create(src io.Reader) error {
 	return nil
 }
 
+// Exists ファイルが存在するかを判定します
+func (f *File) Exists() (bool, error) {
+	if f.ID == "" {
+		return false, fmt.Errorf("file ID is empty")
+	}
+	return db.Get(f)
+}
+
 // Delete file構造体をDBから消去します
 func (f *File) Delete() error {
 	f.IsDeleted = true

--- a/model/files_test.go
+++ b/model/files_test.go
@@ -35,6 +35,25 @@ func TestFile_Create(t *testing.T) {
 	}
 }
 
+func TestFile_Exists(t *testing.T) {
+	assert, _, user, _ := beforeTest(t)
+
+	f := mustMakeFile(t, user.ID)
+	r := &File{ID: f.ID}
+
+	ok, err := r.Exists()
+	if assert.NoError(err) {
+		assert.True(ok)
+	}
+
+	r2 := &File{ID: CreateUUID()}
+
+	ok, err = r2.Exists()
+	if assert.NoError(err) {
+		assert.False(ok)
+	}
+}
+
 func TestFile_Delete(t *testing.T) {
 	assert, _, user, _ := beforeTest(t)
 

--- a/model/messages.go
+++ b/model/messages.go
@@ -47,6 +47,14 @@ func (m *Message) Create() error {
 	return nil
 }
 
+// Exists 指定されたメッセージが存在するかを判定します
+func (m *Message) Exists() (bool, error) {
+	if m.ID == "" {
+		return false, fmt.Errorf("message ID is empty")
+	}
+	return db.Get(m)
+}
+
 // Update メッセージの内容を変更します
 func (m *Message) Update() error {
 	_, err := db.ID(m.ID).UseBool().Update(m)

--- a/model/messages.go
+++ b/model/messages.go
@@ -22,58 +22,58 @@ type Message struct {
 	UpdatedAt time.Time `xorm:"updated not null"`
 }
 
-//TableName :DBの名前を指定するメソッド
-func (message *Message) TableName() string {
+// TableName DBの名前を指定するメソッド
+func (m *Message) TableName() string {
 	return "messages"
 }
 
-// Create method inserts message object to database.
-func (message *Message) Create() error {
-	if message.UserID == "" {
-		return fmt.Errorf("UserID is empty")
+// Create message構造体をDBに入れます
+func (m *Message) Create() error {
+	if m.UserID == "" {
+		return fmt.Errorf("userID is empty")
 	}
 
-	if message.Text == "" {
-		return fmt.Errorf("Text is empty")
+	if m.Text == "" {
+		return fmt.Errorf("text is empty")
 	}
 
-	message.ID = CreateUUID()
-	message.IsDeleted = false
-	message.UpdaterID = message.UserID
+	m.ID = CreateUUID()
+	m.IsDeleted = false
+	m.UpdaterID = m.UserID
 
-	if _, err := db.Insert(message); err != nil {
-		return fmt.Errorf("Failed to create message object: %v", err)
+	if _, err := db.Insert(m); err != nil {
+		return fmt.Errorf("failed to create message object: %v", err)
 	}
 	return nil
 }
 
-// Update method:メッセージの内容を変更します
-func (message *Message) Update() error {
-	_, err := db.ID(message.ID).UseBool().Update(message)
+// Update メッセージの内容を変更します
+func (m *Message) Update() error {
+	_, err := db.ID(m.ID).UseBool().Update(m)
 	if err != nil {
-		return fmt.Errorf("Failed to update this message: %v", err)
+		return fmt.Errorf("failed to update this message: %v", err)
 	}
 	return nil
 }
 
-// GetMessagesFromChannel :指定されたチャンネルのメッセージを取得します
-func GetMessagesFromChannel(channelID string, limit, offset int) ([]*Message, error) {
+// GetMessagesByChannelID 指定されたチャンネルのメッセージを取得します
+func GetMessagesByChannelID(channelID string, limit, offset int) ([]*Message, error) {
 	var messageList []*Message
 	err := db.Where("channel_id = ? AND is_deleted = false", channelID).Desc("created_at").Limit(limit, offset).Find(&messageList)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to find messages: %v", err)
+		return nil, fmt.Errorf("failed to find messages: %v", err)
 	}
 
 	return messageList, nil
 }
 
-// GetMessage :messageIDで指定されたメッセージを取得します
-func GetMessage(messageID string) (*Message, error) {
+// GetMessageByID messageIDで指定されたメッセージを取得します
+func GetMessageByID(messageID string) (*Message, error) {
 	var message = &Message{}
 	has, err := db.ID(messageID).Get(message)
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to find message: %v", err)
+		return nil, fmt.Errorf("failed to find message: %v", err)
 	}
 	if has == false {
 		return nil, ErrNotFound

--- a/model/messages_test.go
+++ b/model/messages_test.go
@@ -19,21 +19,21 @@ func TestMessage_Create(t *testing.T) {
 	assert.Error((&Message{UserID: user.ID, Text: "test"}).Create())
 	assert.Error((&Message{UserID: user.ID, ChannelID: channel.ID}).Create())
 
-	message := &Message{UserID: user.ID, Text: "test", ChannelID: channel.ID}
-	if assert.NoError(message.Create()) {
-		assert.NotEmpty(message.ID)
-		assert.NotEmpty(message.UpdaterID)
+	m := &Message{UserID: user.ID, Text: "test", ChannelID: channel.ID}
+	if assert.NoError(m.Create()) {
+		assert.NotEmpty(m.ID)
+		assert.NotEmpty(m.UpdaterID)
 	}
 }
 
 func TestMessage_Update(t *testing.T) {
 	assert, _, user, channel := beforeTest(t)
 
-	message := mustMakeMessage(t, user.ID, channel.ID)
-	message.Text = "nanachi"
-	message.IsShared = true
+	m := mustMakeMessage(t, user.ID, channel.ID)
+	m.Text = "test message"
+	m.IsShared = true
 
-	assert.NoError(message.Update())
+	assert.NoError(m.Update())
 }
 
 func TestGetMessagesFromChannel(t *testing.T) {
@@ -43,27 +43,27 @@ func TestGetMessagesFromChannel(t *testing.T) {
 		mustMakeMessage(t, user.ID, channel.ID)
 	}
 
-	res, err := GetMessagesFromChannel(channel.ID, 0, 0)
+	r, err := GetMessagesByChannelID(channel.ID, 0, 0)
 	if assert.NoError(err) {
-		assert.Len(res, 10)
+		assert.Len(r, 10)
 	}
 
-	res2, err := GetMessagesFromChannel(channel.ID, 3, 5)
+	r, err = GetMessagesByChannelID(channel.ID, 3, 5)
 	if assert.NoError(err) {
-		assert.Len(res2, 3)
+		assert.Len(r, 3)
 	}
 }
 
 func TestGetMessage(t *testing.T) {
 	assert, _, user, channel := beforeTest(t)
 
-	message := mustMakeMessage(t, user.ID, channel.ID)
+	m := mustMakeMessage(t, user.ID, channel.ID)
 
-	r, err := GetMessage(message.ID)
+	r, err := GetMessageByID(m.ID)
 	if assert.NoError(err) {
-		assert.Equal(message.Text, r.Text)
+		assert.Equal(m.Text, r.Text)
 	}
 
-	_, err = GetMessage("wrong_id")
+	_, err = GetMessageByID("wrong_id")
 	assert.Error(err)
 }

--- a/model/messages_test.go
+++ b/model/messages_test.go
@@ -26,6 +26,24 @@ func TestMessage_Create(t *testing.T) {
 	}
 }
 
+func TestMessage_Exists(t *testing.T) {
+	assert, _, user, channel := beforeTest(t)
+
+	m := mustMakeMessage(t, user.ID, channel.ID)
+
+	r := &Message{ID: m.ID}
+	ok, err := r.Exists()
+
+	if assert.True(ok) && assert.NoError(err) {
+		assert.Equal(m.Text, r.Text)
+	}
+
+	wm := &Message{ID: CreateUUID()}
+	ok, err = wm.Exists()
+	assert.False(ok)
+	assert.NoError(err)
+}
+
 func TestMessage_Update(t *testing.T) {
 	assert, _, user, channel := beforeTest(t)
 

--- a/model/pins.go
+++ b/model/pins.go
@@ -40,6 +40,15 @@ func (pin *Pin) Create() error {
 	return nil
 }
 
+// Exists pinが存在するかどうかを判定する
+func (pin *Pin) Exists() (bool, error) {
+	if pin.ID == "" {
+		return false, fmt.Errorf("pin ID is empty")
+	}
+	return db.Get(pin)
+
+}
+
 //GetPin IDからピン留めを取得する
 func GetPin(ID string) (*Pin, error) {
 	if ID == "" {

--- a/router/clips.go
+++ b/router/clips.go
@@ -40,7 +40,7 @@ func PostClips(c echo.Context) error {
 	}
 
 	// メッセージの存在確認
-	if _, err := model.GetMessage(requestBody.MessageID); err != nil {
+	if _, err := model.GetMessageByID(requestBody.MessageID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 

--- a/router/clips.go
+++ b/router/clips.go
@@ -2,9 +2,10 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/traPtitech/traQ/notification"
 	"github.com/traPtitech/traQ/notification/events"
-	"net/http"
 
 	"github.com/labstack/echo"
 	"github.com/traPtitech/traQ/model"
@@ -77,6 +78,10 @@ func DeleteClips(c echo.Context) error {
 
 	if err := c.Bind(&requestBody); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to bind request body.")
+	}
+
+	if _, err := validateMessageID(requestBody.MessageID); err != nil {
+		return err
 	}
 
 	clip := &model.Clip{

--- a/router/messages.go
+++ b/router/messages.go
@@ -54,13 +54,13 @@ func GetMessagesByChannelID(c echo.Context) error {
 	}
 
 	// channelIDの検証
-	cID := c.Param("channelID")
-	uID := c.Get("user").(*model.User).ID
-	if _, err := validateChannelID(cID, uID); err != nil {
+	channelID := c.Param("channelID")
+	userID := c.Get("user").(*model.User).ID
+	if _, err := validateChannelID(channelID, userID); err != nil {
 		return err
 	}
 
-	messageList, err := model.GetMessagesByChannelID(cID, queryParam.Limit, queryParam.Offset)
+	messageList, err := model.GetMessagesByChannelID(channelID, queryParam.Limit, queryParam.Offset)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessagesFromChannel returned an error : %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "Channel is not found")

--- a/router/messages.go
+++ b/router/messages.go
@@ -34,13 +34,13 @@ type requestCount struct {
 
 // GetMessageByID : /messages/{messageID}のGETメソッド
 func GetMessageByID(c echo.Context) error {
-	ID := c.Param("messageID") // TODO: idの検証
-	raw, err := model.GetMessageByID(ID)
+	mID := c.Param("messageID")
+	m, err := validateMessageID(mID)
 	if err != nil {
-		c.Echo().Logger.Errorf("model.GetMessage returned an error : %v", err)
-		return echo.NewHTTPError(http.StatusNotFound, "Message is not found")
+		return err
 	}
-	res := formatMessage(raw)
+
+	res := formatMessage(m)
 	return c.JSON(http.StatusOK, res)
 }
 
@@ -53,9 +53,14 @@ func GetMessagesByChannelID(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid format")
 	}
 
-	channelID := c.Param("channelID")
+	// channelIDの検証
+	cID := c.Param("channelID")
+	uID := c.Get("user").(*model.User).ID
+	if _, err := validateChannelID(cID, uID); err != nil {
+		return err
+	}
 
-	messageList, err := model.GetMessagesByChannelID(channelID, queryParam.Limit, queryParam.Offset)
+	messageList, err := model.GetMessagesByChannelID(cID, queryParam.Limit, queryParam.Offset)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessagesFromChannel returned an error : %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "Channel is not found")
@@ -72,8 +77,8 @@ func GetMessagesByChannelID(c echo.Context) error {
 
 // PostMessage : /channels/{channelID}/messagesのPOSTメソッド
 func PostMessage(c echo.Context) error {
+	channelID := c.Param("channelID")
 	userID := c.Get("user").(*model.User).ID
-	channelID := c.Param("channelID") //TODO: channelIDの検証
 
 	post := &requestMessage{}
 	if err := c.Bind(post); err != nil {
@@ -98,7 +103,11 @@ func PostMessage(c echo.Context) error {
 // PutMessageByID : /messages/{messageID}のPUTメソッド.メッセージの編集
 func PutMessageByID(c echo.Context) error {
 	userID := c.Get("user").(*model.User).ID
-	messageID := c.Param("messageID") //TODO: messageIDの検証
+	messageID := c.Param("messageID")
+	m, err := validateMessageID(messageID)
+	if err != nil {
+		return err
+	}
 
 	req := &requestMessage{}
 	if err := c.Bind(req); err != nil {
@@ -106,21 +115,17 @@ func PutMessageByID(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid format")
 	}
 
-	message, err := model.GetMessageByID(messageID)
-	if err != nil {
-		c.Echo().Logger.Errorf("model.GetMessage() returned an error: %v", err)
-		return echo.NewHTTPError(http.StatusNotFound, "no message has the messageID: "+messageID)
-	}
-
-	message.Text = req.Text
-	message.UpdaterID = userID
-	if err := message.Update(); err != nil {
+	m.Text = req.Text
+	m.UpdaterID = userID
+	if err := m.Update(); err != nil {
 		c.Echo().Logger.Errorf("message.Update() returned an error: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update the message")
 	}
 
-	go notification.Send(events.MessageUpdated, events.MessageEvent{Message: *message})
-	return c.JSON(http.StatusOK, message)
+	res := formatMessage(m)
+
+	go notification.Send(events.MessageUpdated, events.MessageEvent{Message: *m})
+	return c.JSON(http.StatusOK, res)
 }
 
 // DeleteMessageByID : /message/{messageID}のDELETEメソッド.
@@ -171,4 +176,17 @@ func formatMessage(raw *model.Message) *MessageForResponse {
 		StampList:       stampList,
 	}
 	return res
+}
+
+// リクエストで飛んできたmessageIDを検証する。存在する場合はそのメッセージを返す
+func validateMessageID(messageID string) (*model.Message, error) {
+	m := &model.Message{ID: messageID}
+	ok, err := m.Exists()
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "Message is not found")
+	}
+	if !ok {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "Message is not found")
+	}
+	return m, nil
 }

--- a/router/messages.go
+++ b/router/messages.go
@@ -35,7 +35,7 @@ type requestCount struct {
 // GetMessageByID : /messages/{messageID}のGETメソッド
 func GetMessageByID(c echo.Context) error {
 	ID := c.Param("messageID") // TODO: idの検証
-	raw, err := model.GetMessage(ID)
+	raw, err := model.GetMessageByID(ID)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessage returned an error : %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "Message is not found")
@@ -55,7 +55,7 @@ func GetMessagesByChannelID(c echo.Context) error {
 
 	channelID := c.Param("channelID")
 
-	messageList, err := model.GetMessagesFromChannel(channelID, queryParam.Limit, queryParam.Offset)
+	messageList, err := model.GetMessagesByChannelID(channelID, queryParam.Limit, queryParam.Offset)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessagesFromChannel returned an error : %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "Channel is not found")
@@ -106,7 +106,7 @@ func PutMessageByID(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid format")
 	}
 
-	message, err := model.GetMessage(messageID)
+	message, err := model.GetMessageByID(messageID)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessage() returned an error: %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "no message has the messageID: "+messageID)
@@ -127,7 +127,7 @@ func PutMessageByID(c echo.Context) error {
 func DeleteMessageByID(c echo.Context) error {
 	messageID := c.Param("messageID")
 
-	message, err := model.GetMessage(messageID)
+	message, err := model.GetMessageByID(messageID)
 	if err != nil {
 		c.Echo().Logger.Errorf("model.GetMessage() returned an error: %v", err)
 		return echo.NewHTTPError(http.StatusNotFound, "no message has the messageID: "+messageID)

--- a/router/messages_test.go
+++ b/router/messages_test.go
@@ -100,7 +100,7 @@ func TestPutMessageByID(t *testing.T) {
 	c.SetParamValues(message.ID)
 	requestWithContext(t, mw(PutMessageByID), c)
 
-	message, err = model.GetMessage(message.ID)
+	message, err = model.GetMessageByID(message.ID)
 	require.NoError(err)
 
 	if assert.EqualValues(http.StatusOK, rec.Code, rec.Body.String()) {
@@ -122,6 +122,6 @@ func TestDeleteMessageByID(t *testing.T) {
 	c.SetParamValues(message.ID)
 	requestWithContext(t, mw(DeleteMessageByID), c)
 
-	message, err := model.GetMessage(message.ID)
+	message, err := model.GetMessageByID(message.ID)
 	require.Error(err)
 }

--- a/router/notification.go
+++ b/router/notification.go
@@ -13,7 +13,11 @@ import (
 
 // GetNotificationStatus GET /channels/:channelId/notifications のハンドラ
 func GetNotificationStatus(c echo.Context) error {
-	channelID := c.Param("channelID") //TODO チャンネルIDの検証
+	userID := c.Get("user").(*model.User).ID
+	channelID := c.Param("channelID")
+	if _, err := validateChannelID(channelID, userID); err != nil {
+		return err
+	}
 
 	users, err := model.GetSubscribingUser(uuid.FromStringOrNil(channelID))
 	if err != nil {
@@ -30,7 +34,11 @@ func GetNotificationStatus(c echo.Context) error {
 
 // PutNotificationStatus PUT /channels/:channelId/notifications のハンドラ
 func PutNotificationStatus(c echo.Context) error {
-	channelID := c.Param("channelID") //TODO チャンネルIDの検証
+	userID := c.Get("user").(*model.User).ID
+	channelID := c.Param("channelID")
+	if _, err := validateChannelID(channelID, userID); err != nil {
+		return err
+	}
 
 	var req struct {
 		On  []string `json:"on"`

--- a/router/pin.go
+++ b/router/pin.go
@@ -73,7 +73,7 @@ func PostPin(c echo.Context) error {
 	}
 
 	c.Response().Header().Set(echo.HeaderLocation, "/pin/"+pin.ID)
-	if message, err := model.GetMessage(pin.MessageID); err != nil {
+	if message, err := model.GetMessageByID(pin.MessageID); err != nil {
 		go notification.Send(events.MessagePinned, events.PinEvent{PinID: pin.ID, Message: *message})
 	}
 	return c.JSON(http.StatusCreated, responseBody)
@@ -95,7 +95,7 @@ func DeletePin(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to delete pin: %v", err))
 	}
 
-	if message, err := model.GetMessage(pin.MessageID); err != nil {
+	if message, err := model.GetMessageByID(pin.MessageID); err != nil {
 		go notification.Send(events.MessageUnpinned, events.PinEvent{PinID: pin.ID, Message: *message})
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -133,7 +133,7 @@ func getPinResponse(ID string) (*PinForResponse, error) {
 }
 
 func formatPin(raw *model.Pin) (*PinForResponse, error) {
-	rawMessage, err := model.GetMessage(raw.MessageID)
+	rawMessage, err := model.GetMessageByID(raw.MessageID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get message: %v", err)
 	}

--- a/router/stamp.go
+++ b/router/stamp.go
@@ -1,12 +1,13 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/labstack/echo"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/notification"
 	"github.com/traPtitech/traQ/notification/events"
-	"net/http"
 )
 
 // GetStamps : GET /stamps
@@ -239,7 +240,7 @@ func PostMessageStamp(c echo.Context) error {
 	stampID := c.Param("stampID")
 
 	// メッセージ存在の確認
-	message, err := model.GetMessage(messageID)
+	message, err := model.GetMessageByID(messageID)
 	if err != nil {
 		switch err {
 		case model.ErrNotFound, model.ErrMessageAlreadyDeleted:
@@ -298,7 +299,7 @@ func DeleteMessageStamp(c echo.Context) error {
 	stampID := c.Param("stampID")
 
 	// メッセージ存在の確認
-	message, err := model.GetMessage(messageID)
+	message, err := model.GetMessageByID(messageID)
 	if err != nil {
 		switch err {
 		case model.ErrNotFound, model.ErrMessageAlreadyDeleted:

--- a/router/stars.go
+++ b/router/stars.go
@@ -2,9 +2,10 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/traPtitech/traQ/notification"
 	"github.com/traPtitech/traQ/notification/events"
-	"net/http"
 
 	"github.com/labstack/echo"
 	"github.com/traPtitech/traQ/model"
@@ -62,6 +63,10 @@ func DeleteStars(c echo.Context) error {
 
 	if err := c.Bind(&requestBody); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to bind request body.")
+	}
+
+	if _, err := validateChannelID(requestBody.ChannelID, user.ID); err != nil {
+		return err
 	}
 
 	star := &model.Star{

--- a/router/unread.go
+++ b/router/unread.go
@@ -55,7 +55,7 @@ func getUnreadResponse(userID string) ([]*MessageForResponse, error) {
 
 	responseBody := make([]*MessageForResponse, 0)
 	for _, unread := range unreads {
-		message, err := model.GetMessage(unread.MessageID)
+		message, err := model.GetMessageByID(unread.MessageID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fix #91 リクエスト内の各種IDの検証
各種ID(userID, messageID, channelID, tagID, pinID, fileID)の検証を行う関数群の実装をしました。
メッセージのモデルだけコメントや内部の変数名・関数名にあたりのリファクタリングをしました。