### PR TITLE
Webhook機能

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,9 +163,15 @@
   packages = ["unix"]
   revision = "83801418e1b59fb1880e363299581ee543af32ca"
 
+[[projects]]
+  name = "gopkg.in/go-playground/webhooks.v3"
+  packages = [".","github"]
+  revision = "c271ec3e322dab2e93990e8c5287fe5d5d1209ba"
+  version = "v3.8.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c23756bcfa0a2bf7111023fd312582a4dd77768acb40d7a890620f4a8d61128a"
+  inputs-digest = "7676a3f54e8b8b12a1bcfb01666a779a3b22fc87a05443156eb19dfc8be44e54"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -165,13 +165,16 @@
 
 [[projects]]
   name = "gopkg.in/go-playground/webhooks.v3"
-  packages = [".","github"]
+  packages = [
+    ".",
+    "github"
+  ]
   revision = "c271ec3e322dab2e93990e8c5287fe5d5d1209ba"
   version = "v3.8.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7676a3f54e8b8b12a1bcfb01666a779a3b22fc87a05443156eb19dfc8be44e54"
+  inputs-digest = "cf2dcb205b624efa69106a39b3b789946e3a8afb19c55b8bcdb278cdd5f1c54f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -7,7 +7,8 @@ ID系は全部UUID(string)
 | カラム名 | 型 | 属性 | 説明など | 
 | --- | --- | --- | --- |
 | id | CHAR(36) | PRIMARY KEY | ユーザーID |
-| name | VARCHAR(32) | NOT NULL, UNIQUE | 表示名 |
+| name | VARCHAR(32) | NOT NULL, UNIQUE | 英数字名 |
+| display_name | VARCHAR(32) | NOT NULL | 表示名 |
 | email | TEXT | NOT NULL | メールアドレス |
 | password | CHAR(128) | NOT NULL | ハッシュ化されたパスワード |
 | salt | CHAR(128) | NOT NULL | パスワードソルト |
@@ -31,8 +32,7 @@ user_idとauthority_typeの複合ユニーク制約
 | カラム名 | 型 | 属性 | 説明など | 
 | --- | --- | --- | --- |
 | user_id | CHAR(36) | PRIMARY KEY (外部キー) | botユーザーID |
-| type | INT | NOT NULL | 1:webhook, 2:bot |
-| display_name | VARCHAR(32) | NOT NULL | 表示名 |
+| type | INT | NOT NULL | 1:汎用bot, 2:webhook |
 | description | TEXT | NOT NULL | 説明 |
 | is_valid | BOOLEAN | NOT NULL | 有効かどうか |
 | creator_id | CHAR(36) | NOT NULL (外部キー) | 登録者 |

--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -13,6 +13,7 @@ ID系は全部UUID(string)
 | salt | CHAR(128) | NOT NULL | パスワードソルト |
 | icon | CHAR(36) | NOT NULL | アイコンのファイルID |
 | status | TINYINT | NOT NULL | アカウントの状態 |
+| bot | BOOLEAN | NOT NULL | botアカウントか |
 | created_at | TIMESTAMP | NOT NULL | 作成日時 |
 | updated_at | TIMESTAMP | NOT NULL | 更新日時 |
 
@@ -25,6 +26,28 @@ ID系は全部UUID(string)
 | updated_at | TIMESTAMP | NOT NULL | 更新日時 |
 
 user_idとauthority_typeの複合ユニーク制約
+
+## bots
+| カラム名 | 型 | 属性 | 説明など | 
+| --- | --- | --- | --- |
+| user_id | CHAR(36) | PRIMARY KEY (外部キー) | botユーザーID |
+| type | INT | NOT NULL | 1:webhook, 2:bot |
+| display_name | VARCHAR(32) | NOT NULL | 表示名 |
+| description | TEXT | NOT NULL | 説明 |
+| is_valid | BOOLEAN | NOT NULL | 有効かどうか |
+| creator_id | CHAR(36) | NOT NULL (外部キー) | 登録者 |
+| created_at | TIMESTAMP | NOT NULL | 作成日時 |
+| updater_id | CHAR(36) | NOT NULL (外部キー) | 更新者 | 
+| updated_at | TIMESTAMP | NOT NULL | 更新日時 |
+
+## webhooks
+
+| カラム名 | 型 | 属性 | 説明など | 
+| --- | --- | --- | --- |
+| user_id | CHAR(36) | PRIMARY KEY (外部キー) | botユーザーID |
+| token | VARCHAR(32) | NOT NULL | トークン |
+| channel_id | CHAR(36) | NOT NULL (外部キー) | 投稿先のチャンネルID |
+ 
 
 ## users_tags
 

--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -44,10 +44,9 @@ user_idとauthority_typeの複合ユニーク制約
 
 | カラム名 | 型 | 属性 | 説明など | 
 | --- | --- | --- | --- |
-| user_id | CHAR(36) | PRIMARY KEY (外部キー) | botユーザーID |
-| token | VARCHAR(32) | NOT NULL | トークン |
-| channel_id | CHAR(36) | NOT NULL (外部キー) | 投稿先のチャンネルID |
- 
+| id | CHAR(36) | NOT NULL PRIMARY KEY | webhookID |
+| user_id | CHAR(36) | NOT NULL (外部キー) | botユーザーID |
+| channel_id | CHAR(36) | NOT NULL (外部キー) | 投稿先のデフォルトチャンネルID |
 
 ## users_tags
 

--- a/docs/notification.md
+++ b/docs/notification.md
@@ -22,6 +22,14 @@ TODO
 
 TODO
 
+## USER_UPDATED
+ユーザーの情報が更新された。
+
+### SSE
+対象: 全員
+
++ `id`: 情報が更新されたユーザーのId
+
 ## USER_TAGS_UPDATED
 ユーザーのタグが更新された。
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -461,6 +461,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/User"
+    patch:
+      tags:
+        - user
+      description: 自分のユーザー情報を変更します。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                displayName:
+                  type: string
+                  description: 新しい表示名(0-32文字)
+      responses:
+        "204":
+          description: 正常に変更できました。
+        "400":
+          description: 正常に変更できませんでした。リクエスト内容が不正です。
 
   /users/me/icon:
     get:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1366,13 +1366,11 @@ paths:
         "201":
           description: 正常に登録できました。
 
-  /channels/{channelID}/webhooks:
-    parameters:
-      - $ref: "#/components/parameters/channelIdInPath"
+  /webhooks:
     get:
       tags:
         - webhook
-      description: 指定されたチャンネルのwebhookの一覧を取得します。
+      description: 自分が作成したwebhookの一覧を取得します。
       responses:
         "200":
           description: 正常に取得できました。
@@ -1382,18 +1380,17 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Webhook"
-        "403":
-          description: 取得できませんでした。権限がありません。
     post:
       tags:
         - webhook
-      description: 指定されたチャンネルのwebhookを作成します。
+      description: webhookを作成します。
       requestBody:
         content:
           multipart/form-data:
             schema:
               required:
                 - name
+                - channelId
               properties:
                 name:
                   type: string
@@ -1401,6 +1398,10 @@ paths:
                 description:
                   type: string
                   description: webhookの説明
+                channelId:
+                  type: string
+                  format: uuid
+                  description: デフォルトの投稿先チャンネル
                 file:
                   type: string
                   format: binary
@@ -1413,6 +1414,7 @@ paths:
               type: object
               required:
                 - name
+                - channelId
               properties:
                 name:
                   type: string
@@ -1420,6 +1422,10 @@ paths:
                 description:
                   type: string
                   description: webhookの説明
+                channelId:
+                  type: string
+                  format: uuid
+                  description: デフォルトの投稿先チャンネル
       responses:
         "201":
           description: 正常に作成できました。
@@ -1467,6 +1473,10 @@ paths:
                 description:
                   type: string
                   description: webhookの説明
+                channelId:
+                  type: string
+                  format: uuid
+                  description: デフォルトの投稿先チャンネル
                 file:
                   type: string
                   format: binary
@@ -1486,6 +1496,10 @@ paths:
                 description:
                   type: string
                   description: webhookの説明
+                channelId:
+                  type: string
+                  format: uuid
+                  description: デフォルトの投稿先チャンネル
       responses:
         "204":
           description: 正常に修正できました。
@@ -1506,11 +1520,6 @@ paths:
           description: 削除できませんでした。権限がありません。
         "404":
           description: 削除できませんでした。指定したwebhookは存在しません。
-
-  /webhooks/{webhookID}/{token}:
-    parameters:
-      - $ref: "#/components/parameters/webhookIdInPath"
-      - $ref: "#/components/parameters/webhookTokenInPath"
     post:
       tags:
         - webhook
@@ -1530,6 +1539,10 @@ paths:
                 text:
                   type: string
                   description: メッセージ文字列
+                channelId:
+                  type: string
+                  format: uuid
+                  description: 投稿先チャンネルID(無い場合は事前登録のデフォルト値が使われます)
           application/x-www-form-urlencoded:
             schema:
               type: object
@@ -1539,20 +1552,21 @@ paths:
                 text:
                   type: string
                   description: メッセージ文字列
+                channelId:
+                  type: string
+                  format: uuid
+                  description: 投稿先チャンネルID(無い場合は事前登録のデフォルト値が使われます)
       responses:
         "204":
           description: 正常に送信できました。
         "400":
           description: 正常に送信できませんでした。リクエスト内容が不正です。
-        "403":
-          description: 正常に送信できませんでした。トークンが不正です。
         "404":
           description: 正常に送信できませんでした。指定されたwebhookは存在しません。
 
-  /webhooks/{webhookID}/{token}/github:
+  /webhooks/{webhookID}/github:
     parameters:
       - $ref: "#/components/parameters/webhookIdInPath"
-      - $ref: "#/components/parameters/webhookTokenInPath"
     post:
       tags:
         - webhook
@@ -1567,8 +1581,6 @@ paths:
           description: 正常に送信できました。
         "400":
           description: 正常に送信できませんでした。リクエスト内容が不正です。
-        "403":
-          description: 正常に送信できませんでした。トークンが不正です。
         "404":
           description: 正常に送信できませんでした。指定されたwebhookは存在しません。
 
@@ -1636,13 +1648,6 @@ components:
       schema:
         type: string
         format: uuid
-    webhookTokenInPath:
-      name: token
-      description: webhookのトークン
-      in: path
-      required: true
-      schema:
-        type: string
   schemas:
     Channel:
       type: object
@@ -1920,7 +1925,10 @@ components:
     Webhook:
       type: object
       properties:
-        id:
+        webhookId:
+          type: string
+          format: uuid
+        botUserId:
           type: string
           format: uuid
         displayName:
@@ -1933,8 +1941,6 @@ components:
         channelId:
           type: string
           format: uuid
-        token:
-          type: string
         creatorId:
           type: string
           format: uuid

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -961,7 +961,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Stamp"
         "404":
-          desciption: 取得できませんでした。指定されたスタンプは存在しません。
+          description: 取得できませんでした。指定されたスタンプは存在しません。
     patch:
       description: スタンプを修正します。
       tags:
@@ -1348,6 +1348,212 @@ paths:
         "201":
           description: 正常に登録できました。
 
+  /channels/{channelID}/webhooks:
+    parameters:
+      - $ref: "#/components/parameters/channelIdInPath"
+    get:
+      tags:
+        - webhook
+      description: 指定されたチャンネルのwebhookの一覧を取得します。
+      responses:
+        "200":
+          description: 正常に取得できました。
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Webhook"
+        "403":
+          description: 取得できませんでした。権限がありません。
+    post:
+      tags:
+        - webhook
+      description: 指定されたチャンネルのwebhookを作成します。
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: webhookユーザーの表示名(32文字まで)
+                description:
+                  type: string
+                  description: webhookの説明
+                file:
+                  type: string
+                  format: binary
+                  description: webhookユーザーのアイコン(1MBまでのpng, jpeg, gif, svg)
+            encoding:
+              file:
+                contentType: image/png, image/jpeg, image/gif, image/svg+xml
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: webhookユーザーの表示名(32文字まで)
+                description:
+                  type: string
+                  description: webhookの説明
+      responses:
+        "201":
+          description: 正常に作成できました。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Webhook"
+        "400":
+          description: 作成できませんでした。リクエスト内容が不正です。
+        "403":
+          description: 作成できませんでした。権限がありません。
+        "404":
+          description: 作成できませんでした。指定したチャンネルは存在しません。
+
+  /webhooks/{webhookID}:
+    parameters:
+      - $ref: "#/components/parameters/webhookIdInPath"
+    get:
+      tags:
+        - webhook
+      description: webhookの詳細を取得します。
+      responses:
+        "200":
+          description: 正常に取得できました。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Webhook"
+        "403":
+          description: 取得できませんでした。権限がありません。
+        "404":
+          description: 取得できませんでした。指定したwebhookは存在しません。
+    patch:
+      tags:
+        - webhook
+      description: webhookを修正します。
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: webhookユーザーの表示名(32文字まで)
+                description:
+                  type: string
+                  description: webhookの説明
+                file:
+                  type: string
+                  format: binary
+                  description: webhookユーザーのアイコン(1MBまでのpng, jpeg, gif, svg)
+            encoding:
+              file:
+                contentType: image/png, image/jpeg, image/gif, image/svg+xml
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: webhookユーザーの表示名(32文字まで)
+                description:
+                  type: string
+                  description: webhookの説明
+      responses:
+        "204":
+          description: 正常に修正できました。
+        "400":
+          description: 修正できませんでした。リクエスト内容が不正です。
+        "403":
+          description: 削除できませんでした。権限がありません。
+        "404":
+          description: 修正できませんでした。指定したwebhookは存在しません。
+    delete:
+      tags:
+        - webhook
+      description: webhookを削除します。
+      responses:
+        "204":
+          description: 正常に削除できました。
+        "403":
+          description: 削除できませんでした。権限がありません。
+        "404":
+          description: 削除できませんでした。指定したwebhookは存在しません。
+
+  /webhooks/{webhookID}/{token}:
+    parameters:
+      - $ref: "#/components/parameters/webhookIdInPath"
+      - $ref: "#/components/parameters/webhookTokenInPath"
+    post:
+      tags:
+        - webhook
+      description: webhookを送信します。
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              description: メッセージ文字列
+          application/json:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+                  description: メッセージ文字列
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+                  description: メッセージ文字列
+      responses:
+        "204":
+          description: 正常に送信できました。
+        "400":
+          description: 正常に送信できませんでした。リクエスト内容が不正です。
+        "403":
+          description: 正常に送信できませんでした。トークンが不正です。
+        "404":
+          description: 正常に送信できませんでした。指定されたwebhookは存在しません。
+
+  /webhooks/{webhookID}/{token}/github:
+    parameters:
+      - $ref: "#/components/parameters/webhookIdInPath"
+      - $ref: "#/components/parameters/webhookTokenInPath"
+    post:
+      tags:
+        - webhook
+      description: Github-Compatibleなwebhookを送信します。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: 正常に送信できました。
+        "400":
+          description: 正常に送信できませんでした。リクエスト内容が不正です。
+        "403":
+          description: 正常に送信できませんでした。トークンが不正です。
+        "404":
+          description: 正常に送信できませんでした。指定されたwebhookは存在しません。
+
 components:
   parameters:
     channelIdInPath:
@@ -1400,6 +1606,21 @@ components:
     pinIdInPath:
       name: pinID
       description: 操作の対象となるピン留めID
+      in: path
+      required: true
+      schema:
+        type: string
+    webhookIdInPath:
+      name: webhookID
+      description: 操作の対象となるWebhookのID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    webhookTokenInPath:
+      name: token
+      description: webhookのトークン
       in: path
       required: true
       schema:
@@ -1669,3 +1890,34 @@ components:
           - userId: xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
             status: editing
         channelId: xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
+
+    Webhook:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        iconFileId:
+          type: string
+          format: uuid
+        channelId:
+          type: string
+          format: uuid
+        token:
+          type: string
+        creatorId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: datetime
+        updaterId:
+          type: string
+          format: uuid
+        updatedAt:
+          type: string
+          format: datetime

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1691,9 +1691,13 @@ components:
           format: uuid
         name:
           type: string
+        displayName:
+          type: string
         iconFileId:
           type: string
           format: uuid
+        bot:
+          type: boolean
 
     UserDetail:
       type: object
@@ -1703,9 +1707,13 @@ components:
           format: uuid
         name:
           type: string
+        displayName:
+          type: string
         iconFileId:
           type: string
           format: uuid
+        bot:
+          type: boolean
         tagList:
           $ref: "#/components/schemas/TagList"
 
@@ -1897,7 +1905,7 @@ components:
         id:
           type: string
           format: uuid
-        name:
+        displayName:
           type: string
         description:
           type: string

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 	// Tag: users
 	api.GET("/users", router.GetUsers)
 	api.GET("/users/me", router.GetMe)
+	api.PATCH("/users/me", router.PatchMe)
 	api.GET("/users/me/icon", router.GetMyIcon)
 	api.PUT("/users/me/icon", router.PutMyIcon)
 	api.GET("/users/:userID", router.GetUserByID)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 
 	api := e.Group("/api/1.0")
 	api.Use(router.GetUserInfo)
+	apiNoAuth := e.Group("/api/1.0")
 
 	// Tag: channel
 	api.GET("/channels", router.GetChannels)
@@ -179,6 +180,15 @@ func main() {
 	api.GET("/messages/:messageID/stamps", router.GetMessageStamps)
 	api.POST("/messages/:messageID/stamps/:stampID", router.PostMessageStamp)
 	api.DELETE("/messages/:messageID/stamps/:stampID", router.DeleteMessageStamp)
+
+	// Tag: webhook
+	api.GET("/channels/:channelID/webhooks", router.GetChannelWebhooks)
+	api.POST("/channels/:channelID/webhooks", router.PostChannelWebhooks)
+	api.GET("/webhooks/:webhookID", router.GetWebhook)
+	api.PATCH("/webhooks/:webhookID", router.PatchWebhook)
+	api.DELETE("/webhooks/:webhookID", router.DeleteWebhook)
+	apiNoAuth.POST("/webhooks/:webhookID/:token", router.PostWebhook)
+	apiNoAuth.POST("/webhooks/:webhookID/:token/github", router.PostWebhookByGithub)
 
 	// Serve UI
 	e.Static("/static", "./client/dist/static")

--- a/main.go
+++ b/main.go
@@ -183,13 +183,13 @@ func main() {
 	api.DELETE("/messages/:messageID/stamps/:stampID", router.DeleteMessageStamp)
 
 	// Tag: webhook
-	api.GET("/channels/:channelID/webhooks", router.GetChannelWebhooks)
-	api.POST("/channels/:channelID/webhooks", router.PostChannelWebhooks)
+	api.GET("/webhooks", router.GetWebhooks)
+	api.POST("/webhooks", router.PostWebhooks)
 	api.GET("/webhooks/:webhookID", router.GetWebhook)
 	api.PATCH("/webhooks/:webhookID", router.PatchWebhook)
 	api.DELETE("/webhooks/:webhookID", router.DeleteWebhook)
-	apiNoAuth.POST("/webhooks/:webhookID/:token", router.PostWebhook)
-	apiNoAuth.POST("/webhooks/:webhookID/:token/github", router.PostWebhookByGithub)
+	apiNoAuth.POST("/webhooks/:webhookID", router.PostWebhook)
+	apiNoAuth.POST("/webhooks/:webhookID/github", router.PostWebhookByGithub)
 
 	// Serve UI
 	e.Static("/static", "./client/dist/static")

--- a/model/bots.go
+++ b/model/bots.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	// BotTypeGeneral : 汎用タイプBot
+	BotTypeGeneral = 1
+	// BotTypeWebhook : WebhookタイプBot
+	BotTypeWebhook = 2
+)
+
+var (
+	// ErrBotInvalidName : Botエラー botの名前が不正です。
+	ErrBotInvalidName = errors.New("name must be 1-32 characters")
+
+	// ErrBotRequireDescription : Botエラー botの説明は必須です。
+	ErrBotRequireDescription = errors.New("description is required")
+)
+
+// Bot : Botの詳細構造体
+type Bot struct {
+	UserID      string    `xorm:"char(36) not null pk"`
+	Type        int       `xorm:"int not null"`
+	DisplayName string    `xorm:"varchar(32) not null"`
+	Description string    `xorm:"text not null"`
+	IsValid     bool      `xorm:"bool not null"`
+	CreatorID   string    `xorm:"char(36) not null"`
+	CreatedAt   time.Time `xorm:"created"`
+	UpdaterID   string    `xorm:"char(36) not null"`
+	UpdatedAt   time.Time `xorm:"updated"`
+}
+
+// TableName : Botのテーブル名
+func (*Bot) TableName() string {
+	return "bots"
+}
+
+// Update : Botを更新します
+func (b *Bot) Update() (err error) {
+	if len(b.DisplayName) == 0 || len(b.DisplayName) > 32 {
+		return ErrBotInvalidName
+	}
+
+	_, err = db.ID(b.UserID).UseBool().Update(b)
+	return
+}
+
+// Invalidate : Botを無効化します
+func (b *Bot) Invalidate() (err error) {
+	b.IsValid = false
+
+	_, err = db.ID(b.UserID).UseBool().Update(b)
+	return
+}

--- a/model/bots.go
+++ b/model/bots.go
@@ -24,7 +24,6 @@ var (
 type Bot struct {
 	UserID      string    `xorm:"char(36) not null pk"`
 	Type        int       `xorm:"int not null"`
-	DisplayName string    `xorm:"varchar(32) not null"`
 	Description string    `xorm:"text not null"`
 	IsValid     bool      `xorm:"bool not null"`
 	CreatorID   string    `xorm:"char(36) not null"`
@@ -40,10 +39,6 @@ func (*Bot) TableName() string {
 
 // Update : Botを更新します
 func (b *Bot) Update() (err error) {
-	if len(b.DisplayName) == 0 || len(b.DisplayName) > 32 {
-		return ErrBotInvalidName
-	}
-
 	_, err = db.ID(b.UserID).UseBool().Update(b)
 	return
 }

--- a/model/messages.go
+++ b/model/messages.go
@@ -42,7 +42,7 @@ func (m *Message) Create() error {
 	m.UpdaterID = m.UserID
 
 	if _, err := db.Insert(m); err != nil {
-		return fmt.Errorf("failed to create message object: %v", err)
+		return err
 	}
 	return nil
 }

--- a/model/users.go
+++ b/model/users.go
@@ -30,16 +30,17 @@ var (
 
 // User userの構造体
 type User struct {
-	ID        string    `xorm:"char(36) pk"`
-	Name      string    `xorm:"varchar(32) unique not null"`
-	Email     string    `xorm:"text not null"`
-	Password  string    `xorm:"char(128) not null"`
-	Salt      string    `xorm:"char(128) not null"`
-	Icon      string    `xorm:"char(36) not null"`
-	Status    int       `xorm:"tinyint not null"`
-	Bot       bool      `xorm:"bool not null"`
-	CreatedAt time.Time `xorm:"created not null"`
-	UpdatedAt time.Time `xorm:"updated not null"`
+	ID          string    `xorm:"char(36) pk"`
+	Name        string    `xorm:"varchar(32) unique not null"`
+	DisplayName string    `xorm:"varchar(32) not null"`
+	Email       string    `xorm:"text not null"`
+	Password    string    `xorm:"char(128) not null"`
+	Salt        string    `xorm:"char(128) not null"`
+	Icon        string    `xorm:"char(36) not null"`
+	Status      int       `xorm:"tinyint not null"`
+	Bot         bool      `xorm:"bool not null"`
+	CreatedAt   time.Time `xorm:"created not null"`
+	UpdatedAt   time.Time `xorm:"updated not null"`
 }
 
 // TableName dbの名前を指定する
@@ -163,6 +164,13 @@ func (user *User) UpdateIconID(ID string) error {
 	}
 	user.Icon = ID
 	_, err := db.ID(user.ID).UseBool().Update(user)
+	return err
+}
+
+// UpdateDisplayName ユーザーの表示名を変更する
+func (user *User) UpdateDisplayName(name string) error {
+	user.DisplayName = name
+	_, err := db.MustCols().Update(user)
 	return err
 }
 

--- a/model/users.go
+++ b/model/users.go
@@ -26,6 +26,8 @@ var (
 	ErrUserBotTryLogin = errors.New("bot user is not allowed to login")
 	// ErrUserWrongIDOrPassword : ユーザーエラー IDかパスワードが間違っています。
 	ErrUserWrongIDOrPassword = errors.New("password or id is wrong")
+	// ErrUserInvalidDisplayName : ユーザーエラー DisplayNameは0-32文字である必要があります。
+	ErrUserInvalidDisplayName = errors.New("displayName must be 0-32 characters")
 )
 
 // User userの構造体
@@ -169,6 +171,9 @@ func (user *User) UpdateIconID(ID string) error {
 
 // UpdateDisplayName ユーザーの表示名を変更する
 func (user *User) UpdateDisplayName(name string) error {
+	if len(name) > 32 {
+		return ErrUserInvalidDisplayName
+	}
 	user.DisplayName = name
 	_, err := db.MustCols().Update(user)
 	return err

--- a/model/utils.go
+++ b/model/utils.go
@@ -14,6 +14,8 @@ var (
 	// モデルを追加したら各自ここに追加しなければいけない
 	// **順番注意**
 	tables = []interface{}{
+		&Webhook{},
+		&Bot{},
 		&MessageStamp{},
 		&Stamp{},
 		&Clip{},
@@ -131,6 +133,21 @@ func SyncSchema() error {
 		return err
 	}
 	if _, err := db.Exec("ALTER TABLE `stamps` ADD FOREIGN KEY (`file_id`) REFERENCES `files`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `bots` ADD FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `bots` ADD FOREIGN KEY (`creator_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `bots` ADD FOREIGN KEY (`updater_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `webhooks` ADD FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `webhooks` ADD FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
 		return err
 	}
 

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -1,0 +1,118 @@
+package model
+
+import (
+	"encoding/base64"
+	"github.com/go-xorm/xorm"
+	"github.com/satori/go.uuid"
+)
+
+// Webhook : Webhook構造体
+type Webhook struct {
+	UserID    string `xorm:"char(36) not null pk"` //webhookIDと同義
+	Token     string `xorm:"varchar(32) not null"`
+	ChannelID string `xorm:"char(36) not null"`
+}
+
+// WebhookBotUser : WebhookBotUser構造体 内部にBot, Webhook, Userを内包
+type WebhookBotUser struct {
+	*Bot     `xorm:"extends"`
+	*Webhook `xorm:"extends"`
+	*User    `xorm:"extends"`
+}
+
+// TableName : Webhookのテーブル名
+func (*Webhook) TableName() string {
+	return "webhooks"
+}
+
+// TableName : JOIN処理用
+func (*WebhookBotUser) TableName() string {
+	return "users"
+}
+
+func getWebhookJoinedDB() *xorm.Session {
+	return db.Join("INNER", "bots", "bots.user_id = users.id").Join("INNER", "webhooks", "webhooks.user_id = users.id")
+}
+
+// GetWebhook : Webhookを取得します。
+func GetWebhook(webhookID string) (*WebhookBotUser, error) {
+	webhook := &WebhookBotUser{}
+
+	has, err := getWebhookJoinedDB().Where("users.id = ?", webhookID).Get(webhook)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, ErrNotFound
+	}
+
+	return webhook, nil
+}
+
+// GetWebhooksByChannelID : 指定したchannelにあるWebhookを全て取得します
+func GetWebhooksByChannelID(channelID string) (webhooks []*WebhookBotUser, err error) {
+	err = getWebhookJoinedDB().Where("webhooks.channel_id = ?", channelID).Find(&webhooks)
+	return
+}
+
+// CreateWebhook : Webhookを作成します。
+func CreateWebhook(name, description, channelID, creatorID, iconFileID string) (*WebhookBotUser, error) {
+	if len(name) == 0 || len(name) > 32 {
+		return nil, ErrBotInvalidName
+	}
+	if len(description) == 0 {
+		return nil, ErrBotRequireDescription
+	}
+
+	botUID := uuid.NewV4()
+	user := &User{
+		ID:       botUID.String(),
+		Name:     "Webhook#" + base64.RawStdEncoding.EncodeToString(botUID.Bytes()),
+		Email:    "",
+		Password: "",
+		Salt:     "",
+		Icon:     "",
+		Status:   1, //TODO
+		Bot:      true,
+	}
+
+	//iconがなければ生成
+	if len(iconFileID) != 36 {
+		fileID, err := generateIcon(user.Name, serverUser.ID)
+		if err != nil {
+			return nil, err
+		}
+		user.Icon = fileID
+	} else {
+		user.Icon = iconFileID
+	}
+
+	if _, err := db.Insert(user); err != nil {
+		return nil, err
+	}
+
+	bot := &Bot{
+		UserID:      user.ID,
+		Type:        BotTypeWebhook,
+		DisplayName: name,
+		Description: description,
+		IsValid:     true,
+		CreatorID:   creatorID,
+		UpdaterID:   creatorID,
+	}
+	webhook := &Webhook{
+		UserID:    user.ID,
+		ChannelID: channelID,
+		Token:     base64.RawURLEncoding.EncodeToString(uuid.NewV4().Bytes()),
+	}
+
+	if _, err := db.Insert(bot, webhook); err != nil {
+		return nil, err
+	}
+
+	return &WebhookBotUser{
+		Bot:     bot,
+		Webhook: webhook,
+		User:    user,
+	}, nil
+}

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -66,14 +66,15 @@ func CreateWebhook(name, description, channelID, creatorID, iconFileID string) (
 
 	botUID := uuid.NewV4()
 	user := &User{
-		ID:       botUID.String(),
-		Name:     "Webhook#" + base64.RawStdEncoding.EncodeToString(botUID.Bytes()),
-		Email:    "",
-		Password: "",
-		Salt:     "",
-		Icon:     "",
-		Status:   1, //TODO
-		Bot:      true,
+		ID:          botUID.String(),
+		Name:        "Webhook#" + base64.RawStdEncoding.EncodeToString(botUID.Bytes()),
+		DisplayName: name,
+		Email:       "",
+		Password:    "",
+		Salt:        "",
+		Icon:        "",
+		Status:      1, //TODO
+		Bot:         true,
 	}
 
 	//iconがなければ生成
@@ -94,7 +95,6 @@ func CreateWebhook(name, description, channelID, creatorID, iconFileID string) (
 	bot := &Bot{
 		UserID:      user.ID,
 		Type:        BotTypeWebhook,
-		DisplayName: name,
 		Description: description,
 		IsValid:     true,
 		CreatorID:   creatorID,

--- a/notification/events/types.go
+++ b/notification/events/types.go
@@ -10,6 +10,8 @@ const (
 	UserJoined EventType = "USER_JOINED"
 	//UserLeft ユーザーが脱退した
 	UserLeft EventType = "USER_LEFT"
+	//UserUpdated ユーザーの情報が更新された
+	UserUpdated EventType = "USER_UPDATED"
 	//UserTagsUpdated ユーザーのタグが更新された
 	UserTagsUpdated EventType = "USER_TAGS_UPDATED"
 	//UserIconUpdated ユーザーのアイコンが更新された

--- a/notification/notificator.go
+++ b/notification/notificator.go
@@ -53,7 +53,7 @@ func Send(eventType events.EventType, payload interface{}) {
 	}
 
 	switch eventType {
-	case events.UserJoined, events.UserLeft, events.UserTagsUpdated, events.UserIconUpdated:
+	case events.UserJoined, events.UserLeft, events.UserUpdated, events.UserTagsUpdated, events.UserIconUpdated:
 		data, _ := payload.(events.UserEvent)
 		multicastToAll(&eventData{
 			EventType: eventType,

--- a/router/users.go
+++ b/router/users.go
@@ -15,17 +15,21 @@ import (
 
 // UserForResponse クライアントに返す形のユーザー構造体
 type UserForResponse struct {
-	UserID string `json:"userId"`
-	Name   string `json:"name"`
-	IconID string `json:"iconFileId"`
+	UserID      string `json:"userId"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	IconID      string `json:"iconFileId"`
+	Bot         bool   `json:"bot"`
 }
 
 // UserDetailForResponse クライアントに返す形の詳細ユーザー構造体
 type UserDetailForResponse struct {
-	UserID  string            `json:"userId"`
-	Name    string            `json:"name"`
-	IconID  string            `json:"iconFileId"`
-	TagList []*TagForResponse `json:"tagList"`
+	UserID      string            `json:"userId"`
+	Name        string            `json:"name"`
+	DisplayName string            `json:"displayName"`
+	IconID      string            `json:"iconFileId"`
+	Bot         bool              `json:"bot"`
+	TagList     []*TagForResponse `json:"tagList"`
 }
 
 type loginRequestBody struct {
@@ -229,17 +233,21 @@ func PostUsers(c echo.Context) error {
 
 func formatUser(user *model.User) *UserForResponse {
 	return &UserForResponse{
-		UserID: user.ID,
-		Name:   user.Name,
-		IconID: user.Icon,
+		UserID:      user.ID,
+		Name:        user.Name,
+		DisplayName: user.DisplayName,
+		IconID:      user.Icon,
+		Bot:         user.Bot,
 	}
 }
 
 func formatUserDetail(user *model.User, tagList []*model.UsersTag) (*UserDetailForResponse, error) {
 	userDetail := &UserDetailForResponse{
-		UserID: user.ID,
-		Name:   user.Name,
-		IconID: user.Icon,
+		UserID:      user.ID,
+		Name:        user.Name,
+		DisplayName: user.DisplayName,
+		IconID:      user.Icon,
+		Bot:         user.Bot,
 	}
 	for _, tag := range tagList {
 		formattedTag, err := formatTag(tag)

--- a/router/webhook.go
+++ b/router/webhook.go
@@ -1,0 +1,368 @@
+package router
+
+import (
+	"github.com/labstack/echo"
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/notification"
+	"github.com/traPtitech/traQ/notification/events"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type webhookForResponse struct {
+	ID          string    `json:"id"`
+	DisplayName string    `json:"displayName"`
+	Description string    `json:"description"`
+	IconFileID  string    `json:"iconFileId"`
+	ChannelID   string    `json:"channelId"`
+	Token       string    `json:"token"`
+	Valid       bool      `json:"valid"`
+	CreatorID   string    `json:"creatorId"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdaterID   string    `json:"updaterId"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// GetChannelWebhooks : GET /channels/:channelID/webhooks
+func GetChannelWebhooks(c echo.Context) error {
+	//TODO ユーザー権限によって403にする
+	userID := c.Get("user").(*model.User).ID
+	channelID := c.Param("channelID")
+
+	if _, err := validateChannelID(channelID, userID); err != nil {
+		return err
+	}
+
+	list, err := model.GetWebhooksByChannelID(channelID)
+	if err != nil {
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	res := make([]*webhookForResponse, len(list))
+	for i, v := range list {
+		res[i] = formatWebhook(v)
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// PostChannelWebhooks : POST /channels/:channelID/webhooks
+func PostChannelWebhooks(c echo.Context) error {
+	//TODO ユーザー権限によって403にする
+	userID := c.Get("user").(*model.User).ID
+	channelID := c.Param("channelID")
+
+	if _, err := validateChannelID(channelID, userID); err != nil {
+		return err
+	}
+
+	req := struct {
+		Name        string `json:"name" form:"name"`
+		Description string `json:"description" form:"description"`
+	}{}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+
+	fileID := ""
+
+	if c.Request().MultipartForm != nil {
+		if uploadedFile, err := c.FormFile("file"); err == nil {
+			contentType := uploadedFile.Header.Get(echo.HeaderContentType)
+			switch contentType {
+			case "image/png", "image/jpeg", "image/gif", "image/svg+xml":
+				break
+			default:
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid image file")
+			}
+
+			if uploadedFile.Size > 1024*1024 {
+				return echo.NewHTTPError(http.StatusBadRequest, "too big image file")
+			}
+
+			file := &model.File{
+				Name:      uploadedFile.Filename,
+				Size:      uploadedFile.Size,
+				CreatorID: userID,
+			}
+
+			src, err := uploadedFile.Open()
+			if err != nil {
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+			defer src.Close()
+
+			if err := file.Create(src); err != nil {
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+			fileID = file.ID
+		} else if err != http.ErrMissingFile {
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		}
+	}
+
+	wb, err := model.CreateWebhook(req.Name, req.Description, channelID, userID, fileID)
+	if err != nil {
+		switch err {
+		case model.ErrBotInvalidName:
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	return c.JSON(http.StatusCreated, formatWebhook(wb))
+}
+
+// GetWebhook : GET /webhooks/:webhookID
+func GetWebhook(c echo.Context) error {
+	//TODO ユーザー権限によって403にする
+	webhookID := c.Param("webhookID")
+
+	wb, err := model.GetWebhook(webhookID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	return c.JSON(http.StatusOK, formatWebhook(wb))
+}
+
+// PatchWebhook : PATCH /webhooks/:webhookID
+func PatchWebhook(c echo.Context) error {
+	//TODO ユーザー権限によって403にする
+	webhookID := c.Param("webhookID")
+	userID := c.Get("user").(*model.User).ID
+
+	wb, err := model.GetWebhook(webhookID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if !wb.IsValid {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	req := struct {
+		Name        string `json:"name" form:"name"`
+		Description string `json:"description" form:"description"`
+	}{}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+	if len(req.Name) > 32 {
+		return echo.NewHTTPError(http.StatusBadRequest, model.ErrBotInvalidName)
+	}
+
+	fileID := ""
+
+	if c.Request().MultipartForm != nil {
+		if uploadedFile, err := c.FormFile("file"); err == nil {
+			contentType := uploadedFile.Header.Get(echo.HeaderContentType)
+			switch contentType {
+			case "image/png", "image/jpeg", "image/gif", "image/svg+xml":
+				break
+			default:
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid image file")
+			}
+
+			if uploadedFile.Size > 1024*1024 {
+				return echo.NewHTTPError(http.StatusBadRequest, "too big image file")
+			}
+
+			file := &model.File{
+				Name:      uploadedFile.Filename,
+				Size:      uploadedFile.Size,
+				CreatorID: userID,
+			}
+
+			src, err := uploadedFile.Open()
+			if err != nil {
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+			defer src.Close()
+
+			if err := file.Create(src); err != nil {
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+			fileID = file.ID
+		} else if err != http.ErrMissingFile {
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		}
+	}
+
+	if len(fileID) == 36 {
+		if err := wb.UpdateIconID(fileID); err != nil {
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if len(req.Name) > 0 {
+		if err := wb.UpdateDisplayName(req.Name); err != nil {
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if len(req.Description) > 0 {
+		wb.Description = req.Description
+	}
+
+	if err := wb.Update(); err != nil {
+		switch err {
+		case model.ErrBotInvalidName:
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// DeleteWebhook : DELETE /webhooks/:webhookID
+func DeleteWebhook(c echo.Context) error {
+	//TODO ユーザー権限によって403にする
+	webhookID := c.Param("webhookID")
+
+	wb, err := model.GetWebhook(webhookID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if !wb.IsValid {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	if err := wb.Invalidate(); err != nil {
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// PostWebhook : POST /webhooks/:webhookID/:token
+func PostWebhook(c echo.Context) error {
+	webhookID := c.Param("webhookID")
+	token := c.Param("token")
+
+	wb, err := model.GetWebhook(webhookID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if !wb.IsValid {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	if wb.Token != token {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	message := &model.Message{
+		UserID:    wb.ID,
+		ChannelID: wb.ChannelID,
+	}
+	switch c.Request().Header.Get(echo.HeaderContentType) {
+	case echo.MIMETextPlain, echo.MIMETextPlainCharsetUTF8:
+		if b, err := ioutil.ReadAll(c.Request().Body); err == nil {
+			message.Text = string(b)
+		}
+		if len(message.Text) == 0 {
+			return echo.NewHTTPError(http.StatusBadRequest)
+		}
+
+	case echo.MIMEApplicationJSON, echo.MIMEApplicationForm, echo.MIMEApplicationJSONCharsetUTF8:
+		req := struct {
+			Text string `json:"text" form:"text"`
+		}{}
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		}
+		if len(req.Text) == 0 {
+			return echo.NewHTTPError(http.StatusBadRequest)
+		}
+		message.Text = req.Text
+
+	default:
+		return echo.NewHTTPError(http.StatusUnsupportedMediaType)
+	}
+
+	if err := message.Create(); err != nil {
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	go notification.Send(events.MessageCreated, events.MessageEvent{Message: *message})
+	return c.NoContent(http.StatusNoContent)
+}
+
+// PostWebhookByGithub : POST /webhooks/:webhookID/:token/github
+func PostWebhookByGithub(c echo.Context) error {
+	webhookID := c.Param("webhookID")
+	token := c.Param("token")
+
+	wb, err := model.GetWebhook(webhookID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+	if !wb.IsValid {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	if wb.Token != token {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	//TODO parse JSON and post message
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func formatWebhook(w *model.WebhookBotUser) *webhookForResponse {
+	return &webhookForResponse{
+		ID:          w.ID,
+		DisplayName: w.DisplayName,
+		Description: w.Description,
+		IconFileID:  w.Icon,
+		ChannelID:   w.ChannelID,
+		Token:       w.Token,
+		Valid:       w.IsValid,
+		CreatorID:   w.Bot.CreatorID,
+		CreatedAt:   w.Bot.CreatedAt,
+		UpdaterID:   w.Bot.UpdaterID,
+		UpdatedAt:   w.Bot.UpdatedAt,
+	}
+}

--- a/router/webhook.go
+++ b/router/webhook.go
@@ -118,6 +118,7 @@ func PostChannelWebhooks(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
 	}
+	go notification.Send(events.UserJoined, events.UserEvent{ID: wb.ID})
 
 	return c.JSON(http.StatusCreated, formatWebhook(wb))
 }
@@ -216,12 +217,16 @@ func PatchWebhook(c echo.Context) error {
 			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+
+		go notification.Send(events.UserIconUpdated, events.UserEvent{ID: wb.ID})
 	}
 	if len(req.Name) > 0 {
 		if err := wb.UpdateDisplayName(req.Name); err != nil {
 			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+
+		go notification.Send(events.UserUpdated, events.UserEvent{ID: wb.ID})
 	}
 	if len(req.Description) > 0 {
 		wb.Description = req.Description
@@ -434,6 +439,7 @@ func PostWebhookByGithub(c echo.Context) error {
 			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+		go notification.Send(events.MessageCreated, events.MessageEvent{Message: *message})
 	}
 
 	return c.NoContent(http.StatusNoContent)


### PR DESCRIPTION
```go
	api.PATCH("/users/me", router.PatchMe)
	api.GET("/channels/:channelID/webhooks", router.GetChannelWebhooks)
	api.POST("/channels/:channelID/webhooks", router.PostChannelWebhooks)
	api.GET("/webhooks/:webhookID", router.GetWebhook)
	api.PATCH("/webhooks/:webhookID", router.PatchWebhook)
	api.DELETE("/webhooks/:webhookID", router.DeleteWebhook)
	apiNoAuth.POST("/webhooks/:webhookID/:token", router.PostWebhook)
	apiNoAuth.POST("/webhooks/:webhookID/:token/github", router.PostWebhookByGithub)
```
のAPIを実装。
UserにDisplayName, Botフィールドを追加。
bots, webhooksテーブルを定義。
SSE:USER_UPDATEDイベントを追加。現在はユーザーのDisplayNameが更新された時に通知される。
ユーザーのDisplayNameが空だった場合、apiのレスポンスではNameと同じになる。
ユーザーの権限によってWebhookの作成・管理等を制御するの以外はできている。
一応github-compatible webhookを受けて、メッセージに整形するようにしてるが、Webhookの内容を`!{...}`形式に変換してメッセージに突っ込んでクライアント側で表示を実装したほうがいいです。