### PR TITLE
visibilityタグのAPI実装

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,6 +180,10 @@ func main() {
 	api.POST("/messages/:messageID/stamps/:stampID", router.PostMessageStamp)
 	api.DELETE("/messages/:messageID/stamps/:stampID", router.DeleteMessageStamp)
 
+	//Tag: visibility
+	api.GET("users/me/channels/visibility", router.GetChannelsVisibility)
+	api.PUT("users/me/channels/visibility", router.PutChannelsVisibility)
+
 	// Serve UI
 	e.Static("/static", "./client/dist/static")
 	e.File("*", "./client/dist/index.html")

--- a/model/users_invisible_channels.go
+++ b/model/users_invisible_channels.go
@@ -1,0 +1,96 @@
+package model
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrInvisibleChannelInvalidField channelIDかuserIDが未入力
+	ErrInvisibleChannelInvalidField = errors.New("invalid field")
+)
+
+// UserInvisibleChannel users_invisible_channelsの構造体
+type UserInvisibleChannel struct {
+	UserID    string    `xorm:"char(36) pk not null"`
+	ChannelID string    `xorm:"char(36) pk not null"`
+	CreatedAt time.Time `xorm:"created not null"`
+}
+
+// TableName テーブルの名前を指定する
+func (*UserInvisibleChannel) TableName() string {
+	return "users_invisible_channels"
+}
+
+// Create DBに登録する
+func (i *UserInvisibleChannel) Create() error {
+	if err := validateUserInvisibleChannel(i); err != nil {
+		return err
+	}
+
+	if _, err := db.InsertOne(i); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Exists DBに登録されているかを確認する
+func (i *UserInvisibleChannel) Exists() (bool, error) {
+	if err := validateUserInvisibleChannel(i); err != nil {
+		return false, err
+	}
+
+	return db.Get(i)
+}
+
+// Delete DBから削除する
+func (i *UserInvisibleChannel) Delete() error {
+	if err := validateUserInvisibleChannel(i); err != nil {
+		return err
+	}
+
+	if _, err := db.Delete(i); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetInvisibleChannelsByID 指定されたユーザーから見えないチャンネルのリストを取得する
+func GetInvisibleChannelsByID(userID string) ([]string, error) {
+	var channelIDs []string
+	// FIXME: ここのクエリが不完全
+	err := db.Table("channels").Join("LEFT", []string{"users_private_channels", "p"}, "p.channel_id = channels.id").
+		Join("LEFT", []string{"users_invisible_channels", "i"}, "i.channel_id = channels.id").
+		Where("is_deleted = true OR i.user_id = ? OR is_public = false", userID). // 自分のprivatechannelも取得してしまう
+		Cols("id").Find(&channelIDs)
+	if err != nil {
+		return nil, err
+	}
+	return channelIDs, nil
+}
+
+// GetVisibleChannelsByID 指定されたユーザーから見えるチャンネルのリストを取得する
+func GetVisibleChannelsByID(userID string) ([]string, error) {
+	var channelIDs []string
+	err := db.Table("channels").Join("LEFT", []string{"users_private_channels", "p"}, "p.channel_id = channels.id").
+		Join("LEFT", []string{"users_invisible_channels", "i"}, "i.channel_id = channels.id").
+		Where("(is_public = true OR p.user_id = ?) AND is_deleted = false AND i.user_id IS NULL", userID).
+		Cols("id").Find(&channelIDs)
+	if err != nil {
+		return nil, err
+	}
+	return channelIDs, nil
+}
+
+// 外部キー制約の項目が入力されているかどうかを判定する
+func validateUserInvisibleChannel(i *UserInvisibleChannel) error {
+	if i.UserID == "" {
+		return ErrInvisibleChannelInvalidField
+	}
+	if i.ChannelID == "" {
+		return ErrInvisibleChannelInvalidField
+	}
+
+	return nil
+}

--- a/model/users_invisible_channels_test.go
+++ b/model/users_invisible_channels_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserInvisibleChananel_TabelName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "users_invisible_channels", (&UserInvisibleChannel{}).TableName())
+}
+
+func TestUserInvisibleChananel_Create(t *testing.T) {
+	assert, _, user, channel := beforeTest(t)
+
+	assert.Error((&UserInvisibleChannel{}).Create())
+	assert.Error((&UserInvisibleChannel{UserID: user.ID}).Create())
+	assert.Error((&UserInvisibleChannel{ChannelID: channel.ID}).Create())
+	assert.Error((&UserInvisibleChannel{UserID: CreateUUID()}).Create())
+	assert.Error((&UserInvisibleChannel{ChannelID: CreateUUID()}).Create())
+
+	assert.NoError((&UserInvisibleChannel{UserID: user.ID, ChannelID: channel.ID}).Create())
+}
+
+func TestUserInvisibleChananel_Exists(t *testing.T) {
+	assert, _, user, channel := beforeTest(t)
+
+	i := mustMakeInvisibleChannel(t, channel.ID, user.ID)
+	ok, err := i.Exists()
+	if assert.NoError(err) {
+		assert.True(ok)
+	}
+
+	i = &UserInvisibleChannel{
+		UserID:    CreateUUID(),
+		ChannelID: CreateUUID(),
+	}
+	ok, err = i.Exists()
+	if assert.NoError(err) {
+		assert.False(ok)
+	}
+}
+
+func TestUserInvisibleChananel_Delete(t *testing.T) {
+	assert, _, user, channel := beforeTest(t)
+
+	i := mustMakeInvisibleChannel(t, channel.ID, user.ID)
+
+	ok, err := db.Get(i)
+	if assert.NoError(err) {
+		assert.True(ok)
+	}
+
+	assert.NoError(i.Delete())
+
+	ok, err = db.Get(i)
+	if assert.NoError(err) {
+		assert.False(ok)
+	}
+}
+
+func TestGetInvisibleChannelsByID(t *testing.T) {
+	assert, _, user, _ := beforeTest(t)
+
+	for i := 0; i < 5; i++ {
+		c := mustMakeChannel(t, user.ID, "-"+strconv.Itoa(i))
+		mustMakeInvisibleChannel(t, c.ID, user.ID)
+	}
+
+	// TODO: privateチャンネルに関するテストを追加する
+
+	list, err := GetInvisibleChannelsByID(user.ID)
+	if assert.NoError(err) {
+		assert.Equal(5, len(list))
+	}
+}
+
+func TestGetVisibleChannelsByID(t *testing.T) {
+	assert, _, user, _ := beforeTest(t)
+
+	for i := 0; i < 5; i++ {
+		mustMakeChannel(t, user.ID, "-"+strconv.Itoa(i))
+	}
+
+	list, err := GetVisibleChannelsByID(user.ID)
+	if assert.NoError(err) {
+		assert.Equal(6, len(list))
+	}
+
+}

--- a/model/users_invisible_channels_test.go
+++ b/model/users_invisible_channels_test.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,11 +71,24 @@ func TestGetInvisibleChannelsByID(t *testing.T) {
 		mustMakeInvisibleChannel(t, c.ID, user.ID)
 	}
 
-	// TODO: privateチャンネルに関するテストを追加する
+	c := mustMakeChannelDetail(t, user.ID, "visible-private", "", false)
+	p := &UsersPrivateChannel{
+		UserID:    user.ID,
+		ChannelID: c.ID,
+	}
+	require.NoError(t, p.Create())
+
+	u := mustMakeUser(t, "invisible")
+	c = mustMakeChannelDetail(t, u.ID, "invisible-private", "", false)
+	p = &UsersPrivateChannel{
+		UserID:    u.ID,
+		ChannelID: c.ID,
+	}
+	require.NoError(t, p.Create())
 
 	list, err := GetInvisibleChannelsByID(user.ID)
 	if assert.NoError(err) {
-		assert.Equal(5, len(list))
+		assert.Equal(6, len(list))
 	}
 }
 
@@ -84,9 +99,24 @@ func TestGetVisibleChannelsByID(t *testing.T) {
 		mustMakeChannel(t, user.ID, "-"+strconv.Itoa(i))
 	}
 
+	c := mustMakeChannelDetail(t, user.ID, "visible-private", "", false)
+	p := &UsersPrivateChannel{
+		UserID:    user.ID,
+		ChannelID: c.ID,
+	}
+	require.NoError(t, p.Create())
+
+	u := mustMakeUser(t, "invisible")
+	c = mustMakeChannelDetail(t, u.ID, "invisible-private", "", false)
+	p = &UsersPrivateChannel{
+		UserID:    u.ID,
+		ChannelID: c.ID,
+	}
+	require.NoError(t, p.Create())
+
 	list, err := GetVisibleChannelsByID(user.ID)
 	if assert.NoError(err) {
-		assert.Equal(6, len(list))
+		assert.Equal(7, len(list))
 	}
 
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"errors"
+
 	"github.com/go-xorm/xorm"
 	"github.com/satori/go.uuid"
 )
@@ -14,6 +15,7 @@ var (
 	// モデルを追加したら各自ここに追加しなければいけない
 	// **順番注意**
 	tables = []interface{}{
+		&UserInvisibleChannel{},
 		&MessageStamp{},
 		&Stamp{},
 		&Clip{},
@@ -131,6 +133,12 @@ func SyncSchema() error {
 		return err
 	}
 	if _, err := db.Exec("ALTER TABLE `stamps` ADD FOREIGN KEY (`file_id`) REFERENCES `files`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `users_invisible_channels` ADD FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("ALTER TABLE `users_invisible_channels` ADD FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
 		return err
 	}
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -141,8 +141,8 @@ func SyncSchema() error {
 		return err
 	}
 	if _, err := db.Exec("ALTER TABLE `users_invisible_channels` ADD FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
-    return err
-  }
+		return err
+	}
 	if _, err := db.Exec("ALTER TABLE `bots` ADD FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;"); err != nil {
 		return err
 	}

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -3,10 +3,11 @@ package model
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/go-xorm/core"
@@ -90,6 +91,14 @@ func mustMakeChannelDetail(t *testing.T, creatorID, name, parentID string, isPub
 	channel.IsPublic = isPublic
 	require.NoError(t, channel.Create())
 	return channel
+}
+
+func mustMakeInvisibleChannel(t *testing.T, channelID, userID string) *UserInvisibleChannel {
+	i := &UserInvisibleChannel{}
+	i.UserID = userID
+	i.ChannelID = channelID
+	require.NoError(t, i.Create())
+	return i
 }
 
 func mustMakeMessage(t *testing.T, userID, channelID string) *Message {

--- a/router/utils_test.go
+++ b/router/utils_test.go
@@ -3,12 +3,13 @@ package router
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/go-xorm/core"
@@ -183,6 +184,17 @@ func mustMakeChannel(t *testing.T, userID, name string, isPublic bool) *model.Ch
 	}
 	require.NoError(t, channel.Create())
 	return channel
+}
+
+func mustMakeInvisibleChannel(t *testing.T, userID, name string, isPublic bool) *model.UserInvisibleChannel {
+	c := mustMakeChannel(t, testUser.ID, name, isPublic)
+	i := &model.UserInvisibleChannel{
+		UserID:    userID,
+		ChannelID: c.ID,
+	}
+	require.NoError(t, i.Create())
+	return i
+
 }
 
 func mustMakeMessage(t *testing.T, userID, channelID string) *model.Message {

--- a/router/visibility.go
+++ b/router/visibility.go
@@ -1,0 +1,100 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/traPtitech/traQ/model"
+)
+
+// Visibility visibilityの受け渡し用構造体
+type Visibility struct {
+	Visible []string `json:"visible"`
+	Hidden  []string `json:"hidden"`
+}
+
+// GetChannelsVisibility GET /users/me/channels/visibility
+func GetChannelsVisibility(c echo.Context) error {
+	userID := c.Get("user").(*model.User).ID
+
+	res, err := getVisibilityResponse(c, userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// PutChannelsVisibility PUT /users/me/channels/visibility
+func PutChannelsVisibility(c echo.Context) error {
+	userID := c.Get("user").(*model.User).ID
+
+	req := &Visibility{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request")
+	}
+
+	for _, v := range req.Hidden {
+		i := model.UserInvisibleChannel{
+			UserID:    userID,
+			ChannelID: v,
+		}
+
+		ok, err := i.Exists()
+		if err != nil {
+			c.Logger().Errorf("failed to check users_invisible_channels: %v", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update channel visibility")
+		}
+		if !ok {
+			if err := i.Create(); err != nil {
+				c.Logger().Errorf("failed to create users_invisible_channels: %v", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update channel visibility")
+			}
+		}
+	}
+
+	for _, v := range req.Visible {
+		i := model.UserInvisibleChannel{
+			UserID:    userID,
+			ChannelID: v,
+		}
+		ok, err := i.Exists()
+		if err != nil {
+			c.Logger().Errorf("failed to check users_invisible_channels: %v", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update channel visibility")
+		}
+		if ok {
+			if err := i.Delete(); err != nil {
+				c.Logger().Errorf("failed to delete users_invisible_channels: %v", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update channel visibility")
+			}
+		}
+	}
+
+	res, err := getVisibilityResponse(c, userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+func getVisibilityResponse(c echo.Context, userID string) (*Visibility, error) {
+	visible, err := model.GetVisibleChannelsByID(userID)
+	if err != nil {
+		c.Logger().Errorf("failed to get visible channels: %v", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to get channel visibility")
+	}
+
+	hidden, err := model.GetInvisibleChannelsByID(userID)
+	if err != nil {
+		c.Logger().Errorf("failed to get hidden channels: %v", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to get channel visibility")
+	}
+
+	res := &Visibility{
+		Visible: visible,
+		Hidden:  hidden,
+	}
+	return res, nil
+}

--- a/router/visibility_test.go
+++ b/router/visibility_test.go
@@ -1,0 +1,51 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+func TestGetChannelVisibility(t *testing.T) {
+	e, cookie, mw, assert, require := beforeTest(t)
+
+	for i := 0; i < 5; i++ {
+		mustMakeInvisibleChannel(t, testUser.ID, "test-"+strconv.Itoa(i), true)
+	}
+
+	rec := request(e, t, mw(GetChannelsVisibility), cookie, nil)
+
+	require.EqualValues(http.StatusOK, rec.Code, rec.Body.String())
+
+	var res Visibility
+	if assert.NoError(json.Unmarshal(rec.Body.Bytes(), &res)) {
+		assert.Equal(5, len(res.Hidden))
+	}
+}
+
+func TestPutChannelVisibility(t *testing.T) {
+	e, cookie, mw, assert, require := beforeTest(t)
+	ch := mustMakeChannel(t, testUser.ID, "test", true)
+
+	jsonBody := &Visibility{
+		Visible: []string{},
+		Hidden:  []string{ch.ID},
+	}
+	body, err := json.Marshal(jsonBody)
+	require.NoError(err)
+
+	req := httptest.NewRequest("PUT", "http://test", bytes.NewReader(body))
+	c, rec := getContext(e, t, cookie, req)
+	requestWithContext(t, mw(PutChannelsVisibility), c)
+
+	require.EqualValues(http.StatusOK, rec.Code, rec.Body.String())
+
+	var res Visibility
+	if assert.NoError(json.Unmarshal(rec.Body.Bytes(), &res)) {
+		assert.Equal(len(jsonBody.Hidden), len(res.Hidden))
+	}
+
+}


### PR DESCRIPTION
#170 のものを実装しました

クエリがうまく書けなかったのでそこだけ見てほしいです
model/users_inivisible_channels.goの`GetInvisibleChannelsByID()`の中にあるクエリですが、現状だと自分が参加しているprivateのチャンネルもhiddenとして返してしまうと思われます。
単純に`user_id != userID`としてもprivateのもう片方のほうで拾われてしまうのでうまくいかなさそうです。