### PR TITLE
bmp, png, jpg, webp, gifのサムネイル生成を実装

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -158,6 +158,9 @@ user_idとmessage_idの複合主キー
 | is_deleted | BOOLEAN | NOT NULL | 削除されているか |
 | hash | CHAR(32) | NOT NULL | ハッシュ値 |
 | manager | VARCHAR(30) | NOT NULL DEFAULT '' | マネージャー名(空文字はデフォルトマネージャー) |
+| has_thumbnail | BOOLEAN | NOT NULL | サムネイルがあるか |
+| thumbnail_width | INT | NOT NULL | サムネイルの幅 |
+| thumbnail_height | INT | NOT NULL | サムネイルの高さ |
 | created_at | TIMESTAMP | NOT NULL | 投稿日時 |
 
 ## stars

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1130,10 +1130,12 @@ paths:
             正常に取得できました。
             サムネイルを返します。
           content:
-            image/png:
+            image/jpeg:
               schema:
                 type: string
                 format: binary
+        "404":
+          description: 取得できませんでした。サムネイルは存在しません。
 
   /messages/{messageID}:
     parameters:
@@ -1837,6 +1839,12 @@ components:
         dateTime:
           type: string
           format: date-time
+        hasThumb:
+          type: boolean
+        thumbWidth:
+          type: integer
+        thumbHeight:
+          type: integer
 
     UnreadList:
       type: array

--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func main() {
 	api.GET("/files/:fileID", router.GetFileByID)
 	api.DELETE("/files/:fileID", router.DeleteFileByID)
 	api.GET("/files/:fileID/meta", router.GetMetaDataByFileID)
+	api.GET("/files/:fileID/thumbnail", router.GetThumbnailByID)
 
 	// Tag: pin
 	api.GET("/channels/:channelID/pin", router.GetChannelPin)

--- a/model/files.go
+++ b/model/files.go
@@ -196,6 +196,24 @@ func (f *File) GetRedirectURL() string {
 	return m.GetRedirectURL(f.ID)
 }
 
+// RegenerateThumbnail サムネイル画像を再生成します
+func (f *File) RegenerateThumbnail() error {
+	reader, ok := fileManagers[f.Manager]
+	if !ok {
+		return ErrFileUnknownManager
+	}
+
+	//既存のものを削除
+	reader.DeleteByID(f.ID + "-thumb")
+
+	src, err := reader.OpenFileByID(f.ID)
+	if err != nil {
+		return err
+	}
+
+	return GenerateThumbnail(context.Background(), f, src)
+}
+
 // GenerateThumbnail サムネイル画像を生成します
 func GenerateThumbnail(ctx context.Context, f *File, src io.Reader) error {
 	var (

--- a/model/files.go
+++ b/model/files.go
@@ -1,9 +1,21 @@
 package model
 
 import (
+	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"github.com/labstack/gommon/log"
+	"golang.org/x/image/bmp"
+	"golang.org/x/image/draw"
+	"golang.org/x/image/webp"
+	"golang.org/x/sync/errgroup"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
 	"io"
 	"mime"
 	"os"
@@ -11,9 +23,22 @@ import (
 	"time"
 )
 
-var fileManagers = map[string]FileManager{
-	"": NewDevFileManager(),
-}
+const (
+	thumbnailMaxWidth  = 360
+	thumbnailMaxHeight = 480
+	thumbnailRatio     = float64(thumbnailMaxWidth) / float64(thumbnailMaxHeight)
+)
+
+var (
+	fileManagers = map[string]FileManager{
+		"": NewDevFileManager(),
+	}
+
+	// ErrFileThumbUnsupported : fileエラー この形式のファイルのサムネイル生成はサポートされていない
+	ErrFileThumbUnsupported = errors.New("generating a thumbnail of the file is not supported")
+	// ErrFileUnknownManager : fileエラー 不明なファイルマネージャー
+	ErrFileUnknownManager = errors.New("unknown file manager")
+)
 
 // FileManager ファイルを読み書きするマネージャーのインターフェース
 type FileManager interface {
@@ -29,15 +54,18 @@ type FileManager interface {
 
 // File DBに格納するファイルの構造体
 type File struct {
-	ID        string    `xorm:"char(36) pk"`
-	Name      string    `xorm:"text not null"`
-	Mime      string    `xorm:"text not null"`
-	Size      int64     `xorm:"bigint not null"`
-	CreatorID string    `xorm:"char(36) not null"`
-	IsDeleted bool      `xorm:"bool not null"`
-	Hash      string    `xorm:"char(32) not null"`
-	Manager   string    `xorm:"varchar(30) not null default ''"`
-	CreatedAt time.Time `xorm:"created not null"`
+	ID              string    `xorm:"char(36) pk"`
+	Name            string    `xorm:"text not null"`
+	Mime            string    `xorm:"text not null"`
+	Size            int64     `xorm:"bigint not null"`
+	CreatorID       string    `xorm:"char(36) not null"`
+	IsDeleted       bool      `xorm:"bool not null"`
+	Hash            string    `xorm:"char(32) not null"`
+	Manager         string    `xorm:"varchar(30) not null default ''"`
+	HasThumbnail    bool      `xorm:"bool not null"`
+	ThumbnailWidth  int       `xorm:"int not null"`
+	ThumbnailHeight int       `xorm:"int not null"`
+	CreatedAt       time.Time `xorm:"created not null"`
 }
 
 // TableName dbのtableの名前を返します
@@ -63,18 +91,51 @@ func (f *File) Create(src io.Reader) error {
 
 	writer, ok := fileManagers[f.Manager]
 	if !ok {
-		return fmt.Errorf("unknown file manager: %s", f.Manager)
+		return ErrFileUnknownManager
 	}
 
-	if err := writer.WriteByID(src, f.ID, f.Name, f.Mime); err != nil {
-		return fmt.Errorf("Failed to write data into file: %v", err)
-	}
+	eg, ctx := errgroup.WithContext(context.Background())
 
-	hash, err := calcMD5(src)
-	if err != nil {
+	fileSrc, fileWriter := io.Pipe()
+	thumbSrc, thumbWriter := io.Pipe()
+	hash := md5.New()
+
+	go func() {
+		defer fileWriter.Close()
+		defer thumbWriter.Close()
+		io.Copy(io.MultiWriter(fileWriter, hash, thumbWriter), src) // 並列化してるけど、pipeじゃなくてbuffer使わないとreaderがブロックしてて意味無い疑惑
+	}()
+
+	// fileの保存
+	eg.Go(func() error {
+		defer fileSrc.Close()
+		if err := writer.WriteByID(fileSrc, f.ID, f.Name, f.Mime); err != nil {
+			return fmt.Errorf("Failed to write data into file: %v", err)
+		}
+		return nil
+	})
+
+	// サムネイルの生成
+	eg.Go(func() error {
+		// アップロードされたファイルの拡張子が間違えてたり、変なの送ってきた場合
+		// サムネイルを生成しないだけで全体のエラーにはしない
+		defer thumbSrc.Close()
+		if err := GenerateThumbnail(ctx, f, thumbSrc); err != nil {
+			switch err {
+			case ErrFileThumbUnsupported:
+				return nil
+			default:
+				log.Error(err)
+			}
+		}
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
 		return err
 	}
-	f.Hash = hash
+
+	f.Hash = hex.EncodeToString(hash.Sum(nil))
 
 	if _, err := db.Insert(f); err != nil {
 		return fmt.Errorf("Failed to create file")
@@ -109,7 +170,7 @@ func (f *File) Delete() error {
 func (f *File) Open() (io.ReadCloser, error) {
 	reader, ok := fileManagers[f.Manager]
 	if !ok {
-		return nil, fmt.Errorf("unknown file manager: %s", f.Manager)
+		return nil, ErrFileUnknownManager
 	}
 
 	return reader.OpenFileByID(f.ID)
@@ -124,6 +185,74 @@ func (f *File) GetRedirectURL() string {
 	return m.GetRedirectURL(f.ID)
 }
 
+// GenerateThumbnail サムネイル画像を生成します
+func GenerateThumbnail(ctx context.Context, f *File, src io.Reader) error {
+	var (
+		img       image.Image
+		err       error
+		thumbSize image.Point
+		dst       draw.Image
+		b         = &bytes.Buffer{}
+	)
+
+	writer, ok := fileManagers[f.Manager]
+	if !ok {
+		return ErrFileUnknownManager
+	}
+
+	switch f.Mime {
+	case "image/png":
+		img, err = png.Decode(src)
+	case "image/gif":
+		img, err = gif.Decode(src)
+	case "image/jpeg":
+		img, err = jpeg.Decode(src)
+	case "image/bmp":
+		img, err = bmp.Decode(src)
+	case "image/webp":
+		img, err = webp.Decode(src)
+	default: // Unsupported Type
+		return ErrFileThumbUnsupported
+	}
+	if err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		thumbSize = calcThumbnailSize(img.Bounds().Size())
+		dst = image.NewRGBA(image.Rectangle{Min: image.ZP, Max: thumbSize})
+		draw.Draw(dst, dst.Bounds(), image.White, image.ZP, draw.Src)
+		draw.ApproxBiLinear.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Src, nil)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		if err := jpeg.Encode(b, dst, &jpeg.Options{Quality: 100}); err != nil {
+			return err
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		if err := writer.WriteByID(b, f.ID+"-thumb", f.ID+"-thumb.jpg", "image/jpeg"); err != nil {
+			return err
+		}
+	}
+
+	f.HasThumbnail = true
+	f.ThumbnailWidth = thumbSize.X
+	f.ThumbnailHeight = thumbSize.Y
+
+	return nil
+}
+
 // OpenFileByID ファイルを取得します
 func OpenFileByID(ID string) (io.ReadCloser, error) {
 	meta, err := GetMetaFileDataByID(ID)
@@ -133,7 +262,7 @@ func OpenFileByID(ID string) (io.ReadCloser, error) {
 
 	reader, ok := fileManagers[meta.Manager]
 	if !ok {
-		return nil, fmt.Errorf("unknown file manager: %s", meta.Manager)
+		return nil, ErrFileUnknownManager
 	}
 
 	return reader.OpenFileByID(ID)
@@ -154,13 +283,19 @@ func GetMetaFileDataByID(FileID string) (*File, error) {
 	return f, nil
 }
 
-// 与えられたデータに対してMD5によるハッシュ値を計算します
-func calcMD5(src io.Reader) (string, error) {
-	h := md5.New()
-	if _, err := io.Copy(h, src); err != nil {
-		return "", fmt.Errorf("Failed to calc md5")
+// サムネイルのサイズを計算します
+func calcThumbnailSize(size image.Point) image.Point {
+	if size.X <= thumbnailMaxWidth && size.Y <= thumbnailMaxHeight {
+		// 元画像がサムネイル画像より小さい
+		return size
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+
+	ratio := float64(size.X) / float64(size.Y)
+
+	if ratio > thumbnailRatio {
+		return image.Pt(thumbnailMaxWidth, int(thumbnailMaxWidth/ratio))
+	}
+	return image.Pt(int(thumbnailMaxHeight*ratio), thumbnailMaxHeight)
 }
 
 // SetFileManager ファイルマネージャーリストにマネージャーをセットします

--- a/model/files.go
+++ b/model/files.go
@@ -211,7 +211,14 @@ func (f *File) RegenerateThumbnail() error {
 		return err
 	}
 
-	return GenerateThumbnail(context.Background(), f, src)
+	if err := GenerateThumbnail(context.Background(), f, src); err != nil {
+		return err
+	}
+
+	if _, err := db.ID(f.ID).UseBool().MustCols().Update(f); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GenerateThumbnail サムネイル画像を生成します

--- a/model/files.go
+++ b/model/files.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/labstack/gommon/log"
+	"github.com/traPtitech/traQ/utils"
 	"golang.org/x/image/bmp"
 	"golang.org/x/image/draw"
 	"golang.org/x/image/webp"
@@ -103,7 +104,7 @@ func (f *File) Create(src io.Reader) error {
 	go func() {
 		defer fileWriter.Close()
 		defer thumbWriter.Close()
-		io.Copy(io.MultiWriter(fileWriter, hash, thumbWriter), src) // 並列化してるけど、pipeじゃなくてbuffer使わないとreaderがブロックしてて意味無い疑惑
+		io.Copy(utils.MultiWriter(fileWriter, hash, thumbWriter), src) // 並列化してるけど、pipeじゃなくてbuffer使わないとpipeがブロックしてて意味無い疑惑
 	}()
 
 	// fileの保存
@@ -174,6 +175,16 @@ func (f *File) Open() (io.ReadCloser, error) {
 	}
 
 	return reader.OpenFileByID(f.ID)
+}
+
+// OpenThumbnail サムネイルファイルを開きます
+func (f *File) OpenThumbnail() (io.ReadCloser, error) {
+	reader, ok := fileManagers[f.Manager]
+	if !ok {
+		return nil, ErrFileUnknownManager
+	}
+
+	return reader.OpenFileByID(f.ID + "-thumb")
 }
 
 // GetRedirectURL リダイレクト先URLが存在する場合はそれを返します

--- a/model/files_test.go
+++ b/model/files_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"image"
 )
 
 func TestFile_TableName(t *testing.T) {
@@ -91,4 +92,14 @@ func TestGetMetaFileDataByID(t *testing.T) {
 	none, err := GetMetaFileDataByID("wrongID")
 	assert.NoError(err)
 	assert.Nil(none)
+}
+
+func TestCalcThumbnailSize(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.EqualValues(image.Pt(100, 100), calcThumbnailSize(image.Pt(100, 100)))
+	assert.EqualValues(image.Pt(360, 100), calcThumbnailSize(image.Pt(360, 100)))
+	assert.EqualValues(image.Pt(360, 50), calcThumbnailSize(image.Pt(720, 100)))
+	assert.EqualValues(image.Pt(50, 480), calcThumbnailSize(image.Pt(100, 960)))
+	assert.EqualValues(image.Pt(360, 480), calcThumbnailSize(image.Pt(720, 960)))
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -202,5 +202,14 @@ func InitCache() error {
 		channelPathMap.Store(uuid.FromStringOrNil(v.ID), path)
 	}
 
+	// サムネイル未作成なファイルのサムネイル作成を試みる
+	var files []*File
+	if err := db.Where("is_deleted = false AND has_thumbnail = false").Find(&files); err != nil {
+		return err
+	}
+	for _, f := range files {
+		f.RegenerateThumbnail()
+	}
+
 	return nil
 }

--- a/router/webhook.go
+++ b/router/webhook.go
@@ -411,11 +411,11 @@ func PostWebhookByGithub(c echo.Context) error {
 
 		switch i.Action {
 		case "opened":
-			message.Text = fmt.Sprintf("## Issue Opened\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.URL)
+			message.Text = fmt.Sprintf("## Issue Opened\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.HTMLURL)
 		case "closed":
-			message.Text = fmt.Sprintf("## Issue Closed\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.URL)
+			message.Text = fmt.Sprintf("## Issue Closed\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.HTMLURL)
 		case "reopened":
-			message.Text = fmt.Sprintf("## Issue Reopened\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.URL)
+			message.Text = fmt.Sprintf("## Issue Reopened\n[%s](%s) - [%s](%s)", i.Repository.FullName, i.Repository.HTMLURL, i.Issue.Title, i.Issue.HTMLURL)
 		case "assigned", "unassigned", "labeled", "unlabeled", "edited", "milestoned", "demilestoned":
 			// Unsupported
 		}
@@ -428,15 +428,15 @@ func PostWebhookByGithub(c echo.Context) error {
 
 		switch p.Action {
 		case "opened":
-			message.Text = fmt.Sprintf("## PullRequest Opened\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.URL)
+			message.Text = fmt.Sprintf("## PullRequest Opened\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.HTMLURL)
 		case "closed":
 			if p.PullRequest.Merged {
-				message.Text = fmt.Sprintf("## PullRequest Merged\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.URL)
+				message.Text = fmt.Sprintf("## PullRequest Merged\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.HTMLURL)
 			} else {
-				message.Text = fmt.Sprintf("## PullRequest Closed\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.URL)
+				message.Text = fmt.Sprintf("## PullRequest Closed\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.HTMLURL)
 			}
 		case "reopened":
-			message.Text = fmt.Sprintf("## PullRequest Reopened\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.URL)
+			message.Text = fmt.Sprintf("## PullRequest Reopened\n[%s](%s) - [%s](%s)", p.Repository.FullName, p.Repository.HTMLURL, p.PullRequest.Title, p.PullRequest.HTMLURL)
 		case "assigned", "unassigned", "labeled", "unlabeled", "edited", "review_requested", "review_request_removed":
 			// Unsupported
 		}
@@ -447,7 +447,7 @@ func PostWebhookByGithub(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 
-		message.Text = fmt.Sprintf("## %d Commit(s) Pushed by %s\nrefs: `%s`\n, [compare](%s)\n", len(p.Commits), p.Pusher.Name, p.Ref, p.Compare)
+		message.Text = fmt.Sprintf("## %d Commit(s) Pushed by %s\n[%s](%s) , refs: `%s`, [compare](%s)\n", len(p.Commits), p.Pusher.Name, p.Repository.FullName, p.Repository.HTMLURL, p.Ref, p.Compare)
 
 		for _, v := range p.Commits {
 			message.Text += fmt.Sprintf("+ [`%7s`](%s) - %s \n", v.ID, v.URL, v.Message)

--- a/utils/MultiWriter.go
+++ b/utils/MultiWriter.go
@@ -1,0 +1,30 @@
+package utils
+
+import "io"
+
+type multiWriter struct {
+	writers []io.Writer
+}
+
+func (t *multiWriter) Write(p []byte) (n int, err error) {
+	for _, w := range t.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			if err == io.ErrClosedPipe {
+				continue
+			}
+			return
+		}
+		if n != len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(p), nil
+}
+
+func MultiWriter(writers ...io.Writer) io.Writer {
+	w := make([]io.Writer, len(writers))
+	copy(w, writers)
+	return &multiWriter{w}
+}

--- a/utils/MultiWriter.go
+++ b/utils/MultiWriter.go
@@ -6,6 +6,7 @@ type multiWriter struct {
 	writers []io.Writer
 }
 
+// Write
 func (t *multiWriter) Write(p []byte) (n int, err error) {
 	for _, w := range t.writers {
 		n, err = w.Write(p)
@@ -23,6 +24,9 @@ func (t *multiWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+// MultiWriter creates a writer that duplicates its writes to all the
+// provided writers, similar to the Unix tee(1) command.
+// io.MultiWriterとの違いはwritersがio.ErrClosedPipeを返す場合は処理を続行するという点
 func MultiWriter(writers ...io.Writer) io.Writer {
 	w := make([]io.Writer, len(writers))
 	copy(w, writers)


### PR DESCRIPTION
+ タイトルにある拡張子のサムネイルの生成を実装した。
+ `/files/:fileID/meta`のレスポンスにサムネイル関連の情報を追加
+ ファイルのハッシュが全く計算されてなかった問題を修正
+ サーバー起動時に、サムネイル画像が生成されていないファイルのサムネイルの生成を試みる処理を追加