### PR TITLE
fix #261, #245. impl #92

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1032,20 +1032,20 @@ paths:
               properties:
                 tag:
                   type: string
-                  description: 追加するタグ
+                  description: 追加するタグ(30文字まで)
                   example: 山田太郎
       responses:
         "201":
           description: |+
-            正常に追加できました。追加後のリストを返します
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TagList"
+            正常に追加できました。
         "400":
           description: |+
             正常に追加できませんでした。
             パラメータの形式が不正です。
+        "403":
+          description: |+
+            正常に追加できませんでした。
+            権限がありません。
         "404":
           description: |+
             正常に追加できませんでした。
@@ -1055,17 +1055,16 @@ paths:
     parameters:
       - $ref: "#/components/parameters/userIdInPath"
       - $ref: "#/components/parameters/tagIdInPath"
-    put:
+    patch:
       tags:
         - userTag
-      description: タグのロック、アンロックを変更します
+      description: タグのロック、アンロックを変更します。
       requestBody:
         content:
           application/json:
             schema:
               type: object
               required:
-                - tag
                 - isLocked
               properties:
                 isLocked:
@@ -1073,17 +1072,17 @@ paths:
                   description: lockするときはtrue,解除するときはfalse
                   example: true
       responses:
-        "200":
+        "204":
           description: |+
-            正常に変更できました。変更後のタグのリストを返します
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TagList"
+            正常に変更できました。
         "400":
           description: |+
             正常に変更できませんでした。
             パラメータの形式が不正です。
+        "403":
+          description: |+
+            正常に変更できませんでした。
+            権限がありません。
         "404":
           description: |+
             正常に変更できませんでした。
@@ -1096,6 +1095,10 @@ paths:
         "204":
           description: |+
             正常に削除できました。
+        "403":
+          description: |+
+            正常に削除できませんでした。
+            権限がありません。
         "404":
           description: |+
             正常に削除できませんでした。
@@ -1122,14 +1125,15 @@ paths:
                     tag:
                       type: string
                     users:
-                      type: array
                       $ref: "#/components/schemas/UserList"
 
   /tags/{tagID}:
+    parameters:
+      - $ref: "#/components/parameters/tagIdInPath"
     get:
       tags:
         - userTag
-      description: タグIDで指定されたタグの情報を取得します。
+      description: 指定されたタグの情報を取得します。
       responses:
         "200":
           description: 正常に取得できました。
@@ -1143,12 +1147,39 @@ paths:
                     format: uuid
                   tag:
                     type: string
+                  editable:
+                    type: boolean
                   users:
-                    type: array
                     $ref: "#/components/schemas/UserList"
         "404":
           description: 正常に取得できませんでした。指定されたタグIDは存在しません
-
+    patch:
+      tags:
+        - userTag
+      description: 指定されたタグの情報を変更します。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                type:
+                  type: string
+                  description: タグの種類(30文字以内)
+                restrict:
+                  type: boolean
+                  description: 操作制限付きタグにするか
+                name:
+                  type: string
+                  description: タグ名(30文字以内)
+      responses:
+        "204":
+          description: 正常に変更できました。
+        "400":
+          description: 正常に変更できませんでした。リクエストが不正です。
+        "403":
+          description: 正常に変更できませんでした。権限がありません。
+        "404":
+          description: 正常に変更できませんでした。指定されたタグは存在しません。
 
   /stamps:
     get:
@@ -2152,6 +2183,8 @@ components:
           type: string
         isLocked:
           type: boolean
+        editable:
+          type: boolean
 
     TagList:
       type: array
@@ -2254,17 +2287,6 @@ components:
           type: integer
         thumbHeight:
           type: integer
-
-    UnreadList:
-      type: array
-      items:
-        type: object
-        properties:
-          channelId:
-            type: string
-            format: uuid
-          count:
-            type: integer
 
     Pin:
       type: object

--- a/main.go
+++ b/main.go
@@ -179,10 +179,11 @@ func main() {
 	// Tag: userTag
 	api.GET("/users/:userID/tags", router.GetUserTags, requires(permission.GetTag))
 	api.POST("/users/:userID/tags", router.PostUserTag, requires(permission.AddTag))
-	api.PUT("/users/:userID/tags/:tagID", router.PutUserTag, requires(permission.ChangeTagLockState))
+	api.PATCH("/users/:userID/tags/:tagID", router.PatchUserTag, requires(permission.ChangeTagLockState))
 	api.DELETE("/users/:userID/tags/:tagID", router.DeleteUserTag, requires(permission.RemoveTag))
 	api.GET("/tags", router.GetAllTags, requires(permission.GetTag))
 	api.GET("/tags/:tagID", router.GetUsersByTagID, requires(permission.GetTag))
+	api.PATCH("/tags/:tagID", router.PatchTag, requires(permission.EditTag))
 
 	// Tag: heartbeat
 	api.GET("/heartbeat", router.GetHeartbeat, requires(permission.GetHeartbeat))

--- a/model/channels.go
+++ b/model/channels.go
@@ -79,7 +79,7 @@ func (channel *Channel) Update() error {
 		return err
 	}
 
-	_, err := db.ID(channel.ID).UseBool().MustCols().Update(channel)
+	_, err := db.ID(channel.ID).UseBool().MustCols("topic").Update(channel)
 	if err != nil {
 		return err
 	}

--- a/model/channels_test.go
+++ b/model/channels_test.go
@@ -65,9 +65,16 @@ func TestChannel_Update(t *testing.T) {
 
 	channel.UpdaterID = user.ID
 	channel.Name = "Channel-updated"
+	channel.Topic = "aaaa"
 	channel.ParentID = parentChannel.ID
-
 	assert.NoError(channel.Update())
+
+	channel.Topic = ""
+	assert.NoError(channel.Update())
+	var topic string
+	if ok, err := db.Table(channel).ID(channel.ID).Get(&topic); assert.True(ok) && assert.NoError(err) {
+		assert.Empty(topic)
+	}
 }
 
 func TestChannel_Parent(t *testing.T) {

--- a/model/channels_test.go
+++ b/model/channels_test.go
@@ -72,7 +72,7 @@ func TestChannel_Update(t *testing.T) {
 	channel.Topic = ""
 	assert.NoError(channel.Update())
 	var topic string
-	if ok, err := db.Table(channel).ID(channel.ID).Get(&topic); assert.True(ok) && assert.NoError(err) {
+	if ok, err := db.Table(channel).ID(channel.ID).Cols("topic").Get(&topic); assert.True(ok) && assert.NoError(err) {
 		assert.Empty(topic)
 	}
 }

--- a/model/tags.go
+++ b/model/tags.go
@@ -4,8 +4,10 @@ import "github.com/traPtitech/traQ/utils/validator"
 
 // Tag tag_idの管理をする構造体
 type Tag struct {
-	ID   string `xorm:"char(36) pk"                 validate:"uuid,required"`
-	Name string `xorm:"varchar(30) not null unique" validate:"required,max=30"`
+	ID         string `xorm:"char(36) pk"                 validate:"uuid,required"`
+	Name       string `xorm:"varchar(30) not null unique" validate:"required,max=30"`
+	Restricted bool   `xorm:"bool not null"`
+	Type       string `xorm:"varchar(30) not null"        validate:"max=30"`
 }
 
 // TableName DBの名前を指定
@@ -29,6 +31,15 @@ func (t *Tag) Create() (err error) {
 	return
 }
 
+// Update DBにタグを更新
+func (t *Tag) Update() (err error) {
+	if err := t.Validate(); err != nil {
+		return err
+	}
+	_, err = db.MustCols("type").UseBool().Update(t)
+	return
+}
+
 // Exists DBにその名前のタグが存在するかを確認
 func (t *Tag) Exists() (bool, error) {
 	if t.Name == "" {
@@ -41,6 +52,21 @@ func (t *Tag) Exists() (bool, error) {
 func GetTagByID(ID string) (*Tag, error) {
 	tag := &Tag{
 		ID: ID,
+	}
+
+	has, err := db.Get(tag)
+	if err != nil {
+		return nil, err
+	} else if !has {
+		return nil, ErrNotFound
+	}
+	return tag, nil
+}
+
+// GetTagByName 引数のタグのTag構造体を返す
+func GetTagByName(name string) (*Tag, error) {
+	tag := &Tag{
+		Name: name,
 	}
 
 	has, err := db.Get(tag)

--- a/rbac/permission/list.go
+++ b/rbac/permission/list.go
@@ -46,10 +46,12 @@ var list = map[string]gorbac.Permission{
 	GetUnread.ID():    GetUnread,
 	DeleteUnread.ID(): DeleteUnread,
 
-	GetTag.ID():             GetTag,
-	AddTag.ID():             AddTag,
-	RemoveTag.ID():          RemoveTag,
-	ChangeTagLockState.ID(): ChangeTagLockState,
+	GetTag.ID():                  GetTag,
+	AddTag.ID():                  AddTag,
+	RemoveTag.ID():               RemoveTag,
+	ChangeTagLockState.ID():      ChangeTagLockState,
+	OperateForRestrictedTag.ID(): OperateForRestrictedTag,
+	EditTag.ID():                 EditTag,
 
 	GetStamp.ID():                 GetStamp,
 	CreateStamp.ID():              CreateStamp,

--- a/rbac/permission/userTag.go
+++ b/rbac/permission/userTag.go
@@ -11,4 +11,8 @@ var (
 	RemoveTag = gorbac.NewStdPermission("remove_tag")
 	// ChangeTagLockState : ユーザータグロック状態変更権限
 	ChangeTagLockState = gorbac.NewStdPermission("change_tag_lock_state")
+	// OperateForRestrictedTag : 制限付きタグの操作権限
+	OperateForRestrictedTag = gorbac.NewStdPermission("operate_for_restricted_tag")
+	// EditTag : タグ情報編集権限
+	EditTag = gorbac.NewStdPermission("edit_tag")
 )

--- a/rbac/role/roles.go
+++ b/rbac/role/roles.go
@@ -134,6 +134,9 @@ func SetRole(rbac *rbac.RBAC) {
 
 			permission.ChangeChannelVisibility,
 
+			permission.OperateForRestrictedTag,
+			permission.EditTag,
+
 			permission.EditStampName,
 			permission.EditStampCreatedByOthers,
 			permission.DeleteStamp,

--- a/router/messages.go
+++ b/router/messages.go
@@ -58,7 +58,7 @@ func GetMessagesByChannelID(c echo.Context) error {
 // PostMessage POST /channels/{channelID}/messages のハンドラ
 func PostMessage(c echo.Context) error {
 	// 10KB制限
-	if c.Request().ContentLength > 10*1024*1024 {
+	if c.Request().ContentLength > 10*1024 {
 		return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "a request must be smaller than 10KB")
 	}
 

--- a/router/tags.go
+++ b/router/tags.go
@@ -1,10 +1,12 @@
 package router
 
 import (
-	"net/http"
-
 	"github.com/traPtitech/traQ/notification"
 	"github.com/traPtitech/traQ/notification/events"
+	"github.com/traPtitech/traQ/rbac"
+	"github.com/traPtitech/traQ/rbac/permission"
+	"gopkg.in/go-playground/validator.v9"
+	"net/http"
 
 	"github.com/labstack/echo"
 	"github.com/traPtitech/traQ/model"
@@ -15,15 +17,15 @@ type TagForResponse struct {
 	ID       string `json:"tagId"`
 	Tag      string `json:"tag"`
 	IsLocked bool   `json:"isLocked"`
+	Editable bool   `json:"editable"`
 }
-
-// FIXME: 名前が良くない気がする
 
 // TagListForResponse クライアントに返す形のタグリスト構造体
 type TagListForResponse struct {
-	ID    string             `json:"tagId"`
-	Tag   string             `json:"tag"`
-	Users []*UserForResponse `json:"users"`
+	ID       string             `json:"tagId"`
+	Tag      string             `json:"tag"`
+	Editable bool               `json:"editable"`
+	Users    []*UserForResponse `json:"users"`
 }
 
 // GetUserTags GET /users/{userID}/tags のハンドラ
@@ -40,60 +42,123 @@ func GetUserTags(c echo.Context) error {
 func PostUserTag(c echo.Context) error {
 	id := c.Param("userID")
 
-	body := struct {
-		Tag string `json:"tag"`
+	// リクエスト検証
+	req := struct {
+		Tag string `json:"tag" validate:"required,max=30"`
 	}{}
-	if err := c.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid format")
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+	if err := c.Validate(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
-	ut := &model.UsersTag{
-		UserID: id,
-	}
-	if err := ut.Create(body.Tag); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "Failed to create tag")
-	}
-
-	res, err := getUserTags(id, c)
+	// ユーザー確認
+	_, err := validateUserID(id)
 	if err != nil {
 		return err
 	}
 
+	// タグの確認
+	t, err := model.GetTagByName(req.Tag)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			// 存在しないので新規作成
+			t = &model.Tag{
+				Name: req.Tag,
+			}
+			if err := t.Create(); err != nil {
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	// 操作制約付きタグ
+	if t.Restricted {
+		reqUser := c.Get("user").(*model.User)
+		r := c.Get("rbac").(*rbac.RBAC)
+
+		if !r.IsGranted(reqUser.GetUID(), reqUser.Role, permission.OperateForRestrictedTag) {
+			return echo.NewHTTPError(http.StatusForbidden)
+		}
+	}
+
+	// ユーザーにタグを付与
+	ut := &model.UsersTag{
+		UserID: id,
+	}
+	if err := ut.Create(req.Tag); err != nil {
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
 	go notification.Send(events.UserTagsUpdated, events.UserEvent{ID: id})
-	return c.JSON(http.StatusCreated, res)
+	return c.NoContent(http.StatusCreated)
 }
 
-// PutUserTag PUT /users/{userID}/tags/{tagID} のハンドラ
-func PutUserTag(c echo.Context) error {
+// PatchUserTag PATCH /users/{userID}/tags/{tagID} のハンドラ
+func PatchUserTag(c echo.Context) error {
+	reqUser := c.Get("user").(*model.User)
 	userID := c.Param("userID")
 	tagID := c.Param("tagID")
 
+	// リクエスト検証
 	body := struct {
 		IsLocked bool `json:"isLocked"`
 	}{}
 	if err := c.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid format")
+		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
-	ut, err := validateTagID(tagID, userID, c)
+	// タグがつけられているかを見る
+	ut, err := model.GetTag(userID, tagID)
 	if err != nil {
-		return err
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
 	}
 
+	// 他人のロックは変更不可
+	if reqUser.ID != userID {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	// タグ情報取得
+	t, err := model.GetTagByID(tagID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound: // ここには来ないはず
+			c.Logger().Debug("UNEXPECTED CODE FLOW")
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	// 操作制約付きタグは無効
+	if t.Restricted {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
+	// 更新
 	ut.IsLocked = body.IsLocked
-
 	if err := ut.Update(); err != nil {
-		c.Logger().Error("failed to update usersTag: %v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update tag")
-	}
-
-	res, err := getUserTags(userID, c)
-	if err != nil {
-		return err
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
 	go notification.Send(events.UserTagsUpdated, events.UserEvent{ID: userID})
-	return c.JSON(http.StatusOK, res)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // DeleteUserTag DELETE /users/{userID}/tags/{tagID} のハンドラ
@@ -101,15 +166,45 @@ func DeleteUserTag(c echo.Context) error {
 	userID := c.Param("userID")
 	tagID := c.Param("tagID")
 
-	ut, err := validateTagID(tagID, userID, c)
+	// タグがつけられているかを見る
+	ut, err := model.GetTag(userID, tagID)
 	if err != nil {
-		return err
+		switch err {
+		case model.ErrNotFound: //既にない
+			return c.NoContent(http.StatusNoContent)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
 	}
 
-	// TODO: 既に削除されている場合にもエラーが出るか確認し、そのときは204を返すようにする
+	// タグ情報取得
+	t, err := model.GetTagByID(tagID)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound: // ここには来ないはず
+			c.Logger().Debug("UNEXPECTED CODE FLOW")
+			return c.NoContent(http.StatusNoContent)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	// 操作制約付きタグ
+	if t.Restricted {
+		reqUser := c.Get("user").(*model.User)
+		r := c.Get("rbac").(*rbac.RBAC)
+
+		if !r.IsGranted(reqUser.GetUID(), reqUser.Role, permission.OperateForRestrictedTag) {
+			return echo.NewHTTPError(http.StatusForbidden)
+		}
+	}
+
+	// 削除
 	if err := ut.Delete(); err != nil {
-		c.Logger().Error("failed to delete usersTag: %v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete tag")
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
 	go notification.Send(events.UserTagsUpdated, events.UserEvent{ID: userID})
@@ -120,7 +215,7 @@ func DeleteUserTag(c echo.Context) error {
 func GetAllTags(c echo.Context) error {
 	tags, err := model.GetAllTags()
 	if err != nil {
-		c.Echo().Logger.Errorf("failed to get all tags: %v", err)
+		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
@@ -134,9 +229,10 @@ func GetAllTags(c echo.Context) error {
 		}
 
 		res[i] = &TagListForResponse{
-			ID:    v.ID,
-			Tag:   v.Name,
-			Users: users,
+			ID:       v.ID,
+			Tag:      v.Name,
+			Editable: !v.Restricted,
+			Users:    users,
 		}
 	}
 
@@ -164,12 +260,87 @@ func GetUsersByTagID(c echo.Context) error {
 	}
 
 	res := &TagListForResponse{
-		ID:    t.ID,
-		Tag:   t.Name,
-		Users: users,
+		ID:       t.ID,
+		Tag:      t.Name,
+		Editable: !t.Restricted,
+		Users:    users,
 	}
 
 	return c.JSON(http.StatusOK, res)
+}
+
+// PatchTag PATCH /tags/{tagID} のハンドラ
+func PatchTag(c echo.Context) error {
+	id := c.Param("tagID")
+
+	// リクエスト検証
+	req := struct {
+		Type     *string `json:"type"`
+		Restrict *bool   `json:"restrict"`
+		Name     *string `json:"name"`
+	}{}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+
+	// タグ存在確認
+	t, err := model.GetTagByID(id)
+	if err != nil {
+		switch err {
+		case model.ErrNotFound:
+			return echo.NewHTTPError(http.StatusNotFound)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	// タグ名変更
+	if req.Name != nil {
+		if _, err := model.GetTagByName(*req.Name); err != nil {
+			switch err {
+			case model.ErrNotFound:
+				//OK
+			default:
+				c.Logger().Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+		} else {
+			// 既に存在してかぶる
+			return echo.NewHTTPError(http.StatusBadRequest, "name's tag has already existed.")
+		}
+		t.Name = *req.Name
+	}
+
+	// 制約変更
+	if req.Restrict != nil {
+		reqUser := c.Get("user").(*model.User)
+		r := c.Get("rbac").(*rbac.RBAC)
+
+		if !r.IsGranted(reqUser.GetUID(), reqUser.Role, permission.OperateForRestrictedTag) {
+			return echo.NewHTTPError(http.StatusForbidden)
+		}
+
+		t.Restricted = *req.Restrict
+	}
+
+	// タグタイプ変更
+	if req.Type != nil {
+		t.Type = *req.Type
+	}
+
+	// 更新
+	if err := t.Update(); err != nil {
+		switch err.(type) {
+		case *validator.ValidationErrors:
+			return echo.NewHTTPError(http.StatusBadRequest, err)
+		default:
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }
 
 func getUserTags(ID string, c echo.Context) ([]*TagForResponse, error) {
@@ -224,31 +395,7 @@ func formatTag(ut *model.UsersTag) (*TagForResponse, error) {
 	return &TagForResponse{
 		ID:       tag.ID,
 		Tag:      tag.Name,
-		IsLocked: ut.IsLocked,
+		IsLocked: ut.IsLocked || tag.Restricted,
+		Editable: !tag.Restricted,
 	}, nil
-}
-
-func validateTagID(tagID, userID string, c echo.Context) (*model.UsersTag, error) {
-	if _, err := model.GetTagByID(tagID); err != nil {
-		switch err {
-		case model.ErrNotFound:
-			return nil, echo.NewHTTPError(http.StatusNotFound, "The specified tag does not exist")
-		default:
-			c.Logger().Errorf("failed to get tag: %v", err)
-			return nil, echo.NewHTTPError(http.StatusInternalServerError, "An error occurred while checking existence of tag")
-		}
-	}
-
-	userTag, err := model.GetTag(userID, tagID)
-	if err != nil {
-		switch err {
-		case model.ErrNotFound:
-			return nil, echo.NewHTTPError(http.StatusNotFound, "The specified tag does not exist")
-		default:
-			c.Logger().Errorf("failed to get tag: %v", err)
-			return nil, echo.NewHTTPError(http.StatusInternalServerError, "An error occurred while checking existence of tag")
-		}
-	}
-
-	return userTag, nil
 }

--- a/router/tags_test.go
+++ b/router/tags_test.go
@@ -29,13 +29,7 @@ func TestPostUserTags(t *testing.T) {
 	c.SetParamValues(testUser.ID)
 	requestWithContext(t, mw(PostUserTag), c)
 
-	if assert.EqualValues(http.StatusCreated, rec.Code) {
-		var responseBody []*TagForResponse
-		if assert.NoError(json.Unmarshal(rec.Body.Bytes(), &responseBody)) {
-			assert.Equal(tagText, responseBody[0].Tag)
-			assert.NotEqual("", responseBody[0].ID)
-		}
-	}
+	assert.EqualValues(http.StatusCreated, rec.Code)
 }
 
 func TestGetUserTags(t *testing.T) {
@@ -80,12 +74,7 @@ func TestPutUserTags(t *testing.T) {
 	c.SetParamValues(testUser.ID, tag.TagID)
 	requestWithContext(t, mw(PatchUserTag), c)
 
-	if assert.EqualValues(http.StatusOK, rec.Code) {
-		var responseBody []*TagForResponse
-		if assert.NoError(json.Unmarshal(rec.Body.Bytes(), &responseBody)) {
-			assert.True(responseBody[0].IsLocked)
-		}
-	}
+	assert.EqualValues(http.StatusNoContent, rec.Code)
 }
 
 func TestDeleteUserTags(t *testing.T) {

--- a/router/tags_test.go
+++ b/router/tags_test.go
@@ -78,7 +78,7 @@ func TestPutUserTags(t *testing.T) {
 	c.SetPath("/users/:userID/tags/:tagID")
 	c.SetParamNames("userID", "tagID")
 	c.SetParamValues(testUser.ID, tag.TagID)
-	requestWithContext(t, mw(PutUserTag), c)
+	requestWithContext(t, mw(PatchUserTag), c)
 
 	if assert.EqualValues(http.StatusOK, rec.Code) {
 		var responseBody []*TagForResponse


### PR DESCRIPTION
+ 管理者しか変更できないタグを実装。
+ `POST /users/{userID}/tags`のレスポンスの結果でタグのリストを返さないようにした。
+ `PUT /users/{userID}/tags/{tagID}`を PATCHに変更
+ タグのレスポンスに、変更・追加可能なタグかどうかを表す`editable`を追加

学年タグはDBに学年タグを全部突っ込んで対処することにしました。