### PR TITLE
ciのmysqlのバージョンを5.7.22で固定

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.10.0
-      - image: circleci/mysql:latest-ram
+      - image: circleci/mysql:5.7.22-ram
         environment:
           - MYSQL_DATABASE=traq
           - MYSQL_ROOT_PASSWORD=password


### PR DESCRIPTION
go-sql-driver/mysqlがバージョン8をサポートしていないため