### PR TITLE
fix: issue/316

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func main() {
 	api.GET("/notification", router.GetNotificationStream, requires(permission.ConnectNotificationStream))
 	api.POST("/notification/device", router.PostDeviceToken, requires(permission.RegisterDevice))
 	api.GET("/channels/:ID/notification", router.GetNotification(router.GetNotificationChannels, router.GetNotificationStatus), requires(permission.GetNotificationStatus))
-	api.PUT("/channels/:channelID/notification", router.PutNotificationStatus, requires(permission.ChangeNotificationStatus))
+	api.PUT("/channels/:ID/notification", router.PutNotificationStatus, requires(permission.ChangeNotificationStatus))
 
 	// Tag: file
 	api.POST("/files", router.PostFile, requires(permission.UploadFile))

--- a/router/notification.go
+++ b/router/notification.go
@@ -60,7 +60,7 @@ func GetNotificationStatus(c echo.Context) error {
 // PutNotificationStatus PUT /channels/:channelId/notifications のハンドラ
 func PutNotificationStatus(c echo.Context) error {
 	userID := c.Get("user").(*model.User).ID
-	channelID := c.Param("channelID")
+	channelID := c.Param("ID")
 
 	ch, err := validateChannelID(channelID, userID)
 	if err != nil {

--- a/router/notification_test.go
+++ b/router/notification_test.go
@@ -27,8 +27,8 @@ func TestPutNotificationStatus(t *testing.T) {
 
 	req := httptest.NewRequest("PUT", "http://test", bytes.NewReader(body))
 	c, rec := getContext(e, t, cookie, req)
-	c.SetPath("/channels/:channelID/notification")
-	c.SetParamNames("channelID")
+	c.SetPath("/channels/:ID/notification")
+	c.SetParamNames("ID")
 	c.SetParamValues(channel.ID)
 	requestWithContext(t, mw(PutNotificationStatus), c)
 

--- a/router/notification_test.go
+++ b/router/notification_test.go
@@ -1,14 +1,45 @@
 package router
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/traPtitech/traQ/model"
 )
 
-//TODO TestPutNotificationStatus
+func TestPutNotificationStatus(t *testing.T) {
+	e, cookie, mw, assert, require := beforeTest(t)
+
+	channel := mustMakeChannel(t, testUser.ID, "subscribing", true)
+	userID := mustCreateUser(t, "poyo").ID
+
+	post := struct {
+		On  []string
+		Off []string
+	}{On: []string{userID}, Off: nil}
+
+	body, err := json.Marshal(post)
+	require.NoError(err)
+
+	req := httptest.NewRequest("PUT", "http://test", bytes.NewReader(body))
+	c, rec := getContext(e, t, cookie, req)
+	c.SetPath("/channels/:channelID/notification")
+	c.SetParamNames("channelID")
+	c.SetParamValues(channel.ID)
+	requestWithContext(t, mw(PutNotificationStatus), c)
+
+	if assert.EqualValues(http.StatusOK, rec.Code, rec.Body.String()) {
+		users, err := model.GetSubscribingUser(uuid.FromStringOrNil(channel.ID))
+		require.NoError(err)
+		assert.EqualValues(users, []uuid.UUID{uuid.FromStringOrNil(userID)})
+	}
+
+}
+
 //TODO TestPostDeviceToken
 //TODO TestDeleteDeviceToken
 //TODO TestGetNotificationStream


### PR DESCRIPTION
echoではルーティングの際に
1.まずpathの解析を行う
2.該当するもののparam名にデータを入れる
3.routingする
という流れで行われているのですが、そのためchannelIDに入るべき変数がIDに入っていて死んでいました