### PR TITLE
Bot eventのpayloadにUserの名前と表示名を載せる

### DIFF
--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -30,20 +30,20 @@ func messageCreatedHandler(p *Processor, _ string, fields hub.Fields) {
 
 	ch, err := p.repo.GetChannel(m.ChannelID)
 	if err != nil {
-		p.logger.Error("failed to GetChannel", zap.Error(err))
+		p.logger.Error("failed to GetChannel", zap.Error(err), zap.Stringer("id", m.ChannelID))
 		return
 	}
 
 	user, err := p.repo.GetUser(m.UserID)
 	if err != nil {
-		p.logger.Error("failed to GetUser", zap.Error(err))
+		p.logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("id", m.UserID))
 		return
 	}
 
 	if ch.IsDMChannel() {
 		ids, err := p.repo.GetPrivateChannelMemberIDs(ch.ID)
 		if err != nil {
-			p.logger.Error("failed to GetPrivateChannelMemberIDs", zap.Error(err))
+			p.logger.Error("failed to GetPrivateChannelMemberIDs", zap.Error(err), zap.Stringer("id", ch.ID))
 			return
 		}
 
@@ -58,7 +58,7 @@ func messageCreatedHandler(p *Processor, _ string, fields hub.Fields) {
 		bot, err := p.repo.GetBotByBotUserID(id)
 		if err != nil {
 			if err != repository.ErrNotFound {
-				p.logger.Error("failed to GetBotByBotUserID", zap.Error(err))
+				p.logger.Error("failed to GetBotByBotUserID", zap.Error(err), zap.Stringer("id", id))
 			}
 			return
 		}
@@ -75,7 +75,7 @@ func messageCreatedHandler(p *Processor, _ string, fields hub.Fields) {
 	} else {
 		bots, err := p.repo.GetBotsByChannel(m.ChannelID)
 		if err != nil {
-			p.logger.Error("failed to GetBotsByChannel", zap.Error(err))
+			p.logger.Error("failed to GetBotsByChannel", zap.Error(err), zap.Stringer("id", m.ChannelID))
 			return
 		}
 		bots = filterBots(p, bots, stateFilter(model.BotActive), eventFilter(MessageCreated), botUserIDNotEqualsFilter(m.UserID))
@@ -118,7 +118,7 @@ func botJoinedAndLeftHandler(p *Processor, ev string, fields hub.Fields) {
 	}
 	user, err := p.repo.GetUser(ch.CreatorID)
 	if err != nil {
-		p.logger.Error("failed to GetUser", zap.Error(err))
+		p.logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("id", ch.CreatorID))
 		return
 	}
 
@@ -190,7 +190,7 @@ func channelCreatedHandler(p *Processor, _ string, fields hub.Fields) {
 		}
 		user, err := p.repo.GetUser(ch.CreatorID)
 		if err != nil {
-			p.logger.Error("failed to GetUser", zap.Error(err))
+			p.logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("id", ch.CreatorID))
 			return
 		}
 

--- a/bot/payload.go
+++ b/bot/payload.go
@@ -1,10 +1,11 @@
 package bot
 
 import (
+	"time"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/utils/message"
-	"time"
 )
 
 type basePayload struct {
@@ -19,7 +20,7 @@ func makeBasePayload() basePayload {
 
 type messagePayload struct {
 	ID        uuid.UUID               `json:"id"`
-	UserID    uuid.UUID               `json:"userId"`
+	User      userPayload             `json:"user"`
 	ChannelID uuid.UUID               `json:"channelId"`
 	Text      string                  `json:"text"`
 	PlainText string                  `json:"plainText"`
@@ -28,10 +29,10 @@ type messagePayload struct {
 	UpdatedAt time.Time               `json:"updatedAt"`
 }
 
-func makeMessagePayload(message *model.Message, embedded []*message.EmbeddedInfo, plain string) messagePayload {
+func makeMessagePayload(message *model.Message, user *model.User, embedded []*message.EmbeddedInfo, plain string) messagePayload {
 	return messagePayload{
 		ID:        message.ID,
-		UserID:    message.UserID,
+		User:      makeUserPayload(user),
 		ChannelID: message.ChannelID,
 		Text:      message.Text,
 		PlainText: plain,
@@ -42,13 +43,25 @@ func makeMessagePayload(message *model.Message, embedded []*message.EmbeddedInfo
 }
 
 type channelPayload struct {
-	ID        uuid.UUID `json:"id"`
-	Name      string    `json:"name"`
-	Path      string    `json:"path"`
-	ParentID  uuid.UUID `json:"parentId"`
-	CreatorID uuid.UUID `json:"creatorId"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID        uuid.UUID   `json:"id"`
+	Name      string      `json:"name"`
+	Path      string      `json:"path"`
+	ParentID  uuid.UUID   `json:"parentId"`
+	Creator   userPayload `json:"creator"`
+	CreatedAt time.Time   `json:"createdAt"`
+	UpdatedAt time.Time   `json:"updatedAt"`
+}
+
+func makeChannelPayload(ch *model.Channel, path string, user *model.User) channelPayload {
+	return channelPayload{
+		ID:        ch.ID,
+		Name:      ch.Name,
+		Path:      "#" + path,
+		ParentID:  ch.ParentID,
+		Creator:   makeUserPayload(user),
+		CreatedAt: ch.CreatedAt,
+		UpdatedAt: ch.UpdatedAt,
+	}
 }
 
 type userPayload struct {
@@ -76,7 +89,6 @@ type messageCreatedPayload struct {
 
 type directMessageCreatedPayload struct {
 	basePayload
-	UserID  uuid.UUID      `json:"userId"`
 	Message messagePayload `json:"message"`
 }
 
@@ -86,7 +98,7 @@ type pingPayload struct {
 
 type joinAndLeftPayload struct {
 	basePayload
-	ChannelID uuid.UUID `json:"channelId"`
+	Channel channelPayload `json:"channel"`
 }
 
 type channelCreatedPayload struct {


### PR DESCRIPTION
fix #567 

messagePayload, channelPayloadに、userPayloadを`json:"user"`として載せました
既にuserIDがあった所はuserPayloadで書き換えました

joinAndLeftPayloadもchannelIDからchannelPayloadに変えました