### PR TITLE
remove deleted message from pin

### DIFF
--- a/repository/message_impl.go
+++ b/repository/message_impl.go
@@ -144,6 +144,9 @@ func (repo *GormRepository) DeleteMessage(messageID uuid.UUID) error {
 		if err := tx.Where(&model.Unread{MessageID: messageID}).Delete(model.Unread{}).Error; err != nil {
 			return err
 		}
+		if err := tx.Where(&model.Pin{ID:id}).Delete(model.Pin{}).Error;err != nil {
+			return err
+		}
 		ok = true
 		return nil
 	})

--- a/repository/message_impl.go
+++ b/repository/message_impl.go
@@ -3,13 +3,14 @@ package repository
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/gofrs/uuid"
 	"github.com/jinzhu/gorm"
 	"github.com/leandro-lugaresi/hub"
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/utils/message"
-	"strings"
 )
 
 func (repo *GormRepository) CreateMessage(userID, channelID uuid.UUID, text string) (*model.Message, error) {
@@ -144,7 +145,7 @@ func (repo *GormRepository) DeleteMessage(messageID uuid.UUID) error {
 		if err := tx.Where(&model.Unread{MessageID: messageID}).Delete(model.Unread{}).Error; err != nil {
 			return err
 		}
-		if err := tx.Where(&model.Pin{ID:id}).Delete(model.Pin{}).Error;err != nil {
+		if err := tx.Where(&model.Pin{MessageID: messageID}).Delete(model.Pin{}).Error; err != nil {
 			return err
 		}
 		ok = true


### PR DESCRIPTION
fix #583 
message_impl.goのDeleteMessage関数で削除されるメッセージをpinから外すようにしました。