### PR TITLE
fix #705

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -236,7 +236,9 @@ func Gzip() echo.MiddlewareFunc {
 			gzh(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				c.SetRequest(r)
 				c.Response().Writer = w
-				err = next(c)
+				if err := next(c); err != nil {
+					c.Error(err)
+				}
 			})).ServeHTTP(c.Response().Writer, c.Request())
 			return
 		}


### PR DESCRIPTION
こんな感じだとは思うんですが、`c.Response().Header().Get(echo.HeaderContentType)`が常に空でうまくいかないです…

(trueとfalseが完全に逆になってるのはプルリク直前に気づいたので後で直します)