### PR TITLE
メンション通知が凍結済みユーザーに行かないように

### DIFF
--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -162,6 +162,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 			user, err := ns.repo.GetUser(uid, false)
 			if err != nil {
 				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
+				continue
 			}
 			// 凍結ユーザーの除外
 			if !user.IsActive() {

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -159,8 +159,14 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 
 		// ユーザーグループ・メンションユーザー取得
 		for _, uid := range parsed.Mentions {
-			// TODO 凍結ユーザーの除外
-			// MEMO 凍結ユーザーはクライアント側で置換されないのでこのままでも問題はない
+			user, err := ns.repo.GetUser(uid, false)
+			if err != nil {
+				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
+			}
+			// 凍結ユーザーの除外
+			if !user.IsActive() {
+				continue
+			}
 			notifiedUsers.Add(uid)
 			markedUsers.Add(uid)
 			noticeable.Add(uid)


### PR DESCRIPTION
メンションで凍結済みユーザーには通知が行かないようフィルタしました
一つ一つクエリを飛ばしてチェックしていますが、とりあえずいいのかな...ってなっちゃいました
通知のテストはちょっとわからなかったです
fix #947 