### PR TITLE
キャッシュされたメッセージにnanosecondが含まれていた

### DIFF
--- a/repository/repository_impl.go
+++ b/repository/repository_impl.go
@@ -8,7 +8,15 @@ import (
 	"github.com/traPtitech/traQ/service/rbac/role"
 	"github.com/traPtitech/traQ/utils/gormutil"
 	"go.uber.org/zap"
+	"time"
 )
+
+func init() {
+	// DBにはnanosecondを保存できないため、microsecondまでprecisionを予め落とす
+	gorm.NowFunc = func() time.Time {
+		return time.Now().Truncate(time.Microsecond)
+	}
+}
 
 // GormRepository リポジトリ実装
 type GormRepository struct {


### PR DESCRIPTION
メッセージを作る/編集などするときにgormによって自動でつけられる`CreatedAt`には、DB挿入前はnanosecond精度が入っている
service/message.manager#cacheによりキャッシュされたメッセージのCreatedAtにnanosecond精度が入っていたので、APIにもそのまま意図せず返されていた。

とりあえずgorm.NowFuncに直に書き込んで、nanosecondは帰ってこなくなりました。

参考
http://gorm.io/docs/conventions.html#Timestamp-Tracking
https://godoc.org/github.com/jinzhu/gorm#pkg-variables
https://godoc.org/github.com/jinzhu/gorm#DB.SetNowFuncOverride