### PR TITLE
/logout?all=trueの修正

### DIFF
--- a/router/session/gorm.go
+++ b/router/session/gorm.go
@@ -284,7 +284,7 @@ func (ss *sessionStore) RevokeSessionsByUserID(userID uuid.UUID) error {
 	if err := ss.db.Find(&rs, &model.SessionRecord{UserID: userID}).Error; err != nil {
 		return err
 	}
-	if err := ss.db.Delete(&model.SessionRecord{UserID: userID}).Error; err != nil {
+	if err := ss.db.Delete(&model.SessionRecord{}, "user_id = ?", userID).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`missing WHERE clause while deleting`で500返ってきてたのでuserIdの指定をWHERE句に移しました。
直接SQL書いてるところが他になかったのでとりあえず`.Where()`じゃない方で書きました。