### PR TITLE
親チャンネル変更時の深さ判定を修正

### DIFF
--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -194,7 +194,8 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 						return ErrTooDeepChannel // ループ検出
 					}
 				}
-				if len(ascs)+1+m.T.getChannelDepth(ch.ID) > m.MaxChannelDepth {
+				// 親チャンネル + 自分を含めた子チャンネルの深さ
+				if len(ascs)+m.T.getChannelDepth(ch.ID) > m.MaxChannelDepth {
 					return ErrTooDeepChannel
 				}
 			}

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/traPtitech/traQ/utils/random"
 	"github.com/traPtitech/traQ/utils/set"
 	"go.uber.org/zap"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -476,8 +478,8 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 				},
 			},
 		}
-		for i, cc := range cases {
-			c := cc
+		for i, c := range cases {
+			c := c
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				t.Parallel()
 				ctrl := gomock.NewController(t)
@@ -555,6 +557,12 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 				if assert.NoError(t, err) {
 					v, err := cm.GetChannel(c.ID)
 					require.NoError(t, err)
+					sort.Slice(v.ChildrenID, func(i, j int) bool {
+						return strings.Compare(v.ChildrenID[i].String(), v.ChildrenID[j].String()) > 0
+					})
+					sort.Slice(new.ChildrenID, func(i, j int) bool {
+						return strings.Compare(new.ChildrenID[i].String(), new.ChildrenID[j].String()) > 0
+					})
 					assert.EqualValues(t, &new, v)
 				}
 			})

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -458,6 +458,13 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 				},
 			},
 			{
+				ID: cABCE,
+				Args: repository.UpdateChannelArgs{
+					UpdaterID: uuid.Must(uuid.NewV4()),
+					Parent:    optional.UUIDFrom(cABCD),
+				},
+			},
+			{
 				ID: cEFGHI,
 				Args: repository.UpdateChannelArgs{
 					UpdaterID:          uuid.Must(uuid.NewV4()),
@@ -469,7 +476,8 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 				},
 			},
 		}
-		for i, c := range cases {
+		for i, cc := range cases {
+			c := cc
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				t.Parallel()
 				ctrl := gomock.NewController(t)


### PR DESCRIPTION
修正してテストを一つ追加しました。
ついでに`TestManagerImpl_UpdateChannel/success`のparallelなテストが、ループ中の変数を使っていたせいで上手く動作していなかったっぽいので、直しました。

closes #933