### PR TITLE
画像より動画の方が多いOGPが正しく初期化できていなかった問題を修正

### DIFF
--- a/service/ogp/formatter.go
+++ b/service/ogp/formatter.go
@@ -38,7 +38,7 @@ func MergeDefaultPageMetaAndOpenGraph(og *opengraph.OpenGraph, meta *DefaultPage
 		result.Description = og.Description
 	}
 	if len(og.Videos) > 0 {
-		result.Videos = make([]model.OgpMedia, len(og.Images))
+		result.Videos = make([]model.OgpMedia, len(og.Videos))
 		for i, video := range og.Videos {
 			// Videoは仕様上Imageと同じ構造を持つ
 			result.Videos[i] = toOgpMedia((*opengraph.Image)(video))


### PR DESCRIPTION
動画のフィールドの初期化に画像の個数を参照していた問題の修正です﻿
