### PR TITLE
GET /webrtc/state が空のとき空配列を返す

### DIFF
--- a/router/v3/webrtc.go
+++ b/router/v3/webrtc.go
@@ -57,7 +57,7 @@ func (h *Handlers) GetWebRTCState(c echo.Context) error {
 		Sessions  []StateSession `json:"sessions"`
 	}
 
-	var res []WebRTCUserState
+	res := make([]WebRTCUserState, 0)
 	h.WebRTC.IterateStates(func(state webrtcv3.ChannelState) {
 		for _, userState := range state.Users() {
 			var sessions []StateSession


### PR DESCRIPTION
fixes #1047 