### PR TITLE
グループ名の制約を追加

### DIFF
--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -33,7 +33,7 @@ type PostUserGroupRequest struct {
 
 func (r PostUserGroupRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, vd.Required, vd.RuneLength(1, 30)),
+		vd.Field(&r.Name, validator.UserGroupNameRuleRequired...),
 		vd.Field(&r.Description, vd.RuneLength(0, 100)),
 		vd.Field(&r.Type, vd.RuneLength(0, 30)),
 	)
@@ -82,7 +82,7 @@ type PatchUserGroupRequest struct {
 
 func (r PatchUserGroupRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, vd.RuneLength(1, 30)),
+		vd.Field(&r.Name, validator.UserGroupNameRuleRequired...),
 		vd.Field(&r.Description, vd.RuneLength(0, 100)),
 		vd.Field(&r.Type, vd.RuneLength(0, 30)),
 	)

--- a/utils/message/replacer.go
+++ b/utils/message/replacer.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// ユーザーとグループのnameの和集合
-	mentionRegex    = regexp.MustCompile(`:?[@＠](\S{1,32})`)
+	mentionRegex    = regexp.MustCompile(`:?[@＠]([^\s@＠]{1,31}[^\s@＠:])`)
 	userStartsRegex = regexp.MustCompile(`^[@＠]([a-zA-Z0-9_-]{1,32})`)
 	channelRegex    = regexp.MustCompile(`[#＃]([a-zA-Z0-9_/-]+)`)
 )

--- a/utils/message/replacer_test.go
+++ b/utils/message/replacer_test.go
@@ -106,6 +106,10 @@ func TestReplacer_Replace(t *testing.T) {
 			"@takashi_trapo @takashi_trape",
 			"!{\"type\":\"group\",\"raw\":\"@takashi_trapo\",\"id\":\"dfabf0c9-5de0-46ee-9721-2525e8bb3d46\"} !{\"type\":\"user\",\"raw\":\"@takashi_trape\",\"id\":\"dfdff0c9-5de0-46ee-9721-2525e8bb3d46\"}",
 		},
+		{
+			"@)、(@takashi_trap @takashi_trap)",
+			"@)、(!{\"type\":\"user\",\"raw\":\"@takashi_trap\",\"id\":\"dfdff0c9-5de0-46ee-9721-2525e8bb3d45\"} !{\"type\":\"user\",\"raw\":\"@takashi_trap\",\"id\":\"dfdff0c9-5de0-46ee-9721-2525e8bb3d45\"})",
+		},
 	}
 	for _, v := range tt {
 		assert.Equal(t, v[1], re.Replace(v[0]))

--- a/utils/validator/rules.go
+++ b/utils/validator/rules.go
@@ -40,6 +40,17 @@ var BotUserNameRuleRequired = append([]vd.Rule{
 	vd.Required,
 }, BotUserNameRule...)
 
+// UserGroupNameRule ユーザーグループ名バリデーションルール
+var UserGroupNameRule = []vd.Rule{
+	vd.Match(regexp.MustCompile(`^[^@＠#＃]+[^@＠#＃:]$`)).Error("must not contain [@＠#＃] and the last charactor must not be :"),
+	vd.RuneLength(1, 30),
+}
+
+// UserGroupNameRuleRequired ユーザーグループ名バリデーションルール with Required
+var UserGroupNameRuleRequired = append([]vd.Rule{
+	vd.Required,
+}, UserGroupNameRule...)
+
 // ChannelNameRule チャンネル名バリデーションルール
 var ChannelNameRule = []vd.Rule{
 	vd.Match(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)).Error("must contain [a-zA-Z0-9_-] only"),


### PR DESCRIPTION
BREAKING CHANGE

- ユーザーグループ名の制約を設定
  - `@`と`＠`と`#`と`＃`を含まない、かつ`:`で終わらない
- replacerが動作しないパターンの修正
  - @のあとに@がスペースなしで出現する場合
  - `@)、(@takashi_trap @takashi_trap)`

よろしくお願いします
