### PR TITLE
検索のエンドポイントにソート順の指定を追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -180,6 +180,17 @@ paths:
           in: query
           name: offset
           description: 検索結果から取得するメッセージのオフセット
+        - in: query
+          name: sort
+          schema:
+            type: string
+            default: '-createdAt'
+            enum:
+              - createdAt
+              - '-createdAt'
+              - updatedAt
+              - '-updatedAt'
+          description: 'ソート順 (作成日時が新しい `createdAt`, 作成日時が古い `-createdAt`, 更新日時が新しい `updatedAt`, 更新日時が古い `-updatedAt`)'
       responses:
         '200':
           description: OK

--- a/service/search/engine.go
+++ b/service/search/engine.go
@@ -5,6 +5,8 @@ import (
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/traPtitech/traQ/service/message"
 	"github.com/traPtitech/traQ/utils/optional"
+	"regexp"
+	"strings"
 )
 
 // ErrServiceUnavailable エラー 現在検索サービスが利用できません
@@ -37,6 +39,7 @@ type Query struct {
 	HasAudio       optional.Bool   `query:"hasAudio"`       // 添付ファイル（音声ファイル）
 	Limit          optional.Int    `query:"limit"`          // 取得件数
 	Offset         optional.Int    `query:"offset"`         // 取得Offset
+	Sort           optional.String `query:"sort"`           // 並び順 /[-\+]?key/
 }
 
 func (q Query) Validate() error {
@@ -45,7 +48,30 @@ func (q Query) Validate() error {
 		// Cannot page through more than 10k hits with From and Size
 		// https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html
 		vd.Field(&q.Offset, vd.Min(0), vd.Max(9900)),
+		vd.Field(&q.Sort, vd.Match(allowedSortKeysRegExp)),
 	)
+}
+
+// Sort ソート情報
+type Sort struct {
+	Key  string // 何によってソートするか
+	Desc bool   // 降順にするか
+}
+
+// GetSortKey ソートに使うキーの情報を抽出します
+func (q Query) GetSortKey() Sort {
+	if !q.Sort.Valid {
+		return Sort{Key: createdAtSortKey, Desc: true}
+	}
+	match := allowedSortKeysRegExp.FindStringSubmatch(q.Sort.ValueOrZero())
+	if match[2] == "" {
+		return Sort{Key: createdAtSortKey, Desc: true}
+	}
+	if match[1] == "-" {
+		return Sort{Key: match[2], Desc: !shouldUseDescendingAsDefault(match[2])}
+	} else {
+		return Sort{Key: match[2], Desc: shouldUseDescendingAsDefault(match[2])}
+	}
 }
 
 // Result 検索結果インターフェイス
@@ -54,4 +80,20 @@ type Result interface {
 	TotalHits() int64
 	// Hits createdAtで降順にソートされた、ヒットしたメッセージ
 	Hits() []message.Message
+}
+
+const createdAtSortKey = "createdAt"  // 作成日時の新しい順
+const updatedAtSortKey = "updatedAt"  // 更新日時の新しい順
+
+var allowedSortKeys = []string{createdAtSortKey, updatedAtSortKey}
+var allowedSortKeysRegExp = regexp.MustCompile("([+-]?)(" + strings.Join(allowedSortKeys, "|") + ")")
+
+// `-`のつかないソートキーを指定した時、対応する値の降順にするか
+func shouldUseDescendingAsDefault(key string) bool {
+	switch key {
+	case createdAtSortKey, updatedAtSortKey:
+		return true
+	default:
+		return false
+	}
 }

--- a/service/search/engine.go
+++ b/service/search/engine.go
@@ -69,9 +69,8 @@ func (q Query) GetSortKey() Sort {
 	}
 	if match[1] == "-" {
 		return Sort{Key: match[2], Desc: !shouldUseDescendingAsDefault(match[2])}
-	} else {
-		return Sort{Key: match[2], Desc: shouldUseDescendingAsDefault(match[2])}
 	}
+	return Sort{Key: match[2], Desc: shouldUseDescendingAsDefault(match[2])}
 }
 
 // Result 検索結果インターフェイス
@@ -82,8 +81,8 @@ type Result interface {
 	Hits() []message.Message
 }
 
-const createdAtSortKey = "createdAt"  // 作成日時の新しい順
-const updatedAtSortKey = "updatedAt"  // 更新日時の新しい順
+const createdAtSortKey = "createdAt" // 作成日時の新しい順
+const updatedAtSortKey = "updatedAt" // 更新日時の新しい順
 
 var allowedSortKeys = []string{createdAtSortKey, updatedAtSortKey}
 var allowedSortKeysRegExp = regexp.MustCompile("([+-]?)(" + strings.Join(allowedSortKeys, "|") + ")")

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -252,10 +252,13 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 		offset = int(q.Offset.Int64)
 	}
 
+	// NOTE: 現状`sort.Key`はそのままesのソートキーとして使える前提
+	sort := q.GetSortKey()
+
 	sr, err := e.client.Search().
 		Index(getIndexName(esMessageIndex)).
 		Query(elastic.NewBoolQuery().Must(musts...)).
-		Sort("createdAt", false).
+		Sort(sort.Key, !sort.Desc).
 		Size(limit).
 		From(offset).
 		Do(context.Background())


### PR DESCRIPTION
`GET /messages`にソート順を指定できるようにしました。
作成日時・更新日時のみ対応です。