### PR TITLE
DockerfileにHEALTHCHECKを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ ENV TRAQ_IMAGEMAGICK=/usr/bin/convert
 
 COPY --from=build /traQ ./
 
+HEALTHCHECK CMD ./traQ healthcheck || exit 1
 ENTRYPOINT ./traQ serve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.16-alpine AS build
-RUN apk add --update --no-cache git
 WORKDIR /go/src/github.com/traPtitech/traQ
 COPY ./go.* ./
 RUN go mod download
@@ -12,9 +11,8 @@ RUN CGO_ENABLED=0 go build -o /traQ -ldflags "-s -w -X main.version=$TRAQ_VERSIO
 FROM alpine:3.13.5
 WORKDIR /app
 
-RUN apk add --update ca-certificates imagemagick && \
-    update-ca-certificates && \
-    rm -rf /var/cache/apk/*
+RUN apk add --no-cache --update ca-certificates imagemagick && \
+    update-ca-certificates
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+// healthcheckCommand ヘルスチェックコマンド
+func healthcheckCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "healthcheck",
+		Short: "Run healthcheck",
+		Run: func(cmd *cobra.Command, args []string) {
+			logger := getCLILogger()
+			resp, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:%d/api/ping", c.Port))
+			if err != nil {
+				logger.Fatal("HTTP Client Error", zap.Error(err))
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				logger.Fatal("Unexpected status", zap.Int("status", resp.StatusCode))
+			}
+		},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ func init() {
 		fileCommand(),
 		stampCommand(),
 		versionCommand(),
+		healthcheckCommand(),
 	)
 
 	flags := rootCommand.PersistentFlags()

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -221,7 +221,7 @@ func (r PostLinkExternalAccount) Validate() error {
 	)
 }
 
-// UnlinkExternalAccount POST /users/me/ex-accounts/link
+// LinkExternalAccount POST /users/me/ex-accounts/link
 func (h *Handlers) LinkExternalAccount(c echo.Context) error {
 	var req PostLinkExternalAccount
 	if err := bindAndValidate(c, &req); err != nil {


### PR DESCRIPTION
これだとhealthcheckが、引数に`--config`を渡してportを変えたとき、うまく動かないことに気がついた
→ この場合はrun時にoverrideしてもらえば良さそう https://docs.docker.com/engine/reference/run/#healthcheck
ref #1137 