### PR TITLE
チャンネルを閲覧中はpush通知を飛ばさない

### DIFF
--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -246,7 +246,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	} else {
 		targetFuncNotCited = ws.And(
 			ws.Or(
-				ws.TargetUserSets(notifiedUsers, viewers),
+				ws.TargetUserSets(markedUsers, viewers),
 				ws.TargetTimelineStreamingEnabled(),
 			),
 			ws.Not(ws.TargetUserSets(citedUsers)),

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -108,6 +108,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	markedUsers := set.UUID{}   // チャンネル未読管理ユーザー
 	noticeable := set.UUID{}    // noticeableな未読追加対象のユーザー
 	citedUsers := set.UUID{}    // メッセージで引用されたメッセージを投稿したユーザー
+	dmMembers := set.UUID{}     // isDMの場合 DMのメンバー
 
 	// メッセージボディ作成
 	if !isDM {
@@ -150,6 +151,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		}
 		notifiedUsers.Add(users...)
 		markedUsers.Add(users...)
+		dmMembers.Add(users...)
 
 	default: // 通常チャンネルメッセージ
 		// チャンネル通知購読者取得
@@ -221,7 +223,8 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	for uid, swt := range ns.vm.GetChannelViewers(m.ChannelID) {
 		viewers.Add(uid)
 		if swt.State > viewer.StateNone {
-			markedUsers.Remove(uid) // 閲覧中ユーザーは未読管理から外す
+			markedUsers.Remove(uid)   // 閲覧中ユーザーは未読管理から外す
+			notifiedUsers.Remove(uid) // 閲覧中ユーザーは通知から外す
 		}
 	}
 
@@ -238,12 +241,14 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	var targetFuncNotCited ws.TargetFunc
 	var targetFuncCited ws.TargetFunc
 	if isDM {
-		targetFuncNotCited = ws.TargetUserSets(notifiedUsers)
+		targetFuncNotCited = ws.TargetUserSets(dmMembers)
 		targetFuncCited = ws.TargetNone()
 	} else {
 		targetFuncNotCited = ws.And(
-			ws.Or(ws.TargetUserSets(notifiedUsers, viewers),
-				ws.TargetTimelineStreamingEnabled()),
+			ws.Or(
+				ws.TargetUserSets(notifiedUsers, viewers),
+				ws.TargetTimelineStreamingEnabled(),
+			),
 			ws.Not(ws.TargetUserSets(citedUsers)),
 		)
 		targetFuncCited = ws.TargetUserSets(citedUsers)

--- a/service/ws/target_func.go
+++ b/service/ws/target_func.go
@@ -54,6 +54,7 @@ func TargetTimelineStreamingEnabled() TargetFunc {
 	}
 }
 
+// TargetNone いずれのセッションにも送信しません
 func TargetNone() TargetFunc {
 	return func(s Session) bool {
 		return false
@@ -72,6 +73,7 @@ func Or(funcs ...TargetFunc) TargetFunc {
 	}
 }
 
+// And すべてのTargetFuncの条件に該当する対象に送信します
 func And(funcs ...TargetFunc) TargetFunc {
 	return func(s Session) bool {
 		for _, f := range funcs {
@@ -83,6 +85,7 @@ func And(funcs ...TargetFunc) TargetFunc {
 	}
 }
 
+// Not TargetFuncの条件に該当しない対象に送信します
 func Not(f TargetFunc) TargetFunc {
 	return func(s Session) bool {
 		return !f(s)


### PR DESCRIPTION
+ チャンネルを閲覧中はpush通知を飛ばさない e195cdd
+ チャンネル未読管理 & timeline_streamingでないとき、そのチャンネルの`MESSAGE_CREATED`が意図せず飛んでいなかった 996bc8c

closes #1066 