### PR TITLE
アクティビティのクエリの改善

### DIFF
--- a/repository/message_impl.go
+++ b/repository/message_impl.go
@@ -195,22 +195,9 @@ func (repo *GormRepository) GetMessages(query MessagesQuery) (messages []*model.
 		tx = tx.Offset(query.Offset)
 	}
 
-	if query.ExcludeDMs && query.Channel == uuid.Nil && query.User == uuid.Nil && query.ChannelsSubscribedByUser == uuid.Nil && !query.Since.Valid && !query.Until.Valid && query.Limit > 0 {
-		// アクティビティ用にUSE INDEX指定でクエリ発行
-		// TODO 綺麗じゃない
-		err = tx.
-			Limit(query.Limit + 1).
-			Raw("SELECT messages.* FROM messages USE INDEX (idx_messages_deleted_at_created_at) INNER JOIN channels ON messages.channel_id = channels.id WHERE messages.deleted_at IS NULL AND channels.is_public = true").
-			Scan(&messages).
-			Error
-		if len(messages) > query.Limit {
-			return messages[:len(messages)-1], true, err
-		}
-		return messages, false, err
-	}
-
 	if query.ChannelsSubscribedByUser != uuid.Nil || query.ExcludeDMs {
-		tx = tx.Joins("INNER JOIN channels ON messages.channel_id = channels.id")
+		// JOIN時にidx_messages_channel_id_deleted_at_created_atが使われてしまい、JOIN、WHERE後のレコード数が多い場合はfile sortで重くなる
+		tx = tx.Joins("USE INDEX (`idx_messages_deleted_at_created_at`) INNER JOIN channels ON messages.channel_id = channels.id")
 	}
 
 	if query.Channel != uuid.Nil {

--- a/repository/message_impl.go
+++ b/repository/message_impl.go
@@ -197,6 +197,7 @@ func (repo *GormRepository) GetMessages(query MessagesQuery) (messages []*model.
 
 	if query.ChannelsSubscribedByUser != uuid.Nil || query.ExcludeDMs {
 		// JOIN時にidx_messages_channel_id_deleted_at_created_atが使われてしまい、JOIN、WHERE後のレコード数が多い場合はfile sortで重くなる
+		// NOTE: gorm.io/hints はJOINと同時に使うと順番が壊れる
 		tx = tx.Joins("USE INDEX (`idx_messages_deleted_at_created_at`) INNER JOIN channels ON messages.channel_id = channels.id")
 	}
 

--- a/repository/message_impl_test.go
+++ b/repository/message_impl_test.go
@@ -2,11 +2,13 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/utils/optional"
 )
 
 func TestRepositoryImpl_CreateMessage(t *testing.T) {
@@ -120,6 +122,70 @@ func TestRepositoryImpl_GetMessageByID(t *testing.T) {
 
 	_, err = repo.GetMessageByID(uuid.Must(uuid.NewV4()))
 	assert.Error(err)
+}
+
+func TestRepositoryImpl_GetMessages(t *testing.T) {
+	t.Parallel()
+	repo, _, require, user := setupWithUser(t, ex3)
+	ch1 := mustMakeChannel(t, repo, rand)
+	ch2 := mustMakeChannel(t, repo, rand)
+
+	_, _, err := repo.ChangeChannelSubscription(ch1.ID, ChangeChannelSubscriptionArgs{
+		Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{
+			user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+		},
+	})
+	require.NoError(err)
+
+	m1 := mustMakeMessage(t, repo, user.GetID(), ch1.ID)
+	m2 := mustMakeMessage(t, repo, user.GetID(), ch2.ID)
+
+	messageEquals := func(t *testing.T, expected, actual *model.Message) {
+		t.Helper()
+
+		assert.EqualValues(t, expected.ID, actual.ID)
+		assert.EqualValues(t, expected.Text, actual.Text)
+		assert.EqualValues(t, expected.UserID, actual.UserID)
+		assert.EqualValues(t, expected.ChannelID, actual.ChannelID)
+		assert.NotEmpty(t, actual.CreatedAt)
+		assert.NotEmpty(t, actual.UpdatedAt)
+	}
+
+	t.Run("activity all", func(t *testing.T) {
+		t.Parallel()
+
+		messages, more, err := repo.GetMessages(MessagesQuery{
+			Since:          optional.TimeFrom(time.Now().Add(-7 * 24 * time.Hour)),
+			Limit:          50,
+			ExcludeDMs:     true,
+			DisablePreload: true,
+		})
+
+		if assert.NoError(t, err) {
+			assert.False(t, more)
+			assert.EqualValues(t, 2, len(messages))
+			messageEquals(t, m2, messages[0])
+			messageEquals(t, m1, messages[1])
+		}
+	})
+
+	t.Run("activity subscription", func(t *testing.T) {
+		t.Parallel()
+
+		messages, more, err := repo.GetMessages(MessagesQuery{
+			Since:                    optional.TimeFrom(time.Now().Add(-7 * 24 * time.Hour)),
+			Limit:                    50,
+			ExcludeDMs:               true,
+			DisablePreload:           true,
+			ChannelsSubscribedByUser: user.GetID(),
+		})
+
+		if assert.NoError(t, err) {
+			assert.False(t, more)
+			assert.EqualValues(t, 1, len(messages))
+			messageEquals(t, m1, messages[0])
+		}
+	})
 }
 
 func TestRepositoryImpl_SetMessageUnread(t *testing.T) {

--- a/repository/message_impl_test.go
+++ b/repository/message_impl_test.go
@@ -137,8 +137,11 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	})
 	require.NoError(err)
 
-	m1 := mustMakeMessage(t, repo, user.GetID(), ch1.ID)
-	m2 := mustMakeMessage(t, repo, user.GetID(), ch2.ID)
+	for i := 0; i < 5; i++ {
+		mustMakeMessage(t, repo, user.GetID(), ch1.ID)
+	}
+	m6 := mustMakeMessage(t, repo, user.GetID(), ch1.ID)
+	m7 := mustMakeMessage(t, repo, user.GetID(), ch2.ID)
 
 	messageEquals := func(t *testing.T, expected, actual *model.Message) {
 		t.Helper()
@@ -163,9 +166,27 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			assert.False(t, more)
-			assert.EqualValues(t, 2, len(messages))
-			messageEquals(t, m2, messages[0])
-			messageEquals(t, m1, messages[1])
+			assert.EqualValues(t, 7, len(messages))
+			messageEquals(t, m7, messages[0])
+			messageEquals(t, m6, messages[1])
+		}
+	})
+
+	t.Run("activity all with limit", func(t *testing.T) {
+		t.Parallel()
+
+		messages, more, err := repo.GetMessages(MessagesQuery{
+			Since:          optional.TimeFrom(time.Now().Add(-7 * 24 * time.Hour)),
+			Limit:          5,
+			ExcludeDMs:     true,
+			DisablePreload: true,
+		})
+
+		if assert.NoError(t, err) {
+			assert.True(t, more)
+			assert.EqualValues(t, 5, len(messages))
+			messageEquals(t, m7, messages[0])
+			messageEquals(t, m6, messages[1])
 		}
 	})
 
@@ -182,8 +203,8 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			assert.False(t, more)
-			assert.EqualValues(t, 1, len(messages))
-			messageEquals(t, m1, messages[0])
+			assert.EqualValues(t, 6, len(messages))
+			messageEquals(t, m6, messages[0])
 		}
 	})
 }

--- a/router/v3/activity.go
+++ b/router/v3/activity.go
@@ -6,8 +6,14 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/traQ/router/extension/herror"
 	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/optional"
 	"net/http"
 	"time"
+)
+
+const (
+	// timelineRange activityは直近7日間のメッセージのみを表示
+	timelineRange = 7 * 24 * time.Hour
 )
 
 // GetOnlineUsers GET /activity/onlines
@@ -42,6 +48,7 @@ func (h *Handlers) GetActivityTimeline(c echo.Context) error {
 
 	if !req.PerChannel {
 		query := message.TimelineQuery{
+			Since:          optional.TimeFrom(time.Now().Add(-timelineRange)),
 			Limit:          req.Limit,
 			ExcludeDMs:     true,
 			DisablePreload: true,

--- a/service/message/manager.go
+++ b/service/message/manager.go
@@ -36,6 +36,10 @@ type Manager interface {
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
 	Get(id uuid.UUID) (Message, error)
+	// GetTimeline タイムラインを取得します
+	//
+	// 成功した場合、タイムラインとnilを返します。
+	// DBによるエラーを返すことがあります。
 	GetTimeline(query TimelineQuery) (Timeline, error)
 	// Create メッセージを作成します
 	//


### PR DESCRIPTION
`GET /api/v3/activity/timeline?limit=50&all=false&per_channel=false`
通知チャンネルのみの最新メッセージを取得するクエリが遅いことがあった
`idx_messages_channel_id_deleted_at_created_at`がJOIN時に使われていたため、通知チャンネルが多い場合はfile sortが発生していて重かった

アクティビティを過去7日間のメッセージに限定する、また`idx_messages_deleted_at_created_at`を使わせることで改善

https://gorm.io/docs/hints.html 使おうとしたけどJOINが入ると順番壊れちゃって上手くいかなかったから、JOINにUSE INDEX直書きしちゃった