### PR TITLE
v3 router test

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -329,6 +329,8 @@ paths:
           description: |-
             No Content
             指定したメッセージのピン留めが外されました。
+        '400':
+          description: Bad Request
         '404':
           description: |-
             Not Found

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -1532,12 +1532,10 @@ paths:
     patch:
       summary: Webhook情報を変更
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Webhook'
+        '204':
+          description: |-
+            No Content
+            編集できました。
         '400':
           description: Bad Request
         '404':

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4136,9 +4136,7 @@ paths:
         '204':
           description: 変更できました。
         '400':
-          description: 指定したURLが不正です
-        '404':
-          description: 指定したURLに対するユーザー設定情報が見つかりませんでした。
+          description: Bad Request
       requestBody:
         content:
           application/json:

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -1052,16 +1052,14 @@ paths:
       - $ref: '#/components/parameters/groupIdInPath'
       - $ref: '#/components/parameters/userIdInPath'
     delete:
-      summary: ユーザーグループから削除
+      summary: |-
+        指定したグループからユーザーを削除します。
+        既にグループから削除されているメンバーを指定した場合は204を返します。
       responses:
         '204':
           description: |-
             No Content
             指定したユーザーがユーザーグループから削除されました。
-        '400':
-          description: |-
-            Bad Request
-            ユーザーがグループに存在しません。
         '403':
           description: |-
             Forbidden

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -312,9 +312,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/MessagePin'
         '400':
-          description: |-
-            Forbidden
-            これ以上このメッセージのチャンネルにピン留めすることはできません。
+          description: Bad Request
         '404':
           description: |-
             Not Found

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -235,12 +235,10 @@ paths:
     put:
       summary: メッセージを編集
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Message'
+        '204':
+          description: |-
+            No Content
+            メッセージを編集できました。
         '400':
           description: Bad Request
         '403':
@@ -251,7 +249,7 @@ paths:
           description: Not Found
       description: |-
         指定したメッセージを編集します。
-        自身が投稿したメッセージと自身が管理権限を持つWebhookとBOTが投稿したメッセージのみ編集することができます。
+        自身が投稿したメッセージのみ編集することができます。
         アーカイブされているチャンネルのメッセージを編集することは出来ません。
       requestBody:
         content:

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -1997,10 +1997,6 @@ paths:
             変更されました。
         '400':
           description: Bad Request
-        '403':
-          description: |-
-            Forbidden
-            タグがロックされています。
         '404':
           description: |-
             Not Found

--- a/repository/user_settings.go
+++ b/repository/user_settings.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"github.com/gofrs/uuid"
+
 	"github.com/traPtitech/traQ/model"
 )
 
@@ -16,7 +17,7 @@ type UserSettingsRepository interface {
 	// GetNotifyCitation メッセージ引用通知の情報を取得します
 	//
 	// 返り値がtrueの場合、メッセージ引用通知が有効です
-	// 返り値がfalseの場合、メッセージ引用通知が無効がエラーが発生しています
+	// 返り値がfalseの場合、メッセージ引用通知が無効です
 	// DBによるエラーを返すことがあります
 	GetNotifyCitation(userID uuid.UUID) (bool, error)
 	// GetUserSettings ユーザー設定を返します

--- a/router/v1/bot.go
+++ b/router/v1/bot.go
@@ -1,11 +1,14 @@
 package v1
 
 import (
+	"net/http"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/leandro-lugaresi/hub"
+
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
@@ -17,7 +20,6 @@ import (
 	"github.com/traPtitech/traQ/service/rbac/role"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
 )
 
 // GetBots GET /bots
@@ -301,7 +303,7 @@ func (h *Handlers) GetBotEventLogs(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	return c.JSON(http.StatusOK, logs)
+	return c.JSON(http.StatusOK, formatBotEventLogs(logs))
 }
 
 // GetChannelBots GET /channels/:channelID/bots

--- a/router/v1/responses.go
+++ b/router/v1/responses.go
@@ -1,11 +1,13 @@
 package v1
 
 import (
+	"time"
+
 	"github.com/gofrs/uuid"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/service/rbac/permission"
 	"github.com/traPtitech/traQ/utils/optional"
-	"time"
 )
 
 type meResponse struct {
@@ -261,6 +263,32 @@ func formatBotDetail(b *model.Bot, t *model.OAuth2Token) *botDetailResponse {
 		Privileged:       b.Privileged,
 		BotCode:          b.BotCode,
 	}
+}
+
+type botEventLogResponse struct {
+	RequestID uuid.UUID          `json:"requestId"`
+	BotID     uuid.UUID          `json:"botId"`
+	Event     model.BotEventType `json:"event"`
+	Code      int                `json:"code"`
+	DateTime  time.Time          `json:"datetime"`
+}
+
+func formatBotEventLog(log *model.BotEventLog) *botEventLogResponse {
+	return &botEventLogResponse{
+		RequestID: log.RequestID,
+		BotID:     log.BotID,
+		Event:     log.Event,
+		Code:      log.Code,
+		DateTime:  log.DateTime,
+	}
+}
+
+func formatBotEventLogs(logs []*model.BotEventLog) []*botEventLogResponse {
+	res := make([]*botEventLogResponse, len(logs))
+	for i, log := range logs {
+		res[i] = formatBotEventLog(log)
+	}
+	return res
 }
 
 type tagResponse struct {

--- a/router/v3/activity_test.go
+++ b/router/v3/activity_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/service/message"
 )
 
 func TestGetActivityTimelineRequest_Validate(t *testing.T) {
@@ -49,8 +50,6 @@ func TestGetActivityTimelineRequest_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			r := &GetActivityTimelineRequest{
 				Limit:      tt.fields.Limit,
 				All:        tt.fields.All,
@@ -83,12 +82,12 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 	m2 := env.CreateMessage(t, user.GetID(), ch1.ID, "m2")
 	m3 := env.CreateMessage(t, user.GetID(), ch2.ID, "m3")
 
-	msgEquals := func(t *testing.T, expect *model.Message, actual *httpexpect.Object) {
+	msgEquals := func(t *testing.T, expect message.Message, actual *httpexpect.Object) {
 		t.Helper()
-		actual.Value("id").String().Equal(expect.ID.String())
-		actual.Value("userId").String().Equal(expect.UserID.String())
-		actual.Value("channelId").String().Equal(expect.ChannelID.String())
-		actual.Value("content").String().Equal(expect.Text)
+		actual.Value("id").String().Equal(expect.GetID().String())
+		actual.Value("userId").String().Equal(expect.GetUserID().String())
+		actual.Value("channelId").String().Equal(expect.GetChannelID().String())
+		actual.Value("content").String().Equal(expect.GetText())
 		actual.Value("createdAt").String().NotEmpty()
 		actual.Value("updatedAt").String().NotEmpty()
 	}

--- a/router/v3/activity_test.go
+++ b/router/v3/activity_test.go
@@ -1,0 +1,194 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func TestGetActivityTimelineRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Limit      int
+		All        bool
+		PerChannel bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"no limit",
+			fields{Limit: 0},
+			false,
+		},
+		{
+			"max limit",
+			fields{Limit: 50},
+			false,
+		},
+		{
+			"negative limit",
+			fields{Limit: -10},
+			true,
+		},
+		{
+			"exceeds max limit",
+			fields{Limit: 100},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &GetActivityTimelineRequest{
+				Limit:      tt.fields.Limit,
+				All:        tt.fields.All,
+				PerChannel: tt.fields.PerChannel,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_GetActivityTimeline(t *testing.T) {
+	t.Parallel()
+	path := "/api/v3/activity/timeline"
+	env := Setup(t, s1)
+	user := env.CreateUser(t, rand)
+	commonSession := env.S(t, user.GetID())
+
+	ch1 := env.CreateChannel(t, rand)
+	ch2 := env.CreateChannel(t, rand)
+	_, _, err := env.Repository.ChangeChannelSubscription(ch1.ID, repository.ChangeChannelSubscriptionArgs{
+		Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{
+			user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+		},
+	})
+	require.NoError(t, err)
+
+	m1 := env.CreateMessage(t, user.GetID(), ch1.ID, "m1")
+	m2 := env.CreateMessage(t, user.GetID(), ch1.ID, "m2")
+	m3 := env.CreateMessage(t, user.GetID(), ch2.ID, "m3")
+
+	msgEquals := func(expect *model.Message, actual *httpexpect.Object) {
+		actual.Value("id").String().Equal(expect.ID.String())
+		actual.Value("userId").String().Equal(expect.UserID.String())
+		actual.Value("channelId").String().Equal(expect.ChannelID.String())
+		actual.Value("content").String().Equal(expect.Text)
+		actual.Value("createdAt").String().NotEmpty()
+		actual.Value("updatedAt").String().NotEmpty()
+	}
+
+	t.Run("NotLoggedIn", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad limit 1", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("limit", "-1").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad limit 2", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("limit", "100").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (all=true, per_channel=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", true).
+			WithQuery("per_channel", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+
+		msgEquals(m3, obj.Element(0).Object())
+		msgEquals(m2, obj.Element(1).Object())
+	})
+
+	t.Run("success (all=true, per_channel=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", true).
+			WithQuery("per_channel", false).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(3)
+
+		msgEquals(m3, obj.Element(0).Object())
+		msgEquals(m2, obj.Element(1).Object())
+		msgEquals(m1, obj.Element(2).Object())
+	})
+
+	t.Run("success (all=false, per_channel=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", false).
+			WithQuery("per_channel", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		msgEquals(m2, obj.Element(0).Object())
+	})
+
+	t.Run("success (all=false, per_channel=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", false).
+			WithQuery("per_channel", false).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+
+		msgEquals(m2, obj.Element(0).Object())
+		msgEquals(m1, obj.Element(1).Object())
+	})
+}

--- a/router/v3/activity_test.go
+++ b/router/v3/activity_test.go
@@ -82,7 +82,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 	m2 := env.CreateMessage(t, user.GetID(), ch1.ID, "m2")
 	m3 := env.CreateMessage(t, user.GetID(), ch2.ID, "m3")
 
-	msgEquals := func(t *testing.T, expect message.Message, actual *httpexpect.Object) {
+	timelineMessageEquals := func(t *testing.T, expect message.Message, actual *httpexpect.Object) {
 		t.Helper()
 		actual.Value("id").String().Equal(expect.GetID().String())
 		actual.Value("userId").String().Equal(expect.GetUserID().String())
@@ -134,8 +134,8 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(2)
 
-		msgEquals(t, m3, obj.Element(0).Object())
-		msgEquals(t, m2, obj.Element(1).Object())
+		timelineMessageEquals(t, m3, obj.Element(0).Object())
+		timelineMessageEquals(t, m2, obj.Element(1).Object())
 	})
 
 	t.Run("success (all=true, per_channel=false)", func(t *testing.T) {
@@ -152,9 +152,9 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(3)
 
-		msgEquals(t, m3, obj.Element(0).Object())
-		msgEquals(t, m2, obj.Element(1).Object())
-		msgEquals(t, m1, obj.Element(2).Object())
+		timelineMessageEquals(t, m3, obj.Element(0).Object())
+		timelineMessageEquals(t, m2, obj.Element(1).Object())
+		timelineMessageEquals(t, m1, obj.Element(2).Object())
 	})
 
 	t.Run("success (all=false, per_channel=true)", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(1)
 
-		msgEquals(t, m2, obj.Element(0).Object())
+		timelineMessageEquals(t, m2, obj.Element(0).Object())
 	})
 
 	t.Run("success (all=false, per_channel=false)", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(2)
 
-		msgEquals(t, m2, obj.Element(0).Object())
-		msgEquals(t, m1, obj.Element(1).Object())
+		timelineMessageEquals(t, m2, obj.Element(0).Object())
+		timelineMessageEquals(t, m1, obj.Element(1).Object())
 	})
 }

--- a/router/v3/activity_test.go
+++ b/router/v3/activity_test.go
@@ -83,7 +83,8 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 	m2 := env.CreateMessage(t, user.GetID(), ch1.ID, "m2")
 	m3 := env.CreateMessage(t, user.GetID(), ch2.ID, "m3")
 
-	msgEquals := func(expect *model.Message, actual *httpexpect.Object) {
+	msgEquals := func(t *testing.T, expect *model.Message, actual *httpexpect.Object) {
+		t.Helper()
 		actual.Value("id").String().Equal(expect.ID.String())
 		actual.Value("userId").String().Equal(expect.UserID.String())
 		actual.Value("channelId").String().Equal(expect.ChannelID.String())
@@ -92,7 +93,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 		actual.Value("updatedAt").String().NotEmpty()
 	}
 
-	t.Run("NotLoggedIn", func(t *testing.T) {
+	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.GET(path).
@@ -134,8 +135,8 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(2)
 
-		msgEquals(m3, obj.Element(0).Object())
-		msgEquals(m2, obj.Element(1).Object())
+		msgEquals(t, m3, obj.Element(0).Object())
+		msgEquals(t, m2, obj.Element(1).Object())
 	})
 
 	t.Run("success (all=true, per_channel=false)", func(t *testing.T) {
@@ -152,9 +153,9 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(3)
 
-		msgEquals(m3, obj.Element(0).Object())
-		msgEquals(m2, obj.Element(1).Object())
-		msgEquals(m1, obj.Element(2).Object())
+		msgEquals(t, m3, obj.Element(0).Object())
+		msgEquals(t, m2, obj.Element(1).Object())
+		msgEquals(t, m1, obj.Element(2).Object())
 	})
 
 	t.Run("success (all=false, per_channel=true)", func(t *testing.T) {
@@ -171,7 +172,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(1)
 
-		msgEquals(m2, obj.Element(0).Object())
+		msgEquals(t, m2, obj.Element(0).Object())
 	})
 
 	t.Run("success (all=false, per_channel=false)", func(t *testing.T) {
@@ -188,7 +189,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 		obj.Length().Equal(2)
 
-		msgEquals(m2, obj.Element(0).Object())
-		msgEquals(m1, obj.Element(1).Object())
+		msgEquals(t, m2, obj.Element(0).Object())
+		msgEquals(t, m1, obj.Element(1).Object())
 	})
 }

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -292,8 +292,8 @@ func (h *Handlers) ReissueBot(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{
-		"verificationCode": b.VerificationToken,
-		"accessToken":      t.AccessToken,
+		"verificationToken": b.VerificationToken,
+		"accessToken":       t.AccessToken,
 	})
 }
 

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -229,7 +229,7 @@ func (h *Handlers) GetBotLogs(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	return c.JSON(http.StatusOK, logs)
+	return c.JSON(http.StatusOK, formatBotEventLogs(logs))
 }
 
 // GetChannelBots GET /channels/:channelID/bots

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -130,9 +130,9 @@ type PatchBotRequest struct {
 
 func (r PatchBotRequest) ValidateWithContext(ctx context.Context) error {
 	return vd.ValidateStructWithContext(ctx, &r,
-		vd.Field(&r.DisplayName, vd.RuneLength(1, 32)),
+		vd.Field(&r.DisplayName, validator.RequiredIfValid, vd.RuneLength(1, 32)),
 		vd.Field(&r.Description, vd.RuneLength(0, 1000)),
-		vd.Field(&r.Endpoint, is.URL, validator.NotInternalURL),
+		vd.Field(&r.Endpoint, validator.RequiredIfValid, is.URL, validator.NotInternalURL),
 		vd.Field(&r.DeveloperID, validator.NotNilUUID, utils.IsActiveHumanUserID),
 		vd.Field(&r.SubscribeEvents, utils.IsValidBotEvents),
 	)

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -2,11 +2,14 @@ package v3
 
 import (
 	"context"
+	"net/http"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/leandro-lugaresi/hub"
+
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
@@ -18,7 +21,6 @@ import (
 	"github.com/traPtitech/traQ/service/rbac/role"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
 )
 
 // GetBots GET /bots
@@ -244,7 +246,7 @@ func (h *Handlers) GetChannelBots(c echo.Context) error {
 	res := make([]echo.Map, len(bots))
 	for i, v := range bots {
 		res[i] = echo.Map{
-			"botId":     v.ID,
+			"id":        v.ID,
 			"botUserId": v.BotUserID,
 		}
 	}

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -692,6 +692,7 @@ func TestHandlers_GetChannelBots(t *testing.T) {
 }
 
 func TestHandlers_ActivateBot(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/bots/{botId}/actions/activate"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)
@@ -737,6 +738,7 @@ func TestHandlers_ActivateBot(t *testing.T) {
 }
 
 func TestHandlers_InactivateBot(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/bots/{botId}/actions/inactivate"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)
@@ -782,6 +784,7 @@ func TestHandlers_InactivateBot(t *testing.T) {
 }
 
 func TestHandlers_ReissueBot(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/bots/{botId}/actions/reissue"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)
@@ -832,6 +835,7 @@ func TestHandlers_ReissueBot(t *testing.T) {
 }
 
 func TestHandlers_LetBotJoinChannel(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/bots/{botId}/actions/join"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)
@@ -903,6 +907,7 @@ func TestHandlers_LetBotJoinChannel(t *testing.T) {
 }
 
 func TestHandlers_LetBotLeaveChannel(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/bots/{botId}/actions/leave"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -306,7 +306,8 @@ func TestHandlers_EditBot(t *testing.T) {
 	user2 := env.CreateUser(t, rand)
 	commonSession := env.S(t, user1.GetID())
 	bot1 := env.CreateBot(t, rand, user1.GetID())
-	bot2 := env.CreateBot(t, rand, user2.GetID())
+	bot2 := env.CreateBot(t, rand, user1.GetID())
+	bot3 := env.CreateBot(t, rand, user2.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -376,7 +377,7 @@ func TestHandlers_EditBot(t *testing.T) {
 			Status(http.StatusBadRequest)
 	})
 
-	t.Run("subscribe events (event type)", func(t *testing.T) {
+	t.Run("bad request (subscribe events)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PATCH(path, bot1.ID.String()).
@@ -391,7 +392,7 @@ func TestHandlers_EditBot(t *testing.T) {
 	t.Run("forbidden (cannot patch others' bot)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
-		e.PATCH(path, bot2.ID.String()).
+		e.PATCH(path, bot3.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PatchBotRequest{DisplayName: optional.StringFrom("po")}).
 			Expect().
@@ -421,7 +422,7 @@ func TestHandlers_EditBot(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
-		e.PATCH(path, bot1.ID.String()).
+		e.PATCH(path, bot2.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PatchBotRequest{
 				DisplayName: optional.StringFrom("po"),

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -680,3 +680,143 @@ func TestHandlers_GetChannelBots(t *testing.T) {
 		first.Value("botUserId").String().Equal(bot.BotUserID.String())
 	})
 }
+
+func TestHandlers_ActivateBot(t *testing.T) {
+	path := "/api/v3/bots/{botId}/actions/activate"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	commonSession := env.S(t, user1.GetID())
+	bot1 := env.CreateBot(t, rand, user1.GetID())
+	bot2 := env.CreateBot(t, rand, user2.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot2.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusAccepted)
+	})
+}
+
+func TestHandlers_InactivateBot(t *testing.T) {
+	path := "/api/v3/bots/{botId}/actions/inactivate"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	commonSession := env.S(t, user1.GetID())
+	bot1 := env.CreateBot(t, rand, user1.GetID())
+	bot2 := env.CreateBot(t, rand, user2.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot2.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+}
+
+func TestHandlers_ReissueBot(t *testing.T) {
+	path := "/api/v3/bots/{botId}/actions/reissue"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	commonSession := env.S(t, user1.GetID())
+	bot1 := env.CreateBot(t, rand, user1.GetID())
+	bot2 := env.CreateBot(t, rand, user2.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, bot2.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("verificationToken").String().NotEmpty()
+		obj.Value("accessToken").String().NotEmpty()
+	})
+}

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -599,6 +599,16 @@ func TestHandlers_GetBotLogs(t *testing.T) {
 			Status(http.StatusUnauthorized)
 	})
 
+	t.Run("bad request (negative limit)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("limit", -1).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
 	t.Run("forbidden", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
@@ -854,21 +864,21 @@ func TestHandlers_LetBotJoinChannel(t *testing.T) {
 	t.Run("bad request (nil id)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
-		e.POST(path, bot2.ID.String()).
+		e.POST(path, bot1.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PostBotActionJoinRequest{ChannelID: uuid.Nil}).
 			Expect().
-			Status(http.StatusForbidden)
+			Status(http.StatusBadRequest)
 	})
 
 	t.Run("bad request (dm)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
-		e.POST(path, bot2.ID.String()).
+		e.POST(path, bot1.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PostBotActionJoinRequest{ChannelID: dm.ID}).
 			Expect().
-			Status(http.StatusForbidden)
+			Status(http.StatusBadRequest)
 	})
 
 	t.Run("forbidden", func(t *testing.T) {
@@ -903,7 +913,7 @@ func TestHandlers_LetBotJoinChannel(t *testing.T) {
 }
 
 func TestHandlers_LetBotLeaveChannel(t *testing.T) {
-	path := "/api/v3/bots/{botId}/actions/join"
+	path := "/api/v3/bots/{botId}/actions/leave"
 	env := Setup(t, common1)
 	user1 := env.CreateUser(t, rand)
 	user2 := env.CreateUser(t, rand)
@@ -926,11 +936,11 @@ func TestHandlers_LetBotLeaveChannel(t *testing.T) {
 	t.Run("bad request (nil id)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
-		e.POST(path, bot2.ID.String()).
+		e.POST(path, bot1.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PostBotActionJoinRequest{ChannelID: uuid.Nil}).
 			Expect().
-			Status(http.StatusForbidden)
+			Status(http.StatusBadRequest)
 	})
 
 	t.Run("forbidden", func(t *testing.T) {

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -317,12 +317,32 @@ func TestHandlers_EditBot(t *testing.T) {
 			Status(http.StatusUnauthorized)
 	})
 
-	t.Run("bad request (display name)", func(t *testing.T) {
+	t.Run("bad request (empty display name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PatchBotRequest{DisplayName: optional.StringFrom("")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (too long display name)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PATCH(path, bot1.ID.String()).
 			WithCookie(session.CookieName, commonSession).
 			WithJSON(&PatchBotRequest{DisplayName: optional.StringFrom(strings.Repeat("a", 100))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (empty endpoint)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, bot1.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PatchBotRequest{Endpoint: optional.StringFrom("")}).
 			Expect().
 			Status(http.StatusBadRequest)
 	})

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/traPtitech/traQ/router/session"
 	"github.com/traPtitech/traQ/service/bot/event"
 	"github.com/traPtitech/traQ/utils/optional"
-	"github.com/traPtitech/traQ/utils/random"
-	"github.com/traPtitech/traQ/utils/set"
 )
 
 func botEquals(t *testing.T, expect *model.Bot, actual *httpexpect.Object) {
@@ -842,15 +840,7 @@ func TestHandlers_LetBotJoinChannel(t *testing.T) {
 	bot1 := env.CreateBot(t, rand, user1.GetID())
 	bot2 := env.CreateBot(t, rand, user2.GetID())
 	channel := env.CreateChannel(t, rand)
-	dm, err := env.Repository.CreateChannel(
-		model.Channel{
-			Name:      "dm_" + random.AlphaNumeric(17),
-			IsVisible: true,
-		},
-		set.UUIDSetFromArray([]uuid.UUID{user1.GetID(), user2.GetID()}),
-		true,
-	)
-	require.NoError(t, err)
+	dm := env.CreateDMChannel(t, user1.GetID(), user2.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -1,0 +1,208 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func TestHandlers_GetBots(t *testing.T) {
+	t.Parallel()
+	path := "/api/v3/bots"
+	env := Setup(t, s1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	commonSession := env.S(t, user1.GetID())
+	bot1 := env.CreateBot(t, rand, user1.GetID())
+	env.CreateBot(t, rand, user2.GetID())
+
+	botEquals := func(expect *model.Bot, actual *httpexpect.Object) {
+		actual.Value("id").String().Equal(expect.ID.String())
+		actual.Value("botUserId").String().Equal(expect.BotUserID.String())
+		actual.Value("description").String().Equal(expect.Description)
+		actual.Value("developerId").String().Equal(expect.CreatorID.String())
+		actual.Value("subscribeEvents").Array().Length().Equal(len(expect.SubscribeEvents.Array()))
+		actual.Value("state").Number().Equal(expect.State)
+		actual.Value("createdAt").String().NotEmpty()
+		actual.Value("updatedAt").String().NotEmpty()
+	}
+
+	t.Run("NotLoggedIn", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success (all=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", false).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		botEquals(bot1, obj.Element(0).Object())
+	})
+
+	t.Run("success (all=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+	})
+}
+
+func TestPostBotRequest_Validate(t *testing.T) {
+	type fields struct {
+		Name        string
+		DisplayName string
+		Description string
+		Endpoint    string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{Name: "", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"},
+			true,
+		},
+		{
+			"bad name",
+			fields{Name: "ボットくん", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"},
+			true,
+		},
+		{
+			"empty display name",
+			fields{Name: "name", DisplayName: "", Description: "desc", Endpoint: "https://example.com"},
+			true,
+		},
+		{
+			"bad display name",
+			fields{Name: "name", DisplayName: strings.Repeat("a", 100), Description: "desc", Endpoint: "https://example.com"},
+			true,
+		},
+		{
+			"empty desc",
+			fields{Name: "name", DisplayName: "po", Description: "", Endpoint: "https://example.com"},
+			true,
+		},
+		{
+			"empty endpoint",
+			fields{Name: "name", DisplayName: "po", Description: "desc", Endpoint: ""},
+			true,
+		},
+		{
+			"bad endpoint (not url)",
+			fields{Name: "name", DisplayName: "po", Description: "desc", Endpoint: "bad_url"},
+			true,
+		},
+		{
+			"bad endpoint (internal)",
+			fields{Name: "name", DisplayName: "po", Description: "desc", Endpoint: "https://0.0.0.0:3000"},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "name", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostBotRequest{
+				Name:        tt.fields.Name,
+				DisplayName: tt.fields.DisplayName,
+				Description: tt.fields.Description,
+				Endpoint:    tt.fields.Endpoint,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_CreateBot(t *testing.T) {
+	t.Parallel()
+	path := "/api/v3/bots"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	commonSession := env.S(t, user.GetID())
+	env.CreateBot(t, "575", user.GetID())
+
+	t.Run("NotLoggedIn", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostBotRequest{Name: "ボットくん", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostBotRequest{Name: "575", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostBotRequest{Name: "77", DisplayName: "po", Description: "desc", Endpoint: "https://example.com"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("botUserId").String().NotEmpty()
+		obj.Value("description").String().Equal("desc")
+		obj.Value("subscribeEvents").Array().Length().Equal(0)
+		obj.Value("state").Number().Equal(model.BotInactive)
+		obj.Value("developerId").String().Equal(user.GetID().String())
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("tokens").Object().Value("verificationToken").String().NotEmpty()
+		obj.Value("tokens").Object().Value("accessToken").String().NotEmpty()
+		obj.Value("endpoint").String().Equal("https://example.com")
+		obj.Value("privileged").Boolean().False()
+		obj.Value("channels").Array().Length().Equal(0)
+	})
+}

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -1,9 +1,14 @@
 package v3
 
 import (
+	"net/http"
+	"strconv"
+	"strings"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
@@ -14,9 +19,6 @@ import (
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/set"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 // GetChannels GET /channels
@@ -230,10 +232,6 @@ type channelEventsQuery struct {
 	Order     string        `query:"order"`
 }
 
-func (q *channelEventsQuery) bind(c echo.Context) error {
-	return bindAndValidate(c, q)
-}
-
 func (q *channelEventsQuery) Validate() error {
 	if q.Limit == 0 {
 		q.Limit = 20
@@ -261,7 +259,7 @@ func (h *Handlers) GetChannelEvents(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
 	var req channelEventsQuery
-	if err := req.bind(c); err != nil {
+	if err := bindAndValidate(c, &req); err != nil {
 		return err
 	}
 

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -96,7 +96,7 @@ type PatchChannelRequest struct {
 
 func (r PatchChannelRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, validator.ChannelNameRule...),
+		vd.Field(&r.Name, append(validator.ChannelNameRule, validator.RequiredIfValid)...),
 	)
 }
 

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -342,6 +342,11 @@ func TestPatchChannelRequest_Validate(t *testing.T) {
 			false,
 		},
 		{
+			"empty name",
+			fields{Name: optional.StringFrom("")},
+			true,
+		},
+		{
 			"invalid name",
 			fields{Name: optional.StringFrom("チャンネル")},
 			true,

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -13,9 +13,37 @@ import (
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/service/message"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/random"
+	"github.com/traPtitech/traQ/utils/set"
 )
+
+func messageStampEquals(t *testing.T, expect model.MessageStamp, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("userId").String().Equal(expect.UserID.String())
+	actual.Value("stampId").String().Equal(expect.StampID.String())
+	actual.Value("count").Number().Equal(expect.Count)
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+}
+
+func messageEquals(t *testing.T, expect message.Message, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.GetID().String())
+	actual.Value("userId").String().Equal(expect.GetUserID().String())
+	actual.Value("channelId").String().Equal(expect.GetChannelID().String())
+	actual.Value("content").String().Equal(expect.GetText())
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+	actual.Value("pinned").Boolean().Equal(expect.GetPin() != nil)
+
+	stamps := actual.Value("stamps").Array()
+	stamps.Length().Equal(len(expect.GetStamps()))
+	for i, ex := range expect.GetStamps() {
+		messageStampEquals(t, ex, stamps.Element(i).Object())
+	}
+}
 
 func channelEquals(t *testing.T, expect *model.Channel, actual *httpexpect.Object) {
 	t.Helper()
@@ -37,6 +65,7 @@ func channelEquals(t *testing.T, expect *model.Channel, actual *httpexpect.Objec
 }
 
 func TestHandlers_GetChannels(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels"
 	env := Setup(t, s2)
 	user1 := env.CreateUser(t, rand)
@@ -137,6 +166,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 }
 
 func TestPostChannelRequest_Validate(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Name   string
 		Parent optional.UUID
@@ -181,6 +211,7 @@ func TestPostChannelRequest_Validate(t *testing.T) {
 }
 
 func TestHandlers_CreateChannels(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels"
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
@@ -254,6 +285,7 @@ func TestHandlers_CreateChannels(t *testing.T) {
 }
 
 func TestHandlers_GetChannel(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels/{channelId}"
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
@@ -292,6 +324,7 @@ func TestHandlers_GetChannel(t *testing.T) {
 }
 
 func TestPatchChannelRequest_Validate(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Name     optional.String
 		Archived optional.Bool
@@ -345,6 +378,7 @@ func TestPatchChannelRequest_Validate(t *testing.T) {
 }
 
 func TestHandlers_EditChannel(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels/{channelId}"
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
@@ -444,13 +478,14 @@ func TestHandlers_EditChannel(t *testing.T) {
 }
 
 func TestHandlers_GetChannelStats(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels/{channelId}/stats"
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
 	channel := env.CreateChannel(t, rand)
-	message := env.CreateMessage(t, user.GetID(), channel.ID, rand)
+	m := env.CreateMessage(t, user.GetID(), channel.ID, rand)
 	stamp := env.CreateStamp(t, user.GetID(), rand)
-	env.AddStampToMessage(t, message.GetID(), stamp.ID, user.GetID())
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
 	commonSession := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -498,6 +533,7 @@ func TestHandlers_GetChannelStats(t *testing.T) {
 }
 
 func TestHandlers_GetChannelTopic(t *testing.T) {
+	t.Parallel()
 	path := "/api/v3/channels/{channelId}/topic"
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
@@ -533,5 +569,550 @@ func TestHandlers_GetChannelTopic(t *testing.T) {
 			Object().
 			Value("topic").
 			Equal("this is channel topic")
+	})
+}
+
+func TestHandlers_EditChannelTopic(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/topic"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	channel := env.CreateChannel(t, rand)
+	archived := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, channel.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelTopicRequest{Topic: "test"}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request (archived)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, archived.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelTopicRequest{Topic: "test"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelTopicRequest{Topic: "test"}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ch, err := env.CM.GetChannel(channel.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, "test", ch.Topic)
+
+		e.PUT(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelTopicRequest{Topic: ""}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ch, err = env.CM.GetChannel(channel.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, "", ch.Topic)
+	})
+}
+
+func TestHandlers_GetChannelPins(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/pins"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	channel := env.CreateChannel(t, rand)
+	m1 := env.CreateMessage(t, user.GetID(), channel.ID, rand)
+	env.CreateMessage(t, user.GetID(), channel.ID, rand)
+	_, err := env.MM.Pin(m1.GetID(), user.GetID())
+	require.NoError(t, err)
+	m1, err = env.MM.Get(m1.GetID())
+	require.NoError(t, err)
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, channel.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("userId").String().Equal(user.GetID().String())
+		first.Value("pinnedAt").String().NotEmpty()
+
+		messageEquals(t, m1, first.Value("message").Object())
+	})
+}
+
+func Test_channelEventsQuery_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Limit     int
+		Offset    int
+		Since     optional.Time
+		Until     optional.Time
+		Inclusive bool
+		Order     string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"zero",
+			fields{},
+			false,
+		},
+		{
+			"negative offset",
+			fields{Offset: -1},
+			true,
+		},
+		{
+			"too large limit",
+			fields{Limit: 1000},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &channelEventsQuery{
+				Limit:     tt.fields.Limit,
+				Offset:    tt.fields.Offset,
+				Since:     tt.fields.Since,
+				Until:     tt.fields.Until,
+				Inclusive: tt.fields.Inclusive,
+				Order:     tt.fields.Order,
+			}
+			if err := q.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_GetChannelEvents(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/events"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	channel := env.CreateChannel(t, rand)
+	// TopicChanged
+	require.NoError(t, env.CM.UpdateChannel(channel.ID, repository.UpdateChannelArgs{UpdaterID: user.GetID(), Topic: optional.StringFrom("test topic")}))
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, channel.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("limit", -1).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("type").String().Equal("TopicChanged")
+		first.Value("datetime").String().NotEmpty()
+
+		detail := first.Value("detail").Object()
+		detail.Value("userId").String().Equal(user.GetID().String())
+		detail.Value("before").String().Equal("")
+		detail.Value("after").String().Equal("test topic")
+	})
+}
+
+func TestHandlers_GetChannelSubscribers(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/subscribers"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	channel := env.CreateChannel(t, rand)
+	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+		user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+	}, false, user.GetID())
+	require.NoError(t, err)
+	forced := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.BoolFrom(true)}))
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, channel.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("forbidden (forced)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, forced.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, dm.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		obj.First().String().Equal(user.GetID().String())
+	})
+}
+
+func TestHandlers_SetChannelSubscribers(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/subscribers"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	// user: none
+	// user2: mark and notify
+	channel := env.CreateChannel(t, rand)
+	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+		user2.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+	}, false, user.GetID())
+	require.NoError(t, err)
+	forced := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.BoolFrom(true)}))
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, channel.ID).
+			WithJSON(&PutChannelSubscribersRequest{On: set.UUID{user.GetID(): struct{}{}}}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelSubscribersRequest{On: set.UUID{user.GetID(): struct{}{}}}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("forbidden (forced)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, forced.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelSubscribersRequest{On: set.UUID{user.GetID(): struct{}{}}}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, dm.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelSubscribersRequest{On: set.UUID{user.GetID(): struct{}{}}}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PutChannelSubscribersRequest{On: set.UUID{user.GetID(): struct{}{}}}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.UUIDFrom(channel.ID)})
+		require.NoError(t, err)
+
+		if assert.Len(t, subs, 1) {
+			require.EqualValues(t, channel.ID, subs[0].ChannelID)
+			assert.EqualValues(t, user.GetID(), subs[0].UserID)
+			assert.True(t, subs[0].Mark)
+			assert.True(t, subs[0].Notify)
+		}
+	})
+}
+
+func TestHandlers_EditChannelSubscribers(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/subscribers"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	user4 := env.CreateUser(t, rand)
+	user5 := env.CreateUser(t, rand)
+	// user: none
+	// user2: mark
+	// user3: mark and notify
+	// user4: mark and notify
+	// user5: mark and notify
+	channel := env.CreateChannel(t, rand)
+	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+		user2.GetID(): model.ChannelSubscribeLevelMark,
+		user3.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+		user4.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+		user5.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+	}, false, user.GetID())
+	require.NoError(t, err)
+	forced := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.BoolFrom(true)}))
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	commonSession := env.S(t, user.GetID())
+
+	req := &PatchChannelSubscribersRequest{
+		On: set.UUID{
+			user.GetID():  struct{}{},
+			user5.GetID(): struct{}{},
+		},
+		Off: set.UUID{
+			user2.GetID(): struct{}{},
+			user3.GetID(): struct{}{},
+			user5.GetID(): struct{}{},
+		},
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, channel.ID).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("forbidden (forced)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, forced.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, dm.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, channel.ID.String()).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNoContent)
+
+		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.UUIDFrom(channel.ID)})
+		require.NoError(t, err)
+
+		if assert.Len(t, subs, 4) {
+			require.EqualValues(t, channel.ID, subs[0].ChannelID)
+			require.EqualValues(t, channel.ID, subs[1].ChannelID)
+			require.EqualValues(t, channel.ID, subs[2].ChannelID)
+			require.EqualValues(t, channel.ID, subs[3].ChannelID)
+
+			subsMap := map[uuid.UUID]model.ChannelSubscribeLevel{}
+			for _, subscription := range subs {
+				if subscription.Mark && subscription.Notify {
+					subsMap[subscription.UserID] = model.ChannelSubscribeLevelMarkAndNotify
+				} else if subscription.Mark {
+					subsMap[subscription.UserID] = model.ChannelSubscribeLevelMark
+				} else {
+					subsMap[subscription.UserID] = model.ChannelSubscribeLevelNone
+				}
+			}
+
+			assert.EqualValues(t, model.ChannelSubscribeLevelMarkAndNotify, subsMap[user.GetID()])
+			assert.EqualValues(t, model.ChannelSubscribeLevelMark, subsMap[user2.GetID()])
+			assert.EqualValues(t, model.ChannelSubscribeLevelMarkAndNotify, subsMap[user4.GetID()])
+			assert.EqualValues(t, model.ChannelSubscribeLevelMarkAndNotify, subsMap[user5.GetID()])
+		}
+	})
+}
+
+func TestHandlers_GetUserDMChannel(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/dm-channel"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user2.GetID().String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (existing dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user2.GetID().String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("id").String().Equal(dm.ID.String())
+		obj.Value("userId").String().Equal(user2.GetID().String())
+	})
+
+	t.Run("success (creating dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user3.GetID().String()).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty().NotEqual(dm.ID.String())
+		obj.Value("userId").String().Equal(user3.GetID().String())
 	})
 }

--- a/router/v3/clients.go
+++ b/router/v3/clients.go
@@ -99,9 +99,9 @@ type PatchClientRequest struct {
 
 func (r PatchClientRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, vd.RuneLength(1, 32)),
-		vd.Field(&r.Description, vd.RuneLength(1, 1000)),
-		vd.Field(&r.CallbackURL, is.URL),
+		vd.Field(&r.Name, validator.RequiredIfValid, vd.RuneLength(1, 32)),
+		vd.Field(&r.Description, validator.RequiredIfValid, vd.RuneLength(1, 1000)),
+		vd.Field(&r.CallbackURL, validator.RequiredIfValid, is.URL),
 		vd.Field(&r.DeveloperID, validator.NotNilUUID),
 	)
 }

--- a/router/v3/clients.go
+++ b/router/v3/clients.go
@@ -1,9 +1,12 @@
 package v3
 
 import (
+	"net/http"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/extension/herror"
@@ -11,7 +14,6 @@ import (
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/random"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
 )
 
 // GetClients GET /clients

--- a/router/v3/clients_test.go
+++ b/router/v3/clients_test.go
@@ -1,0 +1,537 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/optional"
+	"github.com/traPtitech/traQ/utils/random"
+)
+
+func oAuth2ClientEquals(t *testing.T, expect *model.OAuth2Client, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.ID)
+	actual.Value("name").String().Equal(expect.Name)
+	actual.Value("description").String().Equal(expect.Description)
+	actual.Value("developerId").String().Equal(expect.CreatorID.String())
+	scopes := make([]interface{}, 0, len(expect.Scopes.StringArray()))
+	for _, scope := range expect.Scopes.StringArray() {
+		scopes = append(scopes, scope)
+	}
+	actual.Value("scopes").Array().Elements(scopes...)
+}
+
+func TestHandlers_GetClients(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clients"
+	env := Setup(t, s1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	c1 := env.CreateOAuth2Client(t, rand, user.GetID())
+	c2 := env.CreateOAuth2Client(t, rand, user2.GetID())
+	commonSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success (all=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		oAuth2ClientEquals(t, c1, first)
+	})
+
+	t.Run("success (all=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, commonSession).
+			WithQuery("all", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+
+		first := obj.Element(0).Object()
+		second := obj.Element(1).Object()
+
+		if first.Value("id").String().Raw() == c1.ID {
+			oAuth2ClientEquals(t, c1, first)
+			oAuth2ClientEquals(t, c2, second)
+		} else {
+			oAuth2ClientEquals(t, c2, first)
+			oAuth2ClientEquals(t, c1, second)
+		}
+	})
+}
+
+func TestPostClientsRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        string
+		Description string
+		CallbackURL string
+		Scopes      model.AccessScopes
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{
+				Name:        "",
+				Description: "desc",
+				CallbackURL: "https://example.com",
+				Scopes: map[model.AccessScope]struct{}{
+					"read": {},
+				},
+			},
+			true,
+		},
+		{
+			"too long name",
+			fields{
+				Name:        strings.Repeat("a", 100),
+				Description: "desc",
+				CallbackURL: "https://example.com",
+				Scopes: map[model.AccessScope]struct{}{
+					"read": {},
+				},
+			},
+			true,
+		},
+		{
+			"empty callback",
+			fields{
+				Name:        "test",
+				Description: "desc",
+				CallbackURL: "",
+				Scopes: map[model.AccessScope]struct{}{
+					"read": {},
+				},
+			},
+			true,
+		},
+		{
+			"empty scopes",
+			fields{
+				Name:        "test",
+				Description: "desc",
+				CallbackURL: "https://example.com",
+				Scopes:      map[model.AccessScope]struct{}{},
+			},
+			true,
+		},
+		{
+			"success",
+			fields{
+				Name:        "test",
+				Description: "desc",
+				CallbackURL: "https://example.com",
+				Scopes: map[model.AccessScope]struct{}{
+					"read": {},
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostClientsRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				CallbackURL: tt.fields.CallbackURL,
+				Scopes:      tt.fields.Scopes,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_CreateClient(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clients"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	commonSession := env.S(t, user.GetID())
+
+	req := &PostClientsRequest{
+		Name:        "test",
+		Description: "desc",
+		CallbackURL: "https://example.com",
+		Scopes:      map[model.AccessScope]struct{}{"read": {}},
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostClientsRequest{Name: "test", Description: "desc", CallbackURL: "https://example.com"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("developerId").String().Equal(user.GetID().String())
+		obj.Value("description").String().Equal("desc")
+		obj.Value("name").String().Equal("test")
+		scopes := obj.Value("scopes").Array()
+		scopes.Length().Equal(1)
+		scopes.First().String().Equal("read")
+		obj.Value("callbackUrl").String().Equal("https://example.com")
+		obj.Value("secret").String().NotEmpty()
+
+		c, err := env.Repository.GetClient(obj.Value("id").String().Raw())
+		assert.NoError(t, err)
+		oAuth2ClientEquals(t, c, obj)
+	})
+}
+
+func TestHandlers_GetClient(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clients/{clientId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	c1 := env.CreateOAuth2Client(t, rand, user1.GetID())
+	c2 := env.CreateOAuth2Client(t, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, c1.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, c2.ID).
+			WithCookie(session.CookieName, user1Session).
+			WithQuery("detail", true).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, random.AlphaNumeric(36)).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (c1, detail=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, c1.ID).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		oAuth2ClientEquals(t, c1, obj)
+	})
+
+	t.Run("success (c2, detail=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, c2.ID).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		oAuth2ClientEquals(t, c2, obj)
+	})
+
+	t.Run("success (c1, detail=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, c1.ID).
+			WithCookie(session.CookieName, user1Session).
+			WithQuery("detail", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		oAuth2ClientEquals(t, c1, obj)
+		obj.Value("callbackUrl").String().NotEmpty()
+		obj.Value("secret").String().NotEmpty()
+	})
+
+	t.Run("success (c1, admin, detail=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, c1.ID).
+			WithCookie(session.CookieName, adminSession).
+			WithQuery("detail", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		oAuth2ClientEquals(t, c1, obj)
+		obj.Value("callbackUrl").String().NotEmpty()
+		obj.Value("secret").String().NotEmpty()
+	})
+}
+
+func TestPatchClientRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        optional.String
+		Description optional.String
+		CallbackURL optional.String
+		DeveloperID optional.UUID
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"too long name",
+			fields{Name: optional.StringFrom(strings.Repeat("a", 100))},
+			true,
+		},
+		{
+			"invalid developer id",
+			fields{DeveloperID: optional.UUIDFrom(uuid.Nil)},
+			true,
+		},
+		{
+			"success",
+			fields{Name: optional.StringFrom("po")},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PatchClientRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				CallbackURL: tt.fields.CallbackURL,
+				DeveloperID: tt.fields.DeveloperID,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditClient(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clients/{clientId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	c1 := env.CreateOAuth2Client(t, rand, user1.GetID())
+	c2 := env.CreateOAuth2Client(t, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, c1.ID).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, c1.ID).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom(strings.Repeat("a", 100))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, c2.ID).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, random.AlphaNumeric(36)).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (user1, c1)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, c1.ID).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		c, err := env.Repository.GetClient(c1.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, c.Name, "po")
+	})
+
+	t.Run("success (admin, c2)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, c2.ID).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PatchClientRequest{Name: optional.StringFrom("po2")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		c, err := env.Repository.GetClient(c2.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, c.Name, "po2")
+	})
+}
+
+func TestHandlers_DeleteClient(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clients/{clientId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	c1 := env.CreateOAuth2Client(t, rand, user1.GetID())
+	c2 := env.CreateOAuth2Client(t, rand, user2.GetID())
+	c3 := env.CreateOAuth2Client(t, rand, user1.GetID())
+	c4 := env.CreateOAuth2Client(t, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, c3.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, c4.ID).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, random.AlphaNumeric(36)).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (user1, c1)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, c1.ID).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetClient(c1.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+
+	t.Run("success (admin, c2)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, c2.ID).
+			WithCookie(session.CookieName, adminSession).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetClient(c2.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}

--- a/router/v3/clients_test.go
+++ b/router/v3/clients_test.go
@@ -359,8 +359,28 @@ func TestPatchClientRequest_Validate(t *testing.T) {
 			false,
 		},
 		{
+			"empty name",
+			fields{Name: optional.StringFrom("")},
+			true,
+		},
+		{
 			"too long name",
 			fields{Name: optional.StringFrom(strings.Repeat("a", 100))},
+			true,
+		},
+		{
+			"empty description",
+			fields{Description: optional.StringFrom("")},
+			true,
+		},
+		{
+			"empty callback url",
+			fields{CallbackURL: optional.StringFrom("")},
+			true,
+		},
+		{
+			"nil developer id",
+			fields{DeveloperID: optional.UUIDFrom(uuid.Nil)},
 			true,
 		},
 		{

--- a/router/v3/clients_test.go
+++ b/router/v3/clients_test.go
@@ -27,7 +27,7 @@ func oAuth2ClientEquals(t *testing.T, expect *model.OAuth2Client, actual *httpex
 	for _, scope := range expect.Scopes.StringArray() {
 		scopes = append(scopes, scope)
 	}
-	actual.Value("scopes").Array().Elements(scopes...)
+	actual.Value("scopes").Array().ContainsOnly(scopes...)
 }
 
 func TestHandlers_GetClients(t *testing.T) {

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -1,15 +1,17 @@
 package v3
 
 import (
-	"github.com/traPtitech/traQ/service/message"
-	"github.com/traPtitech/traQ/utils/optional"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/optional"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
@@ -81,12 +83,7 @@ func (h *Handlers) DeleteClipFolder(c echo.Context) error {
 	folderID := getParamAsUUID(c, consts.ParamClipFolderID)
 
 	if err := h.Repo.DeleteClipFolder(folderID); err != nil {
-		switch {
-		case err == repository.ErrNotFound:
-			return herror.NotFound("clip folder not found")
-		default:
-			return herror.InternalServerError(err)
-		}
+		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -101,12 +98,7 @@ func (h *Handlers) EditClipFolder(c echo.Context) error {
 	}
 
 	if err := h.Repo.UpdateClipFolder(cf.ID, req.Name, req.Description); err != nil {
-		switch {
-		case err == repository.ErrNotFound:
-			return herror.NotFound("clip folder not found")
-		default:
-			return herror.InternalServerError(err)
-		}
+		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -148,8 +140,6 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 		switch {
 		case err == repository.ErrAlreadyExists:
 			return herror.Conflict("clip folder message conflicts")
-		case err == repository.ErrNotFound:
-			return herror.NotFound("clip folder not found")
 		default:
 			return herror.InternalServerError(err)
 		}
@@ -207,10 +197,6 @@ func (h *Handlers) DeleteClipFolderMessages(c echo.Context) error {
 
 	cf := getParamClipFolder(c)
 	if err := h.Repo.DeleteClipFolderMessage(cf.ID, messageID); err != nil {
-		switch {
-		case err == repository.ErrNotFound:
-			return herror.NotFound("clip folder not found")
-		}
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -38,7 +38,7 @@ type UpdateClipFolderRequest struct {
 
 func (r UpdateClipFolderRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, validator.ClipFolderNameRule...),
+		vd.Field(&r.Name, append(validator.ClipFolderNameRule, validator.RequiredIfValid)...),
 		vd.Field(&r.Description, validator.ClipFolderDescriptionRule...),
 	)
 }

--- a/router/v3/clips_test.go
+++ b/router/v3/clips_test.go
@@ -1,0 +1,681 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/optional"
+)
+
+func clipFolderEquals(t *testing.T, expect *model.ClipFolder, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.ID.String())
+	actual.Value("name").String().Equal(expect.Name)
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("ownerId").String().Equal(expect.OwnerID.String())
+	actual.Value("description").String().Equal(expect.Description)
+}
+
+func TestPostClipFolderRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        string
+		Description string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{Name: "", Description: "foo"},
+			true,
+		},
+		{
+			"too long name",
+			fields{Name: strings.Repeat("a", 100), Description: "foo"},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "test", Description: "foo"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostClipFolderRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateClipFolderRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        optional.String
+		Description optional.String
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"too long name",
+			fields{Name: optional.StringFrom(strings.Repeat("a", 100))},
+			true,
+		},
+		{
+			"success",
+			fields{Name: optional.StringFrom("test")},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := UpdateClipFolderRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_CreateClipFolder(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	userSession := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PostClipFolderRequest{Name: strings.Repeat("a", 100), Description: "desc"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PostClipFolderRequest{Name: "nya", Description: "desc"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("name").String().Equal("nya")
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("ownerId").String().Equal(user.GetID().String())
+		obj.Value("description").String().Equal("desc")
+
+		id := obj.Value("id").String().Raw()
+
+		// overlapping name
+		obj = e.POST(path).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PostClipFolderRequest{Name: "nya", Description: "desc"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty().NotEqual(id)
+		obj.Value("name").String().Equal("nya")
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("ownerId").String().Equal(user.GetID().String())
+		obj.Value("description").String().Equal("desc")
+	})
+}
+
+func TestHandlers_GetClipFolders(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	env.CreateClipFolder(t, rand, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		clipFolderEquals(t, cf1, obj.First().Object())
+	})
+}
+
+func TestHandlers_GetClipFolder(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, cf1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, cf2.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		clipFolderEquals(t, cf1, obj)
+	})
+}
+
+func TestHandlers_DeleteClipFolder(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf2.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetClipFolder(cf1.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_EditClipFolder(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	user1Session := env.S(t, user1.GetID())
+
+	req := &UpdateClipFolderRequest{
+		Name:        optional.StringFrom("nya"),
+		Description: optional.StringFrom("foo"),
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, cf1.ID.String()).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&UpdateClipFolderRequest{Name: optional.StringFrom(strings.Repeat("a", 100))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, cf2.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNoContent)
+
+		cf, err := env.Repository.GetClipFolder(cf1.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, "nya", cf.Name)
+		assert.EqualValues(t, "foo", cf.Description)
+	})
+}
+
+func TestHandlers_PostClipFolderMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}/messages"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	cf3 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	c := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user2.GetID(), c.ID, rand)
+	user1Session := env.S(t, user1.GetID())
+
+	_, err := env.Repository.AddClipFolderMessage(cf3.ID, m.GetID())
+	require.NoError(t, err)
+
+	req := &PostClipFolderMessageRequest{
+		MessageID: m.GetID(),
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, cf1.ID.String()).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(map[string]interface{}{"messageId": "po"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (message not found)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(&PostClipFolderMessageRequest{MessageID: uuid.Must(uuid.NewV4())}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, cf2.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found (clip folder)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, cf3.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		messageEquals(t, m, obj.Value("message").Object())
+		obj.Value("clippedAt").String().NotEmpty()
+	})
+}
+
+func Test_clipFolderMessageQuery_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Limit  int
+		Offset int
+		Order  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"negative limit",
+			fields{Limit: -1},
+			true,
+		},
+		{
+			"negative offset",
+			fields{Offset: -1},
+			true,
+		},
+		{
+			"too large limit",
+			fields{Limit: 500},
+			true,
+		},
+		{
+			"success",
+			fields{Limit: 50, Offset: 50, Order: "asc"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &clipFolderMessageQuery{
+				Limit:  tt.fields.Limit,
+				Offset: tt.fields.Offset,
+				Order:  tt.fields.Order,
+			}
+			if err := q.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_GetClipFolderMessages(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}/messages"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	c := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user2.GetID(), c.ID, rand)
+	user1Session := env.S(t, user1.GetID())
+
+	_, err := env.Repository.AddClipFolderMessage(cf1.ID, m.GetID())
+	require.NoError(t, err)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, cf1.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			WithQuery("limit", -1).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, cf2.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4()).String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, cf1.ID.String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		messageEquals(t, m, first.Value("message").Object())
+		first.Value("clippedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_DeleteClipFolderMessages(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/clip-folders/{folderId}/messages/{messageId}"
+	env := Setup(t, common1)
+	user1 := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	cf1 := env.CreateClipFolder(t, rand, rand, user1.GetID())
+	cf2 := env.CreateClipFolder(t, rand, rand, user2.GetID())
+	c := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user2.GetID(), c.ID, rand)
+	m2 := env.CreateMessage(t, user1.GetID(), c.ID, rand)
+	user1Session := env.S(t, user1.GetID())
+
+	_, err := env.Repository.AddClipFolderMessage(cf1.ID, m.GetID())
+	require.NoError(t, err)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf1.ID.String(), m.GetID().String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf2.ID.String(), m.GetID().String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4()).String(), m.GetID().String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (already deleted)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf1.ID, m2.GetID().String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, cf1.ID.String(), m.GetID().String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNoContent)
+
+		messages, more, err := env.Repository.GetClipFolderMessages(cf1.ID, repository.ClipFolderMessageQuery{
+			Limit:  50,
+			Offset: 0,
+			Asc:    false,
+		})
+		require.NoError(t, err)
+		assert.False(t, more)
+		assert.Len(t, messages, 0)
+
+		// already deleted
+		e.DELETE(path, cf1.ID.String(), m.GetID().String()).
+			WithCookie(session.CookieName, user1Session).
+			Expect().
+			Status(http.StatusNoContent)
+
+		messages, more, err = env.Repository.GetClipFolderMessages(cf1.ID, repository.ClipFolderMessageQuery{
+			Limit:  50,
+			Offset: 0,
+			Asc:    false,
+		})
+		require.NoError(t, err)
+		assert.False(t, more)
+		assert.Len(t, messages, 0)
+	})
+}

--- a/router/v3/clips_test.go
+++ b/router/v3/clips_test.go
@@ -84,6 +84,11 @@ func TestUpdateClipFolderRequest_Validate(t *testing.T) {
 			false,
 		},
 		{
+			"empty name",
+			fields{Name: optional.StringFrom("")},
+			true,
+		},
+		{
 			"too long name",
 			fields{Name: optional.StringFrom(strings.Repeat("a", 100))},
 			true,

--- a/router/v3/files_test.go
+++ b/router/v3/files_test.go
@@ -17,7 +17,7 @@ import (
 func TestHandlers_GetFileMeta(t *testing.T) {
 	t.Parallel()
 	path := "/api/v3/files/{fileID}/meta"
-	env := Setup(t, common)
+	env := Setup(t, common1)
 	s := env.S(t, env.CreateUser(t, rand).GetID())
 	file := env.MakeFile(t)
 

--- a/router/v3/files_test.go
+++ b/router/v3/files_test.go
@@ -140,9 +140,9 @@ func TestHandlers_GetFiles(t *testing.T) {
 	user3 := env.CreateUser(t, rand)
 	ch := env.CreateChannel(t, rand)
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
-	f1 := env.MakeFile(t, user.GetID(), uuid.Nil)
-	f2 := env.MakeFile(t, uuid.Nil, ch.ID)
-	env.MakeFile(t, uuid.Nil, dm.ID)
+	f1 := env.CreateFile(t, user.GetID(), uuid.Nil)
+	f2 := env.CreateFile(t, uuid.Nil, ch.ID)
+	env.CreateFile(t, uuid.Nil, dm.ID)
 	s := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -338,8 +338,8 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 	user3 := env.CreateUser(t, rand)
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
 	s := env.S(t, user.GetID())
-	file := env.MakeFile(t, user.GetID(), uuid.Nil)
-	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	file := env.CreateFile(t, user.GetID(), uuid.Nil)
+	secretFile := env.CreateFile(t, user2.GetID(), dm.ID)
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -444,7 +444,7 @@ func TestHandlers_GetThumbnailImage(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	user2 := env.CreateUser(t, rand)
 	user3 := env.CreateUser(t, rand)
-	f := env.MakeFile(t, user.GetID(), uuid.Nil)
+	f := env.CreateFile(t, user.GetID(), uuid.Nil)
 	require.Len(t, f.GetThumbnails(), 0)
 
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
@@ -463,7 +463,7 @@ func TestHandlers_GetThumbnailImage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	secretFile := env.CreateFile(t, user2.GetID(), dm.ID)
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -530,9 +530,9 @@ func TestHandlers_GetFile(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	user2 := env.CreateUser(t, rand)
 	user3 := env.CreateUser(t, rand)
-	f := env.MakeFile(t, user.GetID(), uuid.Nil)
+	f := env.CreateFile(t, user.GetID(), uuid.Nil)
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
-	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	secretFile := env.CreateFile(t, user2.GetID(), dm.ID)
 	s := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -581,10 +581,10 @@ func TestHandlers_DeleteFile(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	user2 := env.CreateUser(t, rand)
 	user3 := env.CreateUser(t, rand)
-	f := env.MakeFile(t, user.GetID(), uuid.Nil)
-	f2 := env.MakeFile(t, user2.GetID(), uuid.Nil)
+	f := env.CreateFile(t, user.GetID(), uuid.Nil)
+	f2 := env.CreateFile(t, user2.GetID(), uuid.Nil)
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
-	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	secretFile := env.CreateFile(t, user2.GetID(), dm.ID)
 	s := env.S(t, user.GetID())
 
 	iconFile, err := file2.GenerateIconFile(env.FM, "test")

--- a/router/v3/files_test.go
+++ b/router/v3/files_test.go
@@ -2,37 +2,373 @@ package v3
 
 import (
 	"bytes"
-	"github.com/go-audio/audio"
-	"github.com/go-audio/wav"
-	"github.com/orcaman/writerseeker"
-	"github.com/stretchr/testify/require"
-	"github.com/traPtitech/traQ/model"
-	"github.com/traPtitech/traQ/router/session"
-	file2 "github.com/traPtitech/traQ/service/file"
+	"crypto/md5"
+	"encoding/hex"
 	"math"
 	"net/http"
 	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+	"github.com/gofrs/uuid"
+	"github.com/orcaman/writerseeker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/router/session"
+	file2 "github.com/traPtitech/traQ/service/file"
+	"github.com/traPtitech/traQ/utils/optional"
 )
 
-func TestHandlers_GetFileMeta(t *testing.T) {
+func fileEquals(t *testing.T, expect model.File, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.GetID().String())
+	actual.Value("name").String().Equal(expect.GetFileName())
+	actual.Value("mime").String().Equal(expect.GetMIMEType())
+	actual.Value("size").Number().Equal(expect.GetFileSize())
+	actual.Value("md5").String().Equal(expect.GetMD5Hash())
+	actual.Value("isAnimatedImage").Boolean().Equal(expect.IsAnimatedImage())
+	actual.Value("thumbnails").Array().Length().Equal(len(expect.GetThumbnails()))
+	actual.Value("channelId").Equal(expect.GetUploadChannelID())
+	actual.Value("uploaderId").Equal(expect.GetCreatorID())
+}
+
+func genSampleAudio(t *testing.T) *bytes.Reader {
+	t.Helper()
+
+	const (
+		sampleRate = 48000
+		bitDepth   = 16
+		length     = 0.1
+	)
+
+	sinWave := func(amplitude, frequency, t float64) float64 {
+		return amplitude * math.Sin(frequency*2*math.Pi*t)
+	}
+
+	buf := &writerseeker.WriterSeeker{}
+	e := wav.NewEncoder(buf, sampleRate, bitDepth, 1, 1)
+
+	data := make([]int, sampleRate*length)
+	for i := 0; i < sampleRate*length; i++ {
+		data[i] = int(sinWave(math.Pow(2, 15)-1, 440, float64(i)/sampleRate))
+	}
+
+	require.NoError(t, e.Write(&audio.IntBuffer{
+		Format: &audio.Format{
+			NumChannels: 1,
+			SampleRate:  sampleRate,
+		},
+		Data:           data,
+		SourceBitDepth: bitDepth,
+	}))
+	require.NoError(t, e.Close())
+
+	return buf.BytesReader()
+}
+
+func TestGetFilesRequest_Validate(t *testing.T) {
+	type fields struct {
+		Limit     int
+		Offset    int
+		Since     optional.Time
+		Until     optional.Time
+		Inclusive bool
+		Order     string
+		ChannelID uuid.UUID
+		Mine      bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"zero limit",
+			fields{Limit: 0, Mine: true},
+			false,
+		},
+		{
+			"too large limit",
+			fields{Limit: 500, Mine: true},
+			true,
+		},
+		{
+			"neither mine or in specific channel",
+			fields{},
+			true,
+		},
+		{
+			"in channel",
+			fields{ChannelID: uuid.Must(uuid.NewV4())},
+			false,
+		},
+		{
+			"mine",
+			fields{Mine: true},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &GetFilesRequest{
+				Limit:     tt.fields.Limit,
+				Offset:    tt.fields.Offset,
+				Since:     tt.fields.Since,
+				Until:     tt.fields.Until,
+				Inclusive: tt.fields.Inclusive,
+				Order:     tt.fields.Order,
+				ChannelID: tt.fields.ChannelID,
+				Mine:      tt.fields.Mine,
+			}
+			if err := q.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_GetFiles(t *testing.T) {
 	t.Parallel()
-	path := "/api/v3/files/{fileID}/meta"
+
+	path := "/api/v3/files"
 	env := Setup(t, common1)
-	s := env.S(t, env.CreateUser(t, rand).GetID())
-	file := env.MakeFile(t)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	f1 := env.MakeFile(t, user.GetID(), uuid.Nil)
+	f2 := env.MakeFile(t, uuid.Nil, ch.ID)
+	env.MakeFile(t, uuid.Nil, dm.ID)
+	s := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
 
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("channelId", dm.ID.String()).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (mine)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("mine", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		fileEquals(t, f1, obj.First().Object())
+	})
+
+	t.Run("success (channel)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("channelId", ch.ID.String()).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		fileEquals(t, f2, obj.First().Object())
+	})
+}
+
+func TestHandlers_PostFile(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/files"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	dm1 := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	dm2 := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	archived := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	s := env.S(t, user.GetID())
+
+	buf := []byte("test file")
+	sum := md5.Sum(buf)
+	hexSum := hex.EncodeToString(sum[:])
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			WithFormField("channelId", ch.ID.String()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (no file)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFormField("channelId", ch.ID.String()).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (no channel id)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			WithFormField("channelId", dm2.ID.String()).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (archived)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			WithFormField("channelId", archived.ID.String()).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (public)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			WithFormField("channelId", ch.ID.String()).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("name").String().Equal("file.txt")
+		obj.Value("mime").String().NotEmpty()
+		obj.Value("size").Number().Equal(9)
+		obj.Value("md5").String().Equal(hexSum)
+		obj.Value("isAnimatedImage").Boolean().False()
+		obj.Value("thumbnails").Array().Length().Equal(0)
+		obj.Value("channelId").String().Equal(ch.ID.String())
+		obj.Value("uploaderId").String().Equal(user.GetID().String())
+	})
+
+	t.Run("success (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithMultipart().
+			WithFileBytes("file", "file.txt", buf).
+			WithFormField("channelId", dm1.ID.String()).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("name").String().Equal("file.txt")
+		obj.Value("mime").String().NotEmpty()
+		obj.Value("size").Number().Equal(9)
+		obj.Value("md5").String().Equal(hexSum)
+		obj.Value("isAnimatedImage").Boolean().False()
+		obj.Value("thumbnails").Array().Length().Equal(0)
+		obj.Value("channelId").String().Equal(dm1.ID.String())
+		obj.Value("uploaderId").String().Equal(user.GetID().String())
+	})
+}
+
+func TestHandlers_GetFileMeta(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/files/{fileId}/meta"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	s := env.S(t, user.GetID())
+	file := env.MakeFile(t, user.GetID(), uuid.Nil)
+	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
 		e := env.R(t)
 		e.GET(path, file.GetID()).
 			Expect().
 			Status(http.StatusUnauthorized)
 	})
 
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, secretFile.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-
 		e := env.R(t)
 		obj := e.GET(path, file.GetID()).
 			WithCookie(session.CookieName, s).
@@ -41,12 +377,7 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 			JSON().
 			Object()
 
-		obj.Value("id").String().Equal(file.GetID().String())
-		obj.Value("name").String().Equal(file.GetFileName())
-		obj.Value("mime").String().Equal(file.GetMIMEType())
-		obj.Value("size").Number().Equal(file.GetFileSize())
-		obj.Value("md5").String().Equal(file.GetMD5Hash())
-		obj.Value("thumbnails").Array().Length().Equal(0)
+		fileEquals(t, file, obj)
 	})
 
 	t.Run("success with image thumbnail", func(t *testing.T) {
@@ -105,36 +436,213 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 	})
 }
 
-func genSampleAudio(t *testing.T) *bytes.Reader {
-	t.Helper()
+func TestHandlers_GetThumbnailImage(t *testing.T) {
+	t.Parallel()
 
-	const (
-		sampleRate = 48000
-		bitDepth   = 16
-		length     = 0.1
-	)
+	path := "/api/v3/files/{fileId}/thumbnail"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	f := env.MakeFile(t, user.GetID(), uuid.Nil)
+	require.Len(t, f.GetThumbnails(), 0)
 
-	sinWave := func(amplitude, frequency, t float64) float64 {
-		return amplitude * math.Sin(frequency*2*math.Pi*t)
-	}
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	s := env.S(t, user.GetID())
 
-	buf := &writerseeker.WriterSeeker{}
-	e := wav.NewEncoder(buf, sampleRate, bitDepth, 1, 1)
+	iconFile, err := file2.GenerateIconFile(env.FM, "test")
+	require.NoError(t, err)
 
-	data := make([]int, sampleRate*length)
-	for i := 0; i < sampleRate*length; i++ {
-		data[i] = int(sinWave(math.Pow(2, 15)-1, 440, float64(i)/sampleRate))
-	}
+	sampleAudio := genSampleAudio(t)
+	audioFile, err := env.FM.Save(file2.SaveArgs{
+		FileName: "sample.wav",
+		FileSize: sampleAudio.Size(),
+		MimeType: "audio/wav",
+		FileType: model.FileTypeUserFile,
+		Src:      sampleAudio,
+	})
+	require.NoError(t, err)
 
-	require.NoError(t, e.Write(&audio.IntBuffer{
-		Format: &audio.Format{
-			NumChannels: 1,
-			SampleRate:  sampleRate,
-		},
-		Data:           data,
-		SourceBitDepth: bitDepth,
-	}))
-	require.NoError(t, e.Close())
+	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
 
-	return buf.BytesReader()
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, iconFile).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, secretFile.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("thumbnail not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, f.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (type=image)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, iconFile).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			ContentType("image/png")
+	})
+
+	t.Run("success (type=waveform)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, audioFile.GetID()).
+			WithCookie(session.CookieName, s).
+			WithQuery("type", "waveform").
+			Expect().
+			Status(http.StatusOK).
+			ContentType("image/svg+xml")
+	})
+}
+
+func TestHandlers_GetFile(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/files/{fileId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	f := env.MakeFile(t, user.GetID(), uuid.Nil)
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, f.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, secretFile.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, f.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			Body().
+			Equal("test message")
+	})
+}
+
+func TestHandlers_DeleteFile(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/files/{fileId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	f := env.MakeFile(t, user.GetID(), uuid.Nil)
+	f2 := env.MakeFile(t, user2.GetID(), uuid.Nil)
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	secretFile := env.MakeFile(t, user2.GetID(), dm.ID)
+	s := env.S(t, user.GetID())
+
+	iconFile, err := file2.GenerateIconFile(env.FM, "test")
+	require.NoError(t, err)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, f.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, secretFile.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (different owner)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, f2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("cannot delete non user file", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, iconFile).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, f.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.FM.Get(f.GetID())
+		assert.ErrorIs(t, err, file2.ErrNotFound)
+	})
 }

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -1,15 +1,17 @@
 package v3
 
 import (
+	"net/http"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension/herror"
 	"github.com/traPtitech/traQ/service/message"
 	"github.com/traPtitech/traQ/service/search"
-	"net/http"
 )
 
 // GetMyUnreadChannels GET /users/me/unread
@@ -141,7 +143,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			wh, err := h.Repo.GetBotByBotUserID(mUser.GetID())
 			if err != nil {
 				switch err {
-				case repository.ErrNotFound:
+				case repository.ErrNotFound: // deleted bot
 					return herror.Forbidden("you are not allowed to delete this message")
 				default:
 					return herror.InternalServerError(err)
@@ -156,7 +158,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			wh, err := h.Repo.GetWebhookByBotUserID(mUser.GetID())
 			if err != nil {
 				switch err {
-				case repository.ErrNotFound:
+				case repository.ErrNotFound: // deleted webhook
 					return herror.Forbidden("you are not allowed to delete this message")
 				default:
 					return herror.InternalServerError(err)

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -1,0 +1,264 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/service/message"
+)
+
+func TestHandlers_GetMyUnreadChannels(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/unread"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array() // unreadは非同期アップデートなのでここでは200だけチェック
+	})
+}
+
+func TestHandlers_ReadChannel(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/unread/{channelId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ch.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+}
+
+func TestHandlers_GetMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	dmm := env.CreateMessage(t, user2.GetID(), dm.ID, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, m.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, dmm.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, m.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		messageEquals(t, m, obj)
+	})
+}
+
+func TestPostMessageRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Content string
+		Embed   bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty content",
+			fields{Content: ""},
+			true,
+		},
+		{
+			"too long content",
+			fields{Content: strings.Repeat("a", 12000)},
+			true,
+		},
+		{
+			"success",
+			fields{Content: "Hello, traP"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostMessageRequest{
+				Content: tt.fields.Content,
+				Embed:   tt.fields.Embed,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}"
+	env := Setup(t, common1)
+
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+
+	pub := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	dm2 := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	archived := env.CreateChannel(t, rand)
+
+	m := env.CreateMessage(t, user.GetID(), pub.ID, rand)
+	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, m.GetID()).
+			WithJSON(&PostMessageRequest{Content: "po"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, m.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMessageRequest{Content: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMessageRequest{Content: "po"}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	tests := []struct {
+		name   string
+		m      message.Message
+		expect int
+	}{
+		{
+			"self message (public)",
+			m,
+			http.StatusNoContent,
+		},
+		{
+			"archived message",
+			archivedM,
+			http.StatusBadRequest,
+		},
+		{
+			"other's message (public)",
+			env.CreateMessage(t, user3.GetID(), pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"self message (dm)",
+			env.CreateMessage(t, user.GetID(), dm.ID, rand),
+			http.StatusNoContent,
+		},
+		{
+			"other's message (dm)",
+			env.CreateMessage(t, user2.GetID(), dm.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"other's dm",
+			env.CreateMessage(t, user2.GetID(), dm2.ID, rand),
+			http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := env.R(t)
+			e.PUT(path, tt.m.GetID()).
+				WithCookie(session.CookieName, s).
+				WithJSON(&PostMessageRequest{Content: "po", Embed: true}).
+				Expect().
+				Status(tt.expect)
+		})
+	}
+}

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -1162,7 +1162,7 @@ func TestHandlers_PostDirectMessage(t *testing.T) {
 	s := env.S(t, user.GetID())
 
 	req := &PostMessageRequest{
-		Content: "aya_se goal",
+		Content: "Hello, traP",
 		Embed:   true,
 	}
 
@@ -1209,7 +1209,7 @@ func TestHandlers_PostDirectMessage(t *testing.T) {
 		obj.Value("id").String().NotEmpty()
 		obj.Value("userId").String().Equal(user.GetID().String())
 		obj.Value("channelId").String().Equal(dm.ID.String())
-		obj.Value("content").String().Equal("aya_se goal")
+		obj.Value("content").String().Equal("Hello, traP")
 		obj.Value("createdAt").String().NotEmpty()
 		obj.Value("updatedAt").String().NotEmpty()
 		obj.Value("pinned").Boolean().False()
@@ -1237,7 +1237,7 @@ func TestHandlers_PostDirectMessage(t *testing.T) {
 		obj.Value("id").String().NotEmpty()
 		obj.Value("userId").String().Equal(user.GetID().String())
 		obj.Value("channelId").String().NotEmpty()
-		obj.Value("content").String().Equal("aya_se goal")
+		obj.Value("content").String().Equal("Hello, traP")
 		obj.Value("createdAt").String().NotEmpty()
 		obj.Value("updatedAt").String().NotEmpty()
 		obj.Value("pinned").Boolean().False()

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -173,13 +173,27 @@ func TestHandlers_EditMessage(t *testing.T) {
 	user3 := env.CreateUser(t, rand)
 
 	pub := env.CreateChannel(t, rand)
+
+	bot := env.CreateBot(t, rand, user.GetID())
+	bot2 := env.CreateBot(t, rand, user2.GetID())
+	bot3 := env.CreateBot(t, rand, user.GetID())
+	w := env.CreateWebhook(t, rand, user.GetID(), pub.ID)
+	w2 := env.CreateWebhook(t, rand, user2.GetID(), pub.ID)
+	w3 := env.CreateWebhook(t, rand, user.GetID(), pub.ID)
+
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	dm2 := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	dm3 := env.CreateDMChannel(t, user2.GetID(), bot.BotUserID)
 	archived := env.CreateChannel(t, rand)
 
 	m := env.CreateMessage(t, user.GetID(), pub.ID, rand)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
 	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+
+	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
+	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
+	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
+	require.NoError(t, env.Repository.DeleteWebhook(w3.GetID()))
 
 	s := env.S(t, user.GetID())
 
@@ -247,6 +261,41 @@ func TestHandlers_EditMessage(t *testing.T) {
 			env.CreateMessage(t, user2.GetID(), dm2.ID, rand),
 			http.StatusNotFound,
 		},
+		{
+			"my bot message (public)",
+			env.CreateMessage(t, bot.BotUserID, pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"other's bot message (public)",
+			env.CreateMessage(t, bot2.BotUserID, pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"my bot message (dm)",
+			env.CreateMessage(t, bot.BotUserID, dm3.ID, rand),
+			http.StatusNotFound,
+		},
+		{
+			"my deleted bot message (public)",
+			bot3M,
+			http.StatusForbidden,
+		},
+		{
+			"my webhook message (public)",
+			env.CreateMessage(t, w.GetBotUserID(), pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"other's webhook message (public)",
+			env.CreateMessage(t, w2.GetBotUserID(), pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"my deleted webhook message (public)",
+			w3M,
+			http.StatusForbidden,
+		},
 	}
 
 	for _, tt := range tests {
@@ -257,6 +306,143 @@ func TestHandlers_EditMessage(t *testing.T) {
 			e.PUT(path, tt.m.GetID()).
 				WithCookie(session.CookieName, s).
 				WithJSON(&PostMessageRequest{Content: "po", Embed: true}).
+				Expect().
+				Status(tt.expect)
+		})
+	}
+}
+
+func TestHandlers_DeleteMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}"
+	env := Setup(t, common1)
+
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+
+	pub := env.CreateChannel(t, rand)
+
+	bot := env.CreateBot(t, rand, user.GetID())
+	bot2 := env.CreateBot(t, rand, user2.GetID())
+	bot3 := env.CreateBot(t, rand, user.GetID())
+	w := env.CreateWebhook(t, rand, user.GetID(), pub.ID)
+	w2 := env.CreateWebhook(t, rand, user2.GetID(), pub.ID)
+	w3 := env.CreateWebhook(t, rand, user.GetID(), pub.ID)
+
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	dm2 := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
+	dm3 := env.CreateDMChannel(t, user2.GetID(), bot.BotUserID)
+	archived := env.CreateChannel(t, rand)
+
+	m := env.CreateMessage(t, user.GetID(), pub.ID, rand)
+	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+
+	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
+	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
+	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
+	require.NoError(t, env.Repository.DeleteWebhook(w3.GetID()))
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	tests := []struct {
+		name   string
+		m      message.Message
+		expect int
+	}{
+		{
+			"self message (public)",
+			m,
+			http.StatusNoContent,
+		},
+		{
+			"archived message",
+			archivedM,
+			http.StatusBadRequest,
+		},
+		{
+			"other's message (public)",
+			env.CreateMessage(t, user3.GetID(), pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"self message (dm)",
+			env.CreateMessage(t, user.GetID(), dm.ID, rand),
+			http.StatusNoContent,
+		},
+		{
+			"other's message (dm)",
+			env.CreateMessage(t, user2.GetID(), dm.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"other's dm",
+			env.CreateMessage(t, user2.GetID(), dm2.ID, rand),
+			http.StatusNotFound,
+		},
+		{
+			"my bot message (public)",
+			env.CreateMessage(t, bot.BotUserID, pub.ID, rand),
+			http.StatusNoContent,
+		},
+		{
+			"other's bot message (public)",
+			env.CreateMessage(t, bot2.BotUserID, pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"my bot message (dm)",
+			env.CreateMessage(t, bot.BotUserID, dm3.ID, rand),
+			http.StatusNotFound,
+		},
+		{
+			"my deleted bot message (public)",
+			bot3M,
+			http.StatusForbidden,
+		},
+		{
+			"my webhook message (public)",
+			env.CreateMessage(t, w.GetBotUserID(), pub.ID, rand),
+			http.StatusNoContent,
+		},
+		{
+			"other's webhook message (public)",
+			env.CreateMessage(t, w2.GetBotUserID(), pub.ID, rand),
+			http.StatusForbidden,
+		},
+		{
+			"my deleted webhook message (public)",
+			w3M,
+			http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := env.R(t)
+			e.DELETE(path, tt.m.GetID()).
+				WithCookie(session.CookieName, s).
 				Expect().
 				Status(tt.expect)
 		})

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -587,3 +587,666 @@ func TestHandlers_CreatePin(t *testing.T) {
 		obj.Value("pinnedAt").String().NotEmpty()
 	})
 }
+
+func TestHandlers_RemovePin(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}/pin"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	archived := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	m2 := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	_, err := env.MM.Pin(m.GetID(), user.GetID())
+	require.NoError(t, err)
+	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
+	_, err = env.MM.Pin(archivedM.GetID(), user.GetID())
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("pin not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("archived", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, archivedM.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		m, err := env.MM.Get(m.GetID())
+		require.NoError(t, err)
+		assert.Nil(t, m.GetPin())
+	})
+}
+
+func TestHandlers_GetMessageStamps(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}/stamps"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	s := env.S(t, user.GetID())
+
+	var err error
+	m, err = env.MM.Get(m.GetID())
+	require.NoError(t, err)
+	require.Len(t, m.GetStamps(), 1)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, m.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, m.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		messageStampEquals(t, m.GetStamps()[0], first)
+	})
+}
+
+func TestPostMessageStampRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Count int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"zero count",
+			fields{Count: 0},
+			false,
+		},
+		{
+			"negative count",
+			fields{Count: -1},
+			true,
+		},
+		{
+			"too large count",
+			fields{Count: 150},
+			true,
+		},
+		{
+			"success",
+			fields{Count: 5},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PostMessageStampRequest{
+				Count: tt.fields.Count,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_AddMessageStamp(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}/stamps/{stampId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	archived := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, m.GetID(), stamp.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("message not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4()), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("stamp not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, m.GetID(), uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, m.GetID(), stamp.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMessageStampRequest{Count: 1000}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("archived", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, archivedM.GetID(), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, m.GetID(), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		m, err := env.MM.Get(m.GetID())
+		require.NoError(t, err)
+
+		if assert.Len(t, m.GetStamps(), 1) {
+			s := m.GetStamps()[0]
+			assert.EqualValues(t, 1, s.Count)
+			assert.EqualValues(t, stamp.ID, s.StampID)
+			assert.EqualValues(t, m.GetID(), s.MessageID)
+			assert.EqualValues(t, user.GetID(), s.UserID)
+		}
+	})
+}
+
+func TestHandlers_RemoveMessageStamp(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}/stamps/{stampId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	archived := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	env.AddStampToMessage(t, archivedM.GetID(), stamp.ID, user.GetID())
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID(), stamp.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("message not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4()), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("stamp not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID(), uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("archived", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, archivedM.GetID(), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, m.GetID(), stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		m, err := env.MM.Get(m.GetID())
+		require.NoError(t, err)
+
+		assert.Len(t, m.GetStamps(), 0)
+	})
+}
+
+func TestHandlers_GetMessageClips(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/messages/{messageId}/clips"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	cf := env.CreateClipFolder(t, rand, rand, user.GetID())
+	_, err := env.Repository.AddClipFolderMessage(cf.ID, m.GetID())
+	require.NoError(t, err)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, m.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, m.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("folderId").String().Equal(cf.ID.String())
+		first.Value("clippedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_GetMessages(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/messages"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	m2 := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ch.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			WithQuery("limit", -1).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+
+		messageEquals(t, m2, obj.Element(0).Object())
+		messageEquals(t, m, obj.Element(1).Object())
+	})
+}
+
+func TestHandlers_PostMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/channels/{channelId}/messages"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	archived := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	s := env.S(t, user.GetID())
+
+	req := &PostMessageRequest{
+		Content: "Hello, traP",
+		Embed:   true,
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ch.ID).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("archived", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, archived.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMessageRequest{Content: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("userId").String().Equal(user.GetID().String())
+		obj.Value("channelId").String().Equal(ch.ID.String())
+		obj.Value("content").String().Equal("Hello, traP")
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("pinned").Boolean().False()
+		obj.Value("stamps").Array().Length().Equal(0)
+
+		id, err := uuid.FromString(obj.Value("id").String().Raw())
+		if assert.NoError(t, err) {
+			m, err := env.MM.Get(id)
+			require.NoError(t, err)
+			messageEquals(t, m, obj)
+		}
+	})
+}
+
+func TestHandlers_GetDirectMessages(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/messages"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	m := env.CreateMessage(t, user.GetID(), dm.ID, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user2.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithQuery("limit", -1).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (existing dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		messageEquals(t, m, obj.First().Object())
+	})
+
+	t.Run("success (creating dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user3.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(0)
+	})
+}
+
+func TestHandlers_PostDirectMessage(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/messages"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	s := env.S(t, user.GetID())
+
+	req := &PostMessageRequest{
+		Content: "aya_se goal",
+		Embed:   true,
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, user2.GetID()).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMessageRequest{Content: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (existing dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("userId").String().Equal(user.GetID().String())
+		obj.Value("channelId").String().Equal(dm.ID.String())
+		obj.Value("content").String().Equal("aya_se goal")
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("pinned").Boolean().False()
+		obj.Value("stamps").Array().Length().Equal(0)
+
+		id, err := uuid.FromString(obj.Value("id").String().Raw())
+		if assert.NoError(t, err) {
+			m, err := env.MM.Get(id)
+			require.NoError(t, err)
+			messageEquals(t, m, obj)
+		}
+	})
+
+	t.Run("success (creating dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, user3.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("userId").String().Equal(user.GetID().String())
+		obj.Value("channelId").String().NotEmpty()
+		obj.Value("content").String().Equal("aya_se goal")
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("pinned").Boolean().False()
+		obj.Value("stamps").Array().Length().Equal(0)
+
+		id, err := uuid.FromString(obj.Value("id").String().Raw())
+		if assert.NoError(t, err) {
+			m, err := env.MM.Get(id)
+			require.NoError(t, err)
+			messageEquals(t, m, obj)
+		}
+	})
+}

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -602,6 +602,7 @@ func TestHandlers_RemovePin(t *testing.T) {
 	require.NoError(t, err)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
 	_, err = env.MM.Pin(archivedM.GetID(), user.GetID())
+	require.NoError(t, err)
 	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
 	s := env.S(t, user.GetID())
 

--- a/router/v3/public_test.go
+++ b/router/v3/public_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestHandlers_GetVersion(t *testing.T) {
 	t.Parallel()
-	env := Setup(t, common)
+	env := Setup(t, common1)
 
 	e := env.R(t)
 	obj := e.GET("/api/v3/version").

--- a/router/v3/public_test.go
+++ b/router/v3/public_test.go
@@ -3,18 +3,49 @@ package v3
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/repository"
+	file2 "github.com/traPtitech/traQ/service/file"
+	"github.com/traPtitech/traQ/service/rbac/role"
+	"github.com/traPtitech/traQ/utils/random"
 )
 
 func TestHandlers_GetVersion(t *testing.T) {
 	t.Parallel()
+
+	path := "/api/v3/version"
 	env := Setup(t, common1)
 
 	e := env.R(t)
-	obj := e.GET("/api/v3/version").
+	obj := e.GET(path).
 		Expect().
 		Status(http.StatusOK).
 		JSON().
 		Object()
 	obj.Value("version").String().Equal("version")
 	obj.Value("revision").String().Equal("revision")
+}
+
+func TestHandlers_GetPublicUserIcon(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/public/icon/{username}"
+	env := Setup(t, common1)
+	iconFileID, err := file2.GenerateIconFile(env.FM, "test")
+	require.NoError(t, err)
+	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		Name:       random.AlphaNumeric(20),
+		Password:   "totallyASecurePassword",
+		Role:       role.User,
+		IconFileID: iconFileID,
+	})
+	require.NoError(t, err)
+
+	e := env.R(t)
+	e.GET(path, user.GetName()).
+		Expect().
+		Status(http.StatusOK).
+		ContentType("image/png")
 }

--- a/router/v3/public_test.go
+++ b/router/v3/public_test.go
@@ -24,8 +24,17 @@ func TestHandlers_GetVersion(t *testing.T) {
 		Status(http.StatusOK).
 		JSON().
 		Object()
+
 	obj.Value("version").String().Equal("version")
 	obj.Value("revision").String().Equal("revision")
+
+	flags := obj.Value("flags").Object()
+
+	flags.Value("signUpAllowed").Boolean().False()
+
+	ext := flags.Value("externalLogin").Array()
+	ext.Length().Equal(1)
+	ext.First().String().Equal("traq")
 }
 
 func TestHandlers_GetPublicUserIcon(t *testing.T) {

--- a/router/v3/responses.go
+++ b/router/v3/responses.go
@@ -62,16 +62,20 @@ type UserTag struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
+func formatUserTag(ut model.UserTag) UserTag {
+	return UserTag{
+		ID:        ut.GetTagID(),
+		Tag:       ut.GetTag(),
+		IsLocked:  ut.GetIsLocked(),
+		CreatedAt: ut.GetCreatedAt(),
+		UpdatedAt: ut.GetUpdatedAt(),
+	}
+}
+
 func formatUserTags(uts []model.UserTag) []UserTag {
 	res := make([]UserTag, len(uts))
 	for i, ut := range uts {
-		res[i] = UserTag{
-			ID:        ut.GetTagID(),
-			Tag:       ut.GetTag(),
-			IsLocked:  ut.GetIsLocked(),
-			CreatedAt: ut.GetCreatedAt(),
-			UpdatedAt: ut.GetUpdatedAt(),
-		}
+		res[i] = formatUserTag(ut)
 	}
 	return res
 }

--- a/router/v3/responses.go
+++ b/router/v3/responses.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/utils/optional"
+
+	"github.com/gofrs/uuid"
 )
 
 type Channel struct {
@@ -239,6 +240,32 @@ func formatBotDetail(b *model.Bot, t *model.OAuth2Token, channels []uuid.UUID) *
 		Privileged: b.Privileged,
 		Channels:   channels,
 	}
+}
+
+type botEventLogResponse struct {
+	RequestID uuid.UUID          `json:"requestId"`
+	BotID     uuid.UUID          `json:"botId"`
+	Event     model.BotEventType `json:"event"`
+	Code      int                `json:"code"`
+	DateTime  time.Time          `json:"datetime"`
+}
+
+func formatBotEventLog(log *model.BotEventLog) *botEventLogResponse {
+	return &botEventLogResponse{
+		RequestID: log.RequestID,
+		BotID:     log.BotID,
+		Event:     log.Event,
+		Code:      log.Code,
+		DateTime:  log.DateTime,
+	}
+}
+
+func formatBotEventLogs(logs []*model.BotEventLog) []*botEventLogResponse {
+	res := make([]*botEventLogResponse, len(logs))
+	for i, log := range logs {
+		res[i] = formatBotEventLog(log)
+	}
+	return res
 }
 
 type Message struct {

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -138,8 +138,12 @@ func TestMain(m *testing.M) {
 			Logger:         zap.NewNop(),
 			Imaging:        env.IP,
 			Config: Config{
-				Version:  "version",
-				Revision: "revision",
+				Version:     "version",
+				Revision:    "revision",
+				AllowSignUp: false,
+				EnabledExternalAccountProviders: map[string]bool{
+					"traq": true,
+				},
 			},
 		}
 		handlers.Setup(e.Group("/api"))
@@ -367,6 +371,14 @@ func (env *Env) CreateOAuth2Client(t *testing.T, name string, creatorID uuid.UUI
 	}
 	require.NoError(t, env.Repository.SaveClient(client))
 	return client
+}
+
+// IssueToken OAuth2トークンを必ず発行します
+func (env *Env) IssueToken(t *testing.T, client *model.OAuth2Client, userID uuid.UUID) *model.OAuth2Token {
+	t.Helper()
+	tok, err := env.Repository.IssueToken(client, userID, "https://example.com", model.AccessScopes{"read": {}}, 86400, false)
+	require.NoError(t, err)
+	return tok
 }
 
 // CreateClipFolder クリップフォルダを必ず作成します

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -259,7 +259,8 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	m, err := env.Repository.CreateBot(name, "po", "totall a desc", uuid.Nil, creatorID, "https://example.com")
+	f := env.MakeFile(t)
+	m, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, "https://example.com")
 	require.NoError(t, err)
 	return m
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -309,6 +309,7 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 	return m
 }
 
+// CreateOAuth2Client OAuth2クライアントを必ず作成します
 func (env *Env) CreateOAuth2Client(t *testing.T, name string, creatorID uuid.UUID) *model.OAuth2Client {
 	t.Helper()
 	if name == rand {
@@ -326,6 +327,20 @@ func (env *Env) CreateOAuth2Client(t *testing.T, name string, creatorID uuid.UUI
 	}
 	require.NoError(t, env.Repository.SaveClient(client))
 	return client
+}
+
+// CreateClipFolder クリップフォルダを必ず作成します
+func (env *Env) CreateClipFolder(t *testing.T, name, desc string, creatorID uuid.UUID) *model.ClipFolder {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	if desc == rand {
+		desc = random.AlphaNumeric(20)
+	}
+	cf, err := env.Repository.CreateClipFolder(creatorID, name, desc)
+	require.NoError(t, err)
+	return cf
 }
 
 func getEnvOrDefault(env string, def string) string {

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -238,6 +238,23 @@ func (env *Env) CreateAdmin(t *testing.T, userName string) model.UserInfo {
 	return u
 }
 
+// AddTag ユーザーに必ずタグを追加します
+func (env *Env) AddTag(t *testing.T, name string, userID uuid.UUID) model.UserTag {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+
+	tag, err := env.Repository.GetOrCreateTag(name)
+	require.NoError(t, err)
+
+	require.NoError(t, env.Repository.AddUserTag(userID, tag.ID))
+
+	ut, err := env.Repository.GetUserTag(userID, tag.ID)
+	require.NoError(t, err)
+	return ut
+}
+
 // CreateChannel チャンネルを必ず作成します
 func (env *Env) CreateChannel(t *testing.T, name string) *model.Channel {
 	t.Helper()

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -263,13 +263,19 @@ func (env *Env) CreateMessage(t *testing.T, userID, channelID uuid.UUID, text st
 	return m
 }
 
+// MakeMessageUnread 指定したメッセージを未読にします
+func (env *Env) MakeMessageUnread(t *testing.T, userID, messageID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, env.Repository.SetMessageUnread(userID, messageID, false))
+}
+
 // CreateStamp スタンプを必ず作成します
 func (env *Env) CreateStamp(t *testing.T, creator uuid.UUID, name string) *model.Stamp {
 	t.Helper()
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	f := env.MakeFile(t, creator, uuid.Nil)
+	f := env.CreateFile(t, creator, uuid.Nil)
 	s, err := env.Repository.CreateStamp(repository.CreateStampArgs{
 		Name:      name,
 		FileID:    f.GetID(),
@@ -286,8 +292,8 @@ func (env *Env) AddStampToMessage(t *testing.T, messageID, stampID, userID uuid.
 	require.NoError(t, err)
 }
 
-// MakeFile ファイルを必ず作成します
-func (env *Env) MakeFile(t *testing.T, creatorID, channelID uuid.UUID) model.File {
+// CreateFile ファイルを必ず作成します
+func (env *Env) CreateFile(t *testing.T, creatorID, channelID uuid.UUID) model.File {
 	t.Helper()
 
 	var cr, ch optional.UUID
@@ -325,7 +331,7 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	f := env.MakeFile(t, creatorID, uuid.Nil)
+	f := env.CreateFile(t, creatorID, uuid.Nil)
 	b, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, "https://example.com")
 	require.NoError(t, err)
 	return b
@@ -337,7 +343,7 @@ func (env *Env) CreateWebhook(t *testing.T, name string, creatorID, channelID uu
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	f := env.MakeFile(t, creatorID, uuid.Nil)
+	f := env.CreateFile(t, creatorID, uuid.Nil)
 	w, err := env.Repository.CreateWebhook(name, "po", channelID, f.GetID(), creatorID, random.SecureAlphaNumeric(20))
 	require.NoError(t, err)
 	return w

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/traPtitech/traQ/service/message"
 	"github.com/traPtitech/traQ/service/rbac"
 	"github.com/traPtitech/traQ/service/rbac/role"
+	"github.com/traPtitech/traQ/service/search"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/random"
 	"github.com/traPtitech/traQ/utils/storage"
@@ -168,6 +169,7 @@ type Env struct {
 	MM         message.Manager
 	FM         file.Manager
 	IP         imaging.Processor
+	SE         search.Engine
 	Hub        *hub.Hub
 	SessStore  session.Store
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -220,6 +220,7 @@ func (env *Env) CreateUser(t *testing.T, userName string) model.UserInfo {
 	return u
 }
 
+// CreateAdmin Adminユーザーを必ず作成します
 func (env *Env) CreateAdmin(t *testing.T, userName string) model.UserInfo {
 	t.Helper()
 	if userName == rand {
@@ -296,6 +297,7 @@ func (env *Env) MakeFile(t *testing.T) model.File {
 	return f
 }
 
+// CreateBot BOTを必ず作成します
 func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model.Bot {
 	t.Helper()
 	if name == rand {
@@ -305,6 +307,25 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 	m, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, "https://example.com")
 	require.NoError(t, err)
 	return m
+}
+
+func (env *Env) CreateOAuth2Client(t *testing.T, name string, creatorID uuid.UUID) *model.OAuth2Client {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	client := &model.OAuth2Client{
+		ID:           random.SecureAlphaNumeric(36),
+		Name:         name,
+		Description:  "desc",
+		Confidential: false,
+		CreatorID:    creatorID,
+		RedirectURI:  "https://example.com",
+		Secret:       random.SecureAlphaNumeric(36),
+		Scopes:       model.AccessScopes{"read": {}},
+	}
+	require.NoError(t, env.Repository.SaveClient(client))
+	return client
 }
 
 func getEnvOrDefault(env string, def string) string {

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -249,6 +249,12 @@ func (env *Env) CreateChannel(t *testing.T, name string) *model.Channel {
 	return ch
 }
 
+// AddStar 指定したチャンネルをスターします
+func (env *Env) AddStar(t *testing.T, userID, channelID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, env.Repository.AddStar(userID, channelID))
+}
+
 // CreateDMChannel DMチャンネルを必ず作成します
 func (env *Env) CreateDMChannel(t *testing.T, user1, user2 uuid.UUID) *model.Channel {
 	dm, err := env.CM.GetDMChannel(user1, user2)

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -255,6 +255,23 @@ func (env *Env) AddTag(t *testing.T, name string, userID uuid.UUID) model.UserTa
 	return ut
 }
 
+// CreateUserGroup ユーザーグループを必ず作成します
+func (env *Env) CreateUserGroup(t *testing.T, name, description, groupType string, adminID uuid.UUID) *model.UserGroup {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	ug, err := env.Repository.CreateUserGroup(name, description, groupType, adminID)
+	require.NoError(t, err)
+	return ug
+}
+
+// AddUserToUserGroup ユーザーをユーザーグループに必ず追加します
+func (env *Env) AddUserToUserGroup(t *testing.T, userID, groupID uuid.UUID, role string) {
+	t.Helper()
+	require.NoError(t, env.Repository.AddUserToGroup(userID, groupID, role))
+}
+
 // CreateChannel チャンネルを必ず作成します
 func (env *Env) CreateChannel(t *testing.T, name string) *model.Channel {
 	t.Helper()

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -326,9 +326,21 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 		name = random.AlphaNumeric(20)
 	}
 	f := env.MakeFile(t, creatorID, uuid.Nil)
-	m, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, "https://example.com")
+	b, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, "https://example.com")
 	require.NoError(t, err)
-	return m
+	return b
+}
+
+// CreateWebhook Webhookを必ず作成します
+func (env *Env) CreateWebhook(t *testing.T, name string, creatorID, channelID uuid.UUID) model.Webhook {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	f := env.MakeFile(t, creatorID, uuid.Nil)
+	w, err := env.Repository.CreateWebhook(name, "po", channelID, f.GetID(), creatorID, random.SecureAlphaNumeric(20))
+	require.NoError(t, err)
+	return w
 }
 
 // CreateOAuth2Client OAuth2クライアントを必ず作成します

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -289,6 +289,17 @@ func (env *Env) CreateStamp(t *testing.T, creator uuid.UUID, name string) *model
 	return s
 }
 
+// CreateStampPalette スタンプパレットを必ず作成します
+func (env *Env) CreateStampPalette(t *testing.T, creator uuid.UUID, name string, stamps model.UUIDs) *model.StampPalette {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	sp, err := env.Repository.CreateStampPalette(name, "desc", stamps, creator)
+	require.NoError(t, err)
+	return sp
+}
+
 // AddStampToMessage メッセージにスタンプを必ず押します
 func (env *Env) AddStampToMessage(t *testing.T, messageID, stampID, userID uuid.UUID) {
 	t.Helper()

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -136,9 +136,10 @@ func TestMain(m *testing.M) {
 			Logger:         l,
 			Imaging:        env.IP,
 			Config: Config{
-				Version:     "version",
-				Revision:    "revision",
-				AllowSignUp: false,
+				Version:         "version",
+				Revision:        "revision",
+				SkyWaySecretKey: "dummy.secret.key",
+				AllowSignUp:     false,
 				EnabledExternalAccountProviders: map[string]bool{
 					"traq": true,
 				},

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -1,17 +1,19 @@
 package v3
 
 import (
+	"net/http"
+	"time"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension/herror"
 	"github.com/traPtitech/traQ/utils/validator"
-	"go.uber.org/zap"
-	"net/http"
-	"time"
 )
 
 // PostLoginRequest POST /login リクエストボディ

--- a/router/v3/sessions_test.go
+++ b/router/v3/sessions_test.go
@@ -1,0 +1,639 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/service/rbac/role"
+	"github.com/traPtitech/traQ/utils/random"
+)
+
+func TestPostLoginRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name     string
+		Password string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{Name: "", Password: "testTestTest"},
+			true,
+		},
+		{
+			"empty password",
+			fields{Name: "po", Password: ""},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "po", Password: "testTestTest"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostLoginRequest{
+				Name:     tt.fields.Name,
+				Password: tt.fields.Password,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_Login(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/login"
+	env := Setup(t, common1)
+	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		Name:        random.AlphaNumeric(20),
+		DisplayName: "po",
+		Role:        role.User,
+		IconFileID:  uuid.Nil,
+		Password:    "testTestTest",
+	})
+	require.NoError(t, err)
+	deactivated, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		Name:        random.AlphaNumeric(20),
+		DisplayName: "po",
+		Role:        role.User,
+		IconFileID:  uuid.Nil,
+		Password:    "testTestTest",
+	})
+	require.NoError(t, err)
+	err = env.Repository.UpdateUser(deactivated.GetID(), repository.UpdateUserArgs{
+		UserState: struct {
+			Valid bool
+			State model.UserAccountStatus
+		}{
+			Valid: true,
+			State: model.UserAccountStatusDeactivated,
+		},
+	})
+	require.NoError(t, err)
+	suspended, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		Name:        random.AlphaNumeric(20),
+		DisplayName: "po",
+		Role:        role.User,
+		IconFileID:  uuid.Nil,
+		Password:    "testTestTest",
+	})
+	require.NoError(t, err)
+	err = env.Repository.UpdateUser(suspended.GetID(), repository.UpdateUserArgs{
+		UserState: struct {
+			Valid bool
+			State model.UserAccountStatus
+		}{
+			Valid: true,
+			State: model.UserAccountStatusSuspended,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLoginRequest{Name: user.GetName()}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("deactivated account", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLoginRequest{Name: deactivated.GetName(), Password: "testTestTest"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("suspended account", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLoginRequest{Name: suspended.GetName(), Password: "testTestTest"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("unknown user", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLoginRequest{Name: random.AlphaNumeric(20), Password: "testTestTest"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLoginRequest{Name: user.GetName(), Password: "testTestTestTest"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		c := e.POST(path).
+			WithJSON(&PostLoginRequest{Name: user.GetName(), Password: "testTestTest"}).
+			Expect().
+			Status(http.StatusNoContent).
+			Cookie(session.CookieName)
+
+		c.Name().Equal(session.CookieName)
+		c.Value().NotEmpty()
+	})
+
+	t.Run("success with redirect", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		res := e.POST(path).
+			WithJSON(&PostLoginRequest{Name: user.GetName(), Password: "testTestTest"}).
+			WithQuery("redirect", "https://example.com").
+			Expect().
+			Status(http.StatusFound)
+
+		res.Header(echo.HeaderLocation).Equal("https://example.com")
+
+		c := res.Cookie(session.CookieName)
+		c.Name().Equal(session.CookieName)
+		c.Value().NotEmpty()
+	})
+}
+
+func TestHandlers_Logout(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/logout"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+	user2 := env.CreateUser(t, rand)
+	s2 := env.S(t, user2.GetID())
+	user3 := env.CreateUser(t, rand)
+	s3 := env.S(t, user3.GetID())
+	env.S(t, user3.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		c := e.POST(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent).
+			Cookie(session.CookieName)
+
+		c.Name().Equal(session.CookieName)
+		c.Value().Empty()
+	})
+
+	t.Run("success with redirect", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		res := e.POST(path).
+			WithCookie(session.CookieName, s2).
+			WithQuery("redirect", "https://example.com").
+			Expect().
+			Status(http.StatusFound)
+
+		res.Header(echo.HeaderLocation).Equal("https://example.com")
+
+		c := res.Cookie(session.CookieName)
+		c.Name().Equal(session.CookieName)
+		c.Value().Empty()
+	})
+
+	t.Run("success with all session revoke", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		c := e.POST(path).
+			WithCookie(session.CookieName, s3).
+			WithQuery("all", true).
+			Expect().
+			Status(http.StatusNoContent).
+			Cookie(session.CookieName)
+
+		c.Name().Equal(session.CookieName)
+		c.Value().Empty()
+
+		sess, err := env.SessStore.GetSessionsByUserID(user3.GetID())
+		require.NoError(t, err)
+		assert.Len(t, sess, 0)
+	})
+}
+
+func TestHandlers_GetMySessions(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/sessions"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("id").String().NotEmpty()
+		first.Value("issuedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_RevokeMySession(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/sessions/{sessionId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+	s2 := env.S(t, user.GetID())
+	sess2, err := env.SessStore.GetSessionByToken(s2)
+	require.NoError(t, err)
+	s3 := env.S(t, user.GetID())
+	sess3, err := env.SessStore.GetSessionByToken(s3)
+	require.NoError(t, err)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, sess3.RefID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("non existent session", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, sess2.RefID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.SessStore.GetSessionByToken(s2)
+		assert.ErrorIs(t, err, session.ErrSessionNotFound)
+
+		// already deleted
+		e.DELETE(path, sess2.RefID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err = env.SessStore.GetSessionByToken(s2)
+		assert.ErrorIs(t, err, session.ErrSessionNotFound)
+	})
+}
+
+func TestHandlers_GetMyTokens(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tokens"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	client := env.CreateOAuth2Client(t, rand, user.GetID())
+	tok := env.IssueToken(t, client, user.GetID())
+	require.ElementsMatch(t, tok.Scopes.StringArray(), []interface{}{"read"})
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("id").String().NotEmpty()
+		first.Value("clientId").String().Equal(client.ID)
+		first.Value("scopes").Array().Length().Equal(1)
+		first.Value("scopes").Array().First().String().Equal("read")
+		first.Value("issuedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_RevokeMyToken(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tokens/{tokenId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	client := env.CreateOAuth2Client(t, rand, user.GetID())
+	tok := env.IssueToken(t, client, user.GetID())
+	tok2 := env.IssueToken(t, client, user2.GetID())
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, tok.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("other's token", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, tok2.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, tok.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetTokenByID(tok.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_GetMyExternalAccounts(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/ex-accounts"
+	env := Setup(t, common1)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+			Name:        random.AlphaNumeric(20),
+			DisplayName: "po",
+			Role:        role.User,
+			IconFileID:  uuid.Nil,
+			Password:    "testTestTestTest",
+		})
+		require.NoError(t, err)
+		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+			ProviderName: "traq",
+			ExternalID:   "sappi_red",
+			Extra:        map[string]interface{}{},
+		})
+		require.NoError(t, err)
+		s := env.S(t, user.GetID())
+
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("providerName").String().Equal("traq")
+		first.Value("linkedAt").String().NotEmpty()
+		first.Value("externalName").String().Equal("sappi_red")
+	})
+
+	t.Run("success with external name", func(t *testing.T) {
+		t.Parallel()
+
+		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+			Name:        random.AlphaNumeric(20),
+			DisplayName: "po",
+			Role:        role.User,
+			IconFileID:  uuid.Nil,
+			Password:    "testTestTestTest",
+		})
+		require.NoError(t, err)
+		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+			ProviderName: "traq",
+			ExternalID:   "motoki317",
+			Extra: map[string]interface{}{
+				"externalName": "toki",
+			},
+		})
+		require.NoError(t, err)
+		s := env.S(t, user.GetID())
+
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("providerName").String().Equal("traq")
+		first.Value("linkedAt").String().NotEmpty()
+		first.Value("externalName").String().Equal("toki")
+	})
+}
+
+func TestHandlers_LinkExternalAccount(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/ex-accounts/link"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostLinkExternalAccount{ProviderName: "traq"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("already linked", func(t *testing.T) {
+		t.Parallel()
+
+		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+			Name:        random.AlphaNumeric(20),
+			DisplayName: "po",
+			Role:        role.User,
+			IconFileID:  uuid.Nil,
+			Password:    "testTestTestTest",
+		})
+		require.NoError(t, err)
+		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+			ProviderName: "traq",
+			ExternalID:   "takashi_trap",
+			Extra:        map[string]interface{}{},
+		})
+		require.NoError(t, err)
+		s := env.S(t, user.GetID())
+
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostLinkExternalAccount{ProviderName: "traq"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("not enabled", func(t *testing.T) {
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostLinkExternalAccount{ProviderName: "google"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostLinkExternalAccount{ProviderName: "traq"}).
+			Expect().
+			Status(http.StatusFound).
+			Header(echo.HeaderLocation).
+			Equal("/api/auth/traq?link=1")
+	})
+}
+
+func TestHandlers_UnlinkExternalAccount(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/ex-accounts/unlink"
+	env := Setup(t, common1)
+
+	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		Name:        random.AlphaNumeric(20),
+		DisplayName: "po",
+		Role:        role.User,
+		IconFileID:  uuid.Nil,
+		Password:    "testTestTestTest",
+	})
+	require.NoError(t, err)
+	err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+		ProviderName: "traq",
+		ExternalID:   "xxpoxx",
+		Extra:        map[string]interface{}{},
+	})
+	require.NoError(t, err)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostUnlinkExternalAccount{ProviderName: "traq"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("external account not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUnlinkExternalAccount{ProviderName: "google"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUnlinkExternalAccount{ProviderName: "traq"}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		externals, err := env.Repository.GetLinkedExternalUserAccounts(user.GetID())
+		require.NoError(t, err)
+		assert.Len(t, externals, 0)
+	})
+}

--- a/router/v3/stamp_palettes.go
+++ b/router/v3/stamp_palettes.go
@@ -76,7 +76,7 @@ type PatchStampPaletteRequest struct {
 
 func (r PatchStampPaletteRequest) Validate() error {
 	err := vd.ValidateStruct(&r,
-		vd.Field(&r.Name, validator.StampPaletteNameRule...),
+		vd.Field(&r.Name, append(validator.StampPaletteNameRule, validator.RequiredIfValid)...),
 		vd.Field(&r.Description, validator.StampPaletteDescriptionRule...),
 	)
 	// model.UUIDsがsql.Valuerを実装しているので別でvalidateしている

--- a/router/v3/stamp_palettes.go
+++ b/router/v3/stamp_palettes.go
@@ -1,11 +1,13 @@
 package v3
 
 import (
-	"github.com/traPtitech/traQ/utils/optional"
 	"net/http"
+
+	"github.com/traPtitech/traQ/utils/optional"
 
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/extension/herror"

--- a/router/v3/stamp_palettes_test.go
+++ b/router/v3/stamp_palettes_test.go
@@ -1,0 +1,386 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/optional"
+)
+
+func stampPaletteEquals(t *testing.T, expect *model.StampPalette, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.ID.String())
+	actual.Value("name").String().Equal(expect.Name)
+	actual.Value("description").String().Equal(expect.Description)
+	actual.Value("creatorId").String().Equal(expect.CreatorID.String())
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+
+	stamps := actual.Value("stamps").Array()
+	stamps.Length().Equal(len(expect.Stamps))
+	for i, s := range expect.Stamps {
+		stamps.Element(i).String().Equal(s.String())
+	}
+}
+
+func TestHandlers_GetStampPalettes(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamp-palettes"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	sp := env.CreateStampPalette(t, user.GetID(), rand, model.UUIDs{stamp.ID})
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		stampPaletteEquals(t, sp, obj.First().Object())
+	})
+}
+
+func TestCreateStampPaletteRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        string
+		Description string
+		Stamps      model.UUIDs
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			true,
+		},
+		{
+			"too long name",
+			fields{Name: strings.Repeat("a", 50)},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "test palette", Description: "description", Stamps: model.UUIDs{uuid.Must(uuid.NewV4())}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := CreateStampPaletteRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				Stamps:      tt.fields.Stamps,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_CreateStampPalette(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamp-palettes"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&CreateStampPaletteRequest{Name: "po"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("invalid name", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&CreateStampPaletteRequest{}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("invalid stamp id", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&CreateStampPaletteRequest{Name: "po", Stamps: model.UUIDs{uuid.Must(uuid.NewV4())}}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&CreateStampPaletteRequest{Name: "po", Stamps: model.UUIDs{stamp.ID}}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("name").String().Equal("po")
+		stamps := obj.Value("stamps").Array()
+		stamps.Length().Equal(1)
+		stamps.First().String().Equal(stamp.ID.String())
+		obj.Value("creatorId").String().Equal(user.GetID().String())
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("description").String().Empty()
+	})
+}
+
+func TestPatchStampPaletteRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        optional.String
+		Description optional.String
+		Stamps      model.UUIDs
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"too long name",
+			fields{Name: optional.StringFrom(strings.Repeat("a", 50))},
+			true,
+		},
+		{
+			"success",
+			fields{
+				Name:        optional.StringFrom("test"),
+				Description: optional.StringFrom("description"),
+				Stamps:      model.UUIDs{uuid.Must(uuid.NewV4())},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PatchStampPaletteRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				Stamps:      tt.fields.Stamps,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditStampPalette(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamp-palettes/{paletteId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	sp := env.CreateStampPalette(t, user.GetID(), rand, model.UUIDs{stamp.ID})
+	sp2 := env.CreateStampPalette(t, user2.GetID(), rand, model.UUIDs{})
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, sp.ID).
+			WithJSON(&PatchStampPaletteRequest{Name: optional.StringFrom("test")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("invalid name", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, sp.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampPaletteRequest{Name: optional.StringFrom(strings.Repeat("a", 50))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("invalid stamp", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, sp.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampPaletteRequest{Stamps: model.UUIDs{uuid.Must(uuid.NewV4())}}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, sp2.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampPaletteRequest{Name: optional.StringFrom("test")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampPaletteRequest{Name: optional.StringFrom("test")}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, sp.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampPaletteRequest{Name: optional.StringFrom("test")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		updated, err := env.Repository.GetStampPalette(sp.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, sp.ID.String(), updated.ID.String())
+		assert.EqualValues(t, "test", updated.Name)
+	})
+}
+
+func TestHandlers_GetStampPalette(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamp-palettes/{paletteId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	sp := env.CreateStampPalette(t, user.GetID(), rand, model.UUIDs{stamp.ID})
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, sp.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, sp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		stampPaletteEquals(t, sp, obj)
+	})
+}
+
+func TestHandlers_DeleteStampPalette(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamp-palettes/{paletteId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	sp := env.CreateStampPalette(t, user.GetID(), rand, model.UUIDs{stamp.ID})
+	sp2 := env.CreateStampPalette(t, user2.GetID(), rand, model.UUIDs{})
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, sp2.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, sp2.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, sp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetStampPalette(sp.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}

--- a/router/v3/stamp_palettes_test.go
+++ b/router/v3/stamp_palettes_test.go
@@ -25,11 +25,12 @@ func stampPaletteEquals(t *testing.T, expect *model.StampPalette, actual *httpex
 	actual.Value("createdAt").String().NotEmpty()
 	actual.Value("updatedAt").String().NotEmpty()
 
-	stamps := actual.Value("stamps").Array()
-	stamps.Length().Equal(len(expect.Stamps))
-	for i, s := range expect.Stamps {
-		stamps.Element(i).String().Equal(s.String())
+	stamps := make([]interface{}, len(expect.Stamps))
+	for i, stamp := range expect.Stamps {
+		stamps[i] = stamp.String()
 	}
+	// Order DOES matter here
+	actual.Value("stamps").Array().Elements(stamps...)
 }
 
 func TestHandlers_GetStampPalettes(t *testing.T) {
@@ -186,6 +187,11 @@ func TestPatchStampPaletteRequest_Validate(t *testing.T) {
 			"empty",
 			fields{},
 			false,
+		},
+		{
+			"empty name",
+			fields{Name: optional.StringFrom("")},
+			true,
 		},
 		{
 			"too long name",

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -2,8 +2,12 @@ package v3
 
 import (
 	"context"
+	"net/http"
+	"strconv"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension"
@@ -12,8 +16,6 @@ import (
 	"github.com/traPtitech/traQ/service/rbac/permission"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
-	"strconv"
 )
 
 // GetStamps GET /stamps
@@ -74,7 +76,7 @@ type PatchStampRequest struct {
 
 func (r PatchStampRequest) ValidateWithContext(ctx context.Context) error {
 	return vd.ValidateStructWithContext(ctx, &r,
-		vd.Field(&r.Name, validator.StampNameRule...),
+		vd.Field(&r.Name, append(validator.StampNameRule, validator.RequiredIfValid)...),
 		vd.Field(&r.CreatorID, validator.NotNilUUID, utils.IsActiveHumanUserID),
 	)
 }

--- a/router/v3/stamps_test.go
+++ b/router/v3/stamps_test.go
@@ -120,7 +120,27 @@ func TestHandlers_EditStamp(t *testing.T) {
 			Status(http.StatusUnauthorized)
 	})
 
-	t.Run("bad request", func(t *testing.T) {
+	t.Run("bad request (empty name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp3.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (nil creator id)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp3.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{CreatorID: optional.UUIDFrom(uuid.Nil)}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (invalid creator id)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PATCH(path, stamp3.ID).

--- a/router/v3/stamps_test.go
+++ b/router/v3/stamps_test.go
@@ -1,0 +1,264 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/optional"
+)
+
+func stampEquals(t *testing.T, expect *model.Stamp, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.ID.String())
+	actual.Value("name").String().Equal(expect.Name)
+	actual.Value("creatorId").String().Equal(expect.CreatorID.String())
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+	actual.Value("fileId").String().Equal(expect.FileID.String())
+	actual.Value("isUnicode").Boolean().Equal(expect.IsUnicode)
+}
+
+func TestHandlers_GetStamps(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamps"
+	env := Setup(t, s1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		stampEquals(t, stamp, obj.First().Object())
+	})
+}
+
+func TestHandlers_GetStamp(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamps/{stampId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, stamp.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		stampEquals(t, stamp, obj)
+	})
+}
+
+func TestHandlers_EditStamp(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamps/{stampId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	stamp2 := env.CreateStamp(t, user2.GetID(), rand)
+	stamp3 := env.CreateStamp(t, user.GetID(), rand)
+	env.CreateStamp(t, user2.GetID(), "409_conflict")
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp3.ID).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("test123")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp3.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{CreatorID: optional.UUIDFrom(uuid.Must(uuid.NewV4()))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp2.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("test123")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("test123")}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp3.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("409_conflict")}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, stamp.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchStampRequest{Name: optional.StringFrom("test123123"), CreatorID: optional.UUIDFrom(user2.GetID())}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		stamp, err := env.Repository.GetStamp(stamp.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, user2.GetID().String(), stamp.CreatorID.String())
+		assert.EqualValues(t, "test123123", stamp.Name)
+	})
+}
+
+func TestHandlers_DeleteStamp(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamps/{stampId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	stamp2 := env.CreateStamp(t, user.GetID(), rand)
+	userSession := env.S(t, user.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, stamp2.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, stamp2.ID).
+			WithCookie(session.CookieName, userSession).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, adminSession).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, stamp.ID).
+			WithCookie(session.CookieName, adminSession).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetStamp(stamp.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_GetStampStats(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/stamps/{stampId}/stats"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	ch := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, stamp.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, stamp.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("count").Number().Equal(1)
+		obj.Value("totalCount").Number().Equal(2)
+	})
+}

--- a/router/v3/star_test.go
+++ b/router/v3/star_test.go
@@ -1,0 +1,137 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func TestHandlers_GetMyStars(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/stars"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch1 := env.CreateChannel(t, rand)
+	ch2 := env.CreateChannel(t, rand)
+	env.CreateChannel(t, rand)
+
+	env.AddStar(t, user.GetID(), ch1.ID)
+	env.AddStar(t, user.GetID(), ch2.ID)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			ContainsOnly(ch1.ID, ch2.ID)
+	})
+}
+
+func TestHandlers_PostStar(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/stars"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostStarRequest{ChannelID: ch.ID}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostStarRequest{ChannelID: dm.ID}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostStarRequest{ChannelID: ch.ID}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		stars, err := env.Repository.GetStaredChannels(user.GetID())
+		require.NoError(t, err)
+		assert.ElementsMatch(t, stars, []uuid.UUID{ch.ID})
+	})
+}
+
+func TestHandlers_RemoveMyStar(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/stars/{channelId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch1 := env.CreateChannel(t, rand)
+	ch2 := env.CreateChannel(t, rand)
+
+	env.AddStar(t, user.GetID(), ch1.ID)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ch1.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success (already removed)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ch2.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ch1.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		stars, err := env.Repository.GetStaredChannels(user.GetID())
+		require.NoError(t, err)
+		assert.Len(t, stars, 0)
+	})
+}

--- a/router/v3/tags.go
+++ b/router/v3/tags.go
@@ -2,14 +2,16 @@ package v3
 
 import (
 	"fmt"
+	"net/http"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension/herror"
-	"net/http"
 )
 
 // GetUserTags GET /users/:userID/tags
@@ -78,7 +80,12 @@ func addUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) e
 		}
 	}
 
-	return c.NoContent(http.StatusCreated)
+	ut, err := repo.GetUserTag(userID, t.ID)
+	if err != nil {
+		return herror.InternalServerError(err)
+	}
+
+	return c.JSON(http.StatusCreated, formatUserTag(ut))
 }
 
 // PatchUserTagRequest PATCH /users/:userID/tags/:tagID リクエストボディ

--- a/router/v3/tags_test.go
+++ b/router/v3/tags_test.go
@@ -1,0 +1,550 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func userTagEquals(t *testing.T, expect model.UserTag, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("tagId").String().Equal(expect.GetTagID().String())
+	actual.Value("tag").String().Equal(expect.GetTag())
+	actual.Value("isLocked").Boolean().Equal(expect.GetIsLocked())
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+}
+
+func TestHandlers_GetUserTags(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/tags"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user2.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		userTagEquals(t, ut, obj.First().Object())
+	})
+}
+
+func TestHandlers_GetMyUserTags(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tags"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		userTagEquals(t, ut, obj.First().Object())
+	})
+}
+
+func TestPostUserTagRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Tag string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty tag name",
+			fields{},
+			true,
+		},
+		{
+			"too long tag name",
+			fields{Tag: strings.Repeat("a", 150)},
+			true,
+		},
+		{
+			"success",
+			fields{Tag: "curiousなきゅうり🥒 curiousなきゅうり🥒+++"}, // 30 runes
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostUserTagRequest{
+				Tag: tt.fields.Tag,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_AddUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/tags"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+
+	env.AddTag(t, "409_conflict", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, user2.GetID()).
+			WithJSON(&PostUserTagRequest{Tag: "†俺があやせだ†"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetBotUserID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "†俺があやせだ†"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "†俺があやせだ†"}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "409_conflict"}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "†俺があやせだ†"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("tagId").String().NotEmpty()
+		obj.Value("tag").String().Equal("†俺があやせだ†")
+		obj.Value("isLocked").Boolean().False()
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_AddMyUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tags"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	env.AddTag(t, "409_conflict", user.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostUserTagRequest{Tag: "普段からJSとか触ってます"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "409_conflict"}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserTagRequest{Tag: "普段からJSとか触ってます"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("tagId").String().NotEmpty()
+		obj.Value("tag").String().Equal("普段からJSとか触ってます")
+		obj.Value("isLocked").Boolean().False()
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_EditUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/tags/{tagId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user.GetID())
+	ut2 := env.AddTag(t, "test", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID(), ut.GetTagID()).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID(), ut.GetTagID()).
+			WithJSON(map[string]interface{}{"isLocked": "po"}).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user2.GetID(), ut2.GetTagID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("user not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4()), ut.GetTagID()).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("tag not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID(), uuid.Must(uuid.NewV4())).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID(), ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ut, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		require.NoError(t, err)
+		assert.True(t, ut.GetIsLocked())
+	})
+}
+
+func TestHandlers_EditMyUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tags/{tagId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ut.GetTagID()).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ut.GetTagID()).
+			WithJSON(map[string]interface{}{"isLocked": "po"}).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("tag not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4())).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserTagRequest{IsLocked: true}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ut, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		require.NoError(t, err)
+		assert.True(t, ut.GetIsLocked())
+	})
+}
+
+func TestHandlers_RemoveUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/tags/{tagId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user2.GetID())
+	ut2 := env.AddTag(t, "test2", user2.GetID())
+	locked := env.AddTag(t, "test3", user2.GetID())
+	require.NoError(t, env.Repository.ChangeUserTagLock(user2.GetID(), locked.GetTagID(), true))
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, user2.GetID(), ut2.GetTagID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, user2.GetID(), locked.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, user2.GetID(), ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetUserTag(user2.GetID(), ut.GetTagID())
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_RemoveMyUserTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/tags/{tagId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, "test", user.GetID())
+	ut2 := env.AddTag(t, "test2", user.GetID())
+	locked := env.AddTag(t, "test3", user.GetID())
+	require.NoError(t, env.Repository.ChangeUserTagLock(user.GetID(), locked.GetTagID(), true))
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ut2.GetTagID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, locked.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_GetTag(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/tags/{tagId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ut := env.AddTag(t, rand, user.GetID())
+	env.AddTag(t, ut.GetTag(), user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ut.GetTagID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("id").String().Equal(ut.GetTagID().String())
+		obj.Value("tag").String().Equal(ut.GetTag())
+		obj.Value("users").Array().ContainsOnly(user.GetID(), user2.GetID())
+	})
+}

--- a/router/v3/tags_test.go
+++ b/router/v3/tags_test.go
@@ -456,6 +456,12 @@ func TestHandlers_RemoveUserTag(t *testing.T) {
 
 		_, err := env.Repository.GetUserTag(user2.GetID(), ut.GetTagID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
+
+		// already removed
+		e.DELETE(path, user2.GetID(), ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
 	})
 }
 
@@ -500,6 +506,12 @@ func TestHandlers_RemoveMyUserTag(t *testing.T) {
 
 		_, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
+
+		// already removed
+		e.DELETE(path, ut.GetTagID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
 	})
 }
 

--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -84,7 +84,8 @@ type PatchUserGroupRequest struct {
 
 func (r PatchUserGroupRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		vd.Field(&r.Name, validator.UserGroupNameRule...),
+		// optionalのvalidationで、valid時に空の値を弾きたいときは vd.NilOrNotEmpty を使う
+		vd.Field(&r.Name, append(validator.UserGroupNameRule, vd.NilOrNotEmpty)...),
 		vd.Field(&r.Description, vd.RuneLength(0, 100)),
 		vd.Field(&r.Type, vd.RuneLength(0, 30)),
 	)

--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -84,8 +84,7 @@ type PatchUserGroupRequest struct {
 
 func (r PatchUserGroupRequest) Validate() error {
 	return vd.ValidateStruct(&r,
-		// optionalのvalidationで、valid時に空の値を弾きたいときは vd.NilOrNotEmpty を使う
-		vd.Field(&r.Name, append(validator.UserGroupNameRule, vd.NilOrNotEmpty)...),
+		vd.Field(&r.Name, append(validator.UserGroupNameRule, validator.RequiredIfValid)...),
 		vd.Field(&r.Description, vd.RuneLength(0, 100)),
 		vd.Field(&r.Type, vd.RuneLength(0, 30)),
 	)

--- a/router/v3/user_groups_test.go
+++ b/router/v3/user_groups_test.go
@@ -1,0 +1,941 @@
+package v3
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/optional"
+	random2 "github.com/traPtitech/traQ/utils/random"
+)
+
+func userGroupEquals(t *testing.T, expect *model.UserGroup, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.ID.String())
+	actual.Value("name").String().Equal(expect.Name)
+	actual.Value("description").String().Equal(expect.Description)
+	actual.Value("type").String().Equal(expect.Type)
+	members := make([]interface{}, len(expect.Members))
+	for i, member := range expect.Members {
+		members[i] = map[string]interface{}{
+			"id":   member.UserID.String(),
+			"role": member.Role,
+		}
+	}
+	actual.Value("members").Array().ContainsOnly(members...)
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+	admins := make([]interface{}, len(expect.Admins))
+	for i, admin := range expect.Admins {
+		admins[i] = admin.UserID
+	}
+	actual.Value("admins").Array().ContainsOnly(admins...)
+}
+
+func TestHandlers_GetUserGroups(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups"
+	env := Setup(t, s1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, "SysAd", "po", "", user.GetID())
+	env.AddUserToUserGroup(t, user2.GetID(), ug.ID, "")
+	ug, err := env.Repository.GetUserGroup(ug.ID)
+	require.NoError(t, err)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		userGroupEquals(t, ug, obj.First().Object())
+	})
+}
+
+func TestPostUserGroupRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        string
+		Description string
+		Type        string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{},
+			true,
+		},
+		{
+			"too long name",
+			fields{Name: strings.Repeat("a", 50)},
+			true,
+		},
+		{
+			"invalid name 1",
+			fields{Name: "@po"},
+			true,
+		},
+		{
+			"invalid name 2",
+			fields{Name: ":po:"},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "graphics", Description: "graphics", Type: ""},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostUserGroupRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				Type:        tt.fields.Type,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_PostUserGroups(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	conflict := env.CreateUserGroup(t, rand, "", "", user.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostUserGroupRequest{Name: "testGroup123456"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupRequest{Name: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden (special group)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupRequest{Name: "22B", Type: "grade"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupRequest{Name: conflict.Name}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupRequest{Name: "testGroup123"}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("name").String().Equal("testGroup123")
+		obj.Value("description").String().Empty()
+		obj.Value("type").String().Empty()
+		obj.Value("members").Array().Length().Equal(0)
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("admins").Array().ContainsOnly(user.GetID())
+	})
+}
+
+func TestHandlers_GetUserGroup(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "po", "", user.GetID())
+	env.AddUserToUserGroup(t, user2.GetID(), ug.ID, "")
+	ug, err := env.Repository.GetUserGroup(ug.ID)
+	require.NoError(t, err)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ug.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		userGroupEquals(t, ug, obj)
+	})
+}
+
+func TestPatchUserGroupRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name        optional.String
+		Description optional.String
+		Type        optional.String
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"empty name",
+			fields{Name: optional.StringFrom("")},
+			true,
+		},
+		{
+			"too long name",
+			fields{Name: optional.StringFrom(strings.Repeat("a", 50))},
+			true,
+		},
+		{
+			"invalid name 1",
+			fields{Name: optional.StringFrom("@po")},
+			true,
+		},
+		{
+			"invalid name 2",
+			fields{Name: optional.StringFrom(":po:")},
+			true,
+		},
+		{
+			"success",
+			fields{
+				Name:        optional.StringFrom("graphics"),
+				Description: optional.StringFrom(""),
+				Type:        optional.StringFrom(""),
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PatchUserGroupRequest{
+				Name:        tt.fields.Name,
+				Description: tt.fields.Description,
+				Type:        tt.fields.Type,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditUserGroup(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+	conflict := env.CreateUserGroup(t, rand, "", "", user.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID).
+			WithJSON(&PatchUserGroupRequest{Name: optional.StringFrom(random2.AlphaNumeric(20))}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupRequest{Name: optional.StringFrom("")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug2.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupRequest{Name: optional.StringFrom(random2.AlphaNumeric(20))}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (special group)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupRequest{Type: optional.StringFrom("grade")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupRequest{Name: optional.StringFrom(conflict.Name)}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupRequest{Name: optional.StringFrom("testGroup456")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, "testGroup456", ug.Name)
+	})
+}
+
+func TestHandlers_DeleteUserGroup(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug2.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetUserGroup(ug.ID)
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_GetUserGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/members"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	env.AddUserToUserGroup(t, user.GetID(), ug.ID, "")
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ug.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("id").String().Equal(user.GetID().String())
+		first.Value("role").String().Empty()
+	})
+}
+
+func TestHandlers_AddUserGroupMember(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/members"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithJSON(&PostUserGroupMemberRequest{ID: user.GetID()}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupMemberRequest{ID: uuid.Must(uuid.NewV4())}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug2.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupMemberRequest{ID: user.GetID()}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupMemberRequest{ID: user.GetID()}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupMemberRequest{ID: user.GetID()}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+		if assert.Len(t, ug.Members, 1) {
+			m := ug.Members[0]
+			assert.EqualValues(t, m.UserID, user.GetID())
+			assert.EqualValues(t, m.Role, "")
+		}
+	})
+}
+
+func TestPatchUserGroupMemberRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Role string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"too long role name",
+			fields{Role: strings.Repeat("a", 150)},
+			true,
+		},
+		{
+			"success",
+			fields{Role: "po"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PatchUserGroupMemberRequest{
+				Role: tt.fields.Role,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditUserGroupMember(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/members/{userId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+	env.AddUserToUserGroup(t, user.GetID(), ug.ID, "")
+	env.AddUserToUserGroup(t, user.GetID(), ug2.ID, "")
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID, user.GetID()).
+			WithJSON(&PatchUserGroupMemberRequest{Role: "po"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (non existent member)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupMemberRequest{Role: "po"}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (role name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupMemberRequest{Role: strings.Repeat("a", 150)}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug2.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupMemberRequest{Role: "po"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("user group not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4()), user.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupMemberRequest{Role: "po"}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, ug.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchUserGroupMemberRequest{Role: "po"}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+		if assert.Len(t, ug.Members, 1) {
+			m := ug.Members[0]
+			assert.EqualValues(t, m.UserID, user.GetID())
+			assert.EqualValues(t, m.Role, "po")
+		}
+	})
+}
+
+func TestHandlers_RemoveUserGroupMember(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/members/{userId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+	env.AddUserToUserGroup(t, user.GetID(), ug.ID, "")
+	env.AddUserToUserGroup(t, user.GetID(), ug2.ID, "")
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID, user.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug2.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("user group not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, uuid.Must(uuid.NewV4()), user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("already removed", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID, user2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+		assert.Len(t, ug.Members, 0)
+
+		// already removed
+		e.DELETE(path, ug.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+}
+
+func TestHandlers_GetUserGroupAdmins(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/admins"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ug.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (my group)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			ContainsOnly(user.GetID())
+	})
+
+	t.Run("success (other group)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, ug2.ID).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array().
+			ContainsOnly(user2.GetID())
+	})
+}
+
+func TestHandlers_AddUserGroupAdmin(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/admins"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithJSON(&PostUserGroupAdminRequest{ID: user2.GetID()}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (invalid user id)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupAdminRequest{ID: wh.GetID()}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug2.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupAdminRequest{ID: user.GetID()}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupAdminRequest{ID: user2.GetID()}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, ug.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostUserGroupAdminRequest{ID: user2.GetID()}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+
+		admins := make([]uuid.UUID, len(ug.Admins))
+		for i, admin := range ug.Admins {
+			admins[i] = admin.UserID
+		}
+		assert.ElementsMatch(t, admins, []uuid.UUID{user.GetID(), user2.GetID()})
+	})
+}
+
+func TestHandlers_RemoveUserGroupAdmin(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/groups/{groupId}/admins/{userId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	user3 := env.CreateUser(t, rand)
+
+	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug2 := env.CreateUserGroup(t, rand, "", "", user.GetID())
+	ug3 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
+	require.NoError(t, env.Repository.AddUserToGroupAdmin(user3.GetID(), ug.ID))
+	require.NoError(t, env.Repository.AddUserToGroupAdmin(user3.GetID(), ug3.ID))
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID, user3.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (last admin)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug2.ID, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug3.ID, user3.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, ug.ID, user3.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		ug, err := env.Repository.GetUserGroup(ug.ID)
+		require.NoError(t, err)
+		if assert.Len(t, ug.Admins, 1) {
+			admin := ug.Admins[0]
+			assert.EqualValues(t, user.GetID(), admin.UserID)
+		}
+	})
+}

--- a/router/v3/user_settings.go
+++ b/router/v3/user_settings.go
@@ -4,73 +4,55 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/traPtitech/traQ/repository"
+
 	"github.com/traPtitech/traQ/router/extension/herror"
 )
 
-// PutUserSettingsRequest PUT /user/me/settings/notify-citation リクエストボディ
-type PutUserSettingsRequest struct {
-	NotifyCitation bool `json:"notifyCitation"`
-}
-
-type getNotifyCitationResponce struct {
+// PutMyNotifyCitationRequest PUT /user/me/settings/notify-citation リクエストボディ
+type PutMyNotifyCitationRequest struct {
 	NotifyCitation bool `json:"notifyCitation"`
 }
 
 // PutMyNotifyCitation PUT /user/me/settings/notify-citation
 func (h *Handlers) PutMyNotifyCitation(c echo.Context) error {
 	id := getRequestUserID(c)
-	var us PutUserSettingsRequest
+
+	var us PutMyNotifyCitationRequest
 	if err := bindAndValidate(c, &us); err != nil {
 		return err
 	}
-	err := h.Repo.UpdateNotifyCitation(id, us.NotifyCitation)
 
-	if err != nil {
-		switch {
-		case err == repository.ErrNilID:
-			return herror.BadRequest("Invalid url")
-		case err == repository.ErrNotFound:
-			return herror.NotFound("User not found")
-		default:
-			return herror.InternalServerError(err)
-		}
+	if err := h.Repo.UpdateNotifyCitation(id, us.NotifyCitation); err != nil {
+		return herror.InternalServerError(err)
 	}
 
 	return c.NoContent(http.StatusNoContent)
-
 }
 
 // GetMySettings GET /user/me/settings
 func (h *Handlers) GetMySettings(c echo.Context) error {
 	id := getRequestUserID(c)
+
 	us, err := h.Repo.GetUserSettings(id)
 	if err != nil {
-		switch {
-		case err == repository.ErrNilID:
-			return herror.BadRequest("Invalid url")
-		case err == repository.ErrNotFound:
-			return herror.NotFound("User not found")
-		default:
-			return herror.InternalServerError(err)
-		}
+		return herror.InternalServerError(err)
 	}
+
 	return c.JSON(http.StatusOK, us)
 }
 
 // GetMyNotifyCitation GET /user/me/settings/notify-citation
 func (h *Handlers) GetMyNotifyCitation(c echo.Context) error {
 	id := getRequestUserID(c)
+
 	nc, err := h.Repo.GetNotifyCitation(id)
 	if err != nil {
-		switch {
-		case err == repository.ErrNilID:
-			return herror.BadRequest("Invalid url")
-		case err == repository.ErrNotFound:
-			return herror.NotFound("User not found")
-		default:
-			return herror.InternalServerError(err)
-		}
+		return herror.InternalServerError(err)
 	}
-	return c.JSON(http.StatusOK, &getNotifyCitationResponce{NotifyCitation: nc})
+
+	type res struct {
+		NotifyCitation bool `json:"notifyCitation"`
+	}
+
+	return c.JSON(http.StatusOK, &res{NotifyCitation: nc})
 }

--- a/router/v3/user_settings_test.go
+++ b/router/v3/user_settings_test.go
@@ -1,0 +1,104 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func TestHandlers_PutMyNotifyCitation(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/settings/notify-citation"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path).
+			WithJSON(&PutMyNotifyCitationRequest{NotifyCitation: true}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutMyNotifyCitationRequest{NotifyCitation: true}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		nc, err := env.Repository.GetNotifyCitation(user.GetID())
+		require.NoError(t, err)
+		assert.True(t, nc)
+	})
+}
+
+func TestHandlers_GetMySettings(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/settings"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("id").String().Equal(user.GetID().String())
+		obj.Value("notifyCitation").Boolean().False()
+	})
+}
+
+func TestHandlers_GetMyNotifyCitation(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/settings/notify-citation"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("notifyCitation").Boolean().False()
+	})
+}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -425,7 +425,7 @@ func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
 
 	ch, err := h.ChannelManager.GetChannel(channelID)
 	if err != nil {
-		if err == repository.ErrNotFound {
+		if err == channel.ErrChannelNotFound {
 			return herror.NotFound()
 		}
 		return herror.InternalServerError(err)

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -2,11 +2,15 @@ package v3
 
 import (
 	"context"
+	"net/http"
+	"time"
+
 	"github.com/dgrijalva/jwt-go"
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/skip2/go-qrcode"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
@@ -18,8 +22,6 @@ import (
 	jwt2 "github.com/traPtitech/traQ/utils/jwt"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/validator"
-	"net/http"
-	"time"
 )
 
 // GetUsers GET /users
@@ -52,7 +54,7 @@ type PostUserRequest struct {
 func (r PostUserRequest) Validate() error {
 	return vd.ValidateStruct(&r,
 		vd.Field(&r.Name, validator.UserNameRuleRequired...),
-		vd.Field(&r.Password, validator.PasswordRule...),
+		vd.Field(&r.Password, append(validator.PasswordRule, validator.RequiredIfValid)...),
 	)
 }
 

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -1,19 +1,21 @@
 package v3
 
 import (
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/traPtitech/traQ/router/session"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/router/session"
 )
 
 func TestHandlers_PutMyPassword(t *testing.T) {
 	t.Parallel()
 	path := "/api/v3/users/me/password"
-	env := Setup(t, common)
+	env := Setup(t, common1)
 	commonSession := env.S(t, env.CreateUser(t, rand).GetID())
 
 	t.Run("NotLoggedIn", func(t *testing.T) {
@@ -79,15 +81,15 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		user := env.CreateUser(t, rand)
 
 		e := env.R(t)
-		new := strings.Repeat("a", 20)
+		newPass := strings.Repeat("a", 20)
 		e.PUT(path).
 			WithCookie(session.CookieName, env.S(t, user.GetID())).
-			WithJSON(echo.Map{"password": "testtesttesttest", "newPassword": new}).
+			WithJSON(echo.Map{"password": "testtesttesttest", "newPassword": newPass}).
 			Expect().
 			Status(http.StatusNoContent)
 
 		u, err := env.Repository.GetUser(user.GetID(), false)
 		require.NoError(t, err)
-		assert.NoError(t, u.Authenticate(new))
+		assert.NoError(t, u.Authenticate(newPass))
 	})
 }

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -5,20 +5,395 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/session"
+	"github.com/traPtitech/traQ/utils/jwt"
+	"github.com/traPtitech/traQ/utils/optional"
+	random2 "github.com/traPtitech/traQ/utils/random"
+	"github.com/traPtitech/traQ/utils/set"
 )
+
+func userEquals(t *testing.T, expect model.UserInfo, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.GetID().String())
+	actual.Value("name").String().Equal(expect.GetName())
+	actual.Value("displayName").String().Equal(expect.GetResponseDisplayName())
+	actual.Value("iconFileId").String().Equal(expect.GetIconFileID().String())
+	actual.Value("bot").Boolean().Equal(expect.IsBot())
+	actual.Value("state").Number().Equal(expect.GetState())
+	actual.Value("updatedAt").String().NotEmpty()
+}
+
+func TestHandlers_GetUsers(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users"
+	env := Setup(t, s3)
+
+	user := env.CreateUser(t, "xxpoxx")
+	user2 := env.CreateUser(t, "sappi_red")
+	deactivated := env.CreateUser(t, "deactivated")
+	suspended := env.CreateUser(t, "suspended")
+	err := env.Repository.UpdateUser(deactivated.GetID(), repository.UpdateUserArgs{
+		UserState: struct {
+			Valid bool
+			State model.UserAccountStatus
+		}{
+			true,
+			model.UserAccountStatusDeactivated,
+		},
+	})
+	require.NoError(t, err)
+	err = env.Repository.UpdateUser(suspended.GetID(), repository.UpdateUserArgs{
+		UserState: struct {
+			Valid bool
+			State model.UserAccountStatus
+		}{
+			true,
+			model.UserAccountStatusSuspended,
+		},
+	})
+	require.NoError(t, err)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (include-suspended and name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("include-suspended", true).
+			WithQuery("name", "xxpoxx").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success (include-suspended=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("include-suspended", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(4)
+	})
+
+	t.Run("success (name=sappi_red)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("name", "sappi_red").
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		userEquals(t, user2, obj.First().Object())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+	})
+}
+
+func TestPostUserRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Name     string
+		Password optional.String
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty name",
+			fields{Name: "", Password: optional.StringFrom("totallySecurePassword")},
+			true,
+		},
+		{
+			"empty password",
+			fields{Name: "temma", Password: optional.StringFrom("")},
+			true,
+		},
+		{
+			"too short password",
+			fields{Name: "temma", Password: optional.StringFrom("password")},
+			true,
+		},
+		{
+			"success",
+			fields{Name: "temma", Password: optional.StringFrom("totallySecurePassword")},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostUserRequest{
+				Name:     tt.fields.Name,
+				Password: tt.fields.Password,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_CreateUser(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	userSession := env.S(t, user.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostUserRequest{Name: "temma", Password: optional.StringFrom("totallySecurePassword")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (short password)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PostUserRequest{Name: "temma", Password: optional.StringFrom("password")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PostUserRequest{Name: "temma", Password: optional.StringFrom("totallySecurePassword")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PostUserRequest{Name: admin.GetName(), Password: optional.StringFrom("totallySecurePassword")}).
+			Expect().
+			Status(http.StatusConflict)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		name := random2.AlphaNumeric(20)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PostUserRequest{Name: name, Password: optional.StringFrom("totallySecurePassword")}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("state").Number().Equal(model.UserAccountStatusActive)
+		obj.Value("bot").Boolean().False()
+		obj.Value("iconFileId").String().NotEmpty()
+		obj.Value("displayName").String().Equal(name)
+		obj.Value("name").String().Equal(name)
+		obj.Value("twitterId").String().Empty()
+		obj.Value("lastOnline").Null()
+		obj.Value("updatedAt").String().NotEmpty()
+		obj.Value("tags").Array().Length().Equal(0)
+		obj.Value("groups").Array().Length().Equal(0)
+		obj.Value("bio").String().Empty()
+		obj.Value("homeChannel").Null()
+	})
+}
+
+func TestHandlers_GetMe(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		userEquals(t, user, obj)
+		obj.Value("twitterId").String().Empty()
+		obj.Value("lastOnline").Null()
+		obj.Value("tags").Array().Length().Equal(0)
+		obj.Value("groups").Array().Length().Equal(0)
+		obj.Value("bio").String().Empty()
+		obj.Value("homeChannel").Null()
+		obj.Value("permissions").Array()
+	})
+}
+
+func TestHandlers_EditMe(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path).
+			WithJSON(&PatchMeRequest{DisplayName: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (invalid twitter id)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchMeRequest{TwitterID: optional.StringFrom("ぽ")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (invalid home channel)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchMeRequest{HomeChannel: optional.UUIDFrom(uuid.Must(uuid.NewV4()))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchMeRequest{
+				DisplayName: optional.StringFrom("po"),
+				HomeChannel: optional.UUIDFrom(ch.ID),
+			}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		profile, err := env.Repository.GetUser(user.GetID(), true)
+		require.NoError(t, err)
+		assert.EqualValues(t, "po", profile.GetDisplayName())
+		if assert.True(t, profile.GetHomeChannel().Valid) {
+			assert.EqualValues(t, ch.ID, profile.GetHomeChannel().UUID)
+		}
+	})
+}
+
+func TestPutMyPasswordRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Password    string
+		NewPassword string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty old password",
+			fields{NewPassword: "totallySecurePassword"},
+			true,
+		},
+		{
+			"empty new password",
+			fields{Password: "totallySecurePassword"},
+			true,
+		},
+		{
+			"success",
+			fields{Password: "totallySecurePassword", NewPassword: "evenMoreSecurePassword"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PutMyPasswordRequest{
+				Password:    tt.fields.Password,
+				NewPassword: tt.fields.NewPassword,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestHandlers_PutMyPassword(t *testing.T) {
 	t.Parallel()
+
 	path := "/api/v3/users/me/password"
 	env := Setup(t, common1)
-	commonSession := env.S(t, env.CreateUser(t, rand).GetID())
+	s := env.S(t, env.CreateUser(t, rand).GetID())
 
-	t.Run("NotLoggedIn", func(t *testing.T) {
+	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
@@ -30,7 +405,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
-			WithCookie(session.CookieName, commonSession).
+			WithCookie(session.CookieName, s).
 			WithJSON(echo.Map{"password": 111, "newPassword": false}).
 			Expect().
 			Status(http.StatusBadRequest)
@@ -40,7 +415,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
-			WithCookie(session.CookieName, commonSession).
+			WithCookie(session.CookieName, s).
 			WithJSON(echo.Map{"password": "test", "newPassword": "a"}).
 			Expect().
 			Status(http.StatusBadRequest)
@@ -50,7 +425,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
-			WithCookie(session.CookieName, commonSession).
+			WithCookie(session.CookieName, s).
 			WithJSON(echo.Map{"password": "test", "newPassword": "アイウエオ"}).
 			Expect().
 			Status(http.StatusBadRequest)
@@ -60,7 +435,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
-			WithCookie(session.CookieName, commonSession).
+			WithCookie(session.CookieName, s).
 			WithJSON(echo.Map{"password": "test", "newPassword": strings.Repeat("a", 33)}).
 			Expect().
 			Status(http.StatusBadRequest)
@@ -70,7 +445,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		e.PUT(path).
-			WithCookie(session.CookieName, commonSession).
+			WithCookie(session.CookieName, s).
 			WithJSON(echo.Map{"password": "wrong password", "newPassword": strings.Repeat("a", 20)}).
 			Expect().
 			Status(http.StatusUnauthorized)
@@ -91,5 +466,692 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 		u, err := env.Repository.GetUser(user.GetID(), false)
 		require.NoError(t, err)
 		assert.NoError(t, u.Authenticate(newPass))
+	})
+}
+
+func TestHandlers_GetMyQRCode(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/qr-code"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	privRaw, _ := random2.GenerateECDSAKey()
+	require.NoError(t, jwt.SetupSigner(privRaw))
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success (image/png)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			ContentType("image/png")
+	})
+
+	t.Run("success (text/plain)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("token", true).
+			Expect().
+			Status(http.StatusOK).
+			ContentType("text/plain")
+	})
+}
+
+func TestGetMyStampHistoryRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Limit int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"zero limit",
+			fields{Limit: 0},
+			false,
+		},
+		{
+			"too large limit",
+			fields{Limit: 500},
+			true,
+		},
+		{
+			"success",
+			fields{Limit: 50},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &GetMyStampHistoryRequest{
+				Limit: tt.fields.Limit,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_GetMyStampHistory(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/stamp-history"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithCookie(session.CookieName, s).
+			WithQuery("limit", 500).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("stampId").String().Equal(stamp.ID.String())
+		first.Value("datetime").String().NotEmpty()
+	})
+}
+
+func TestPostMyFCMDeviceRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Token string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			true,
+		},
+		{
+			"success",
+			fields{Token: "dummy:token"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostMyFCMDeviceRequest{
+				Token: tt.fields.Token,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_PostMyFCMDevice(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/fcm-device"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostMyFCMDeviceRequest{Token: "dummy:token"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (empty token)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMyFCMDeviceRequest{Token: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostMyFCMDeviceRequest{Token: "dummy:token"}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		tokens, err := env.Repository.GetDeviceTokens(set.UUID{user.GetID(): {}})
+		require.NoError(t, err)
+		if assert.Len(t, tokens, 1) {
+			assert.ElementsMatch(t, tokens[user.GetID()], []string{"dummy:token"})
+		}
+	})
+}
+
+func TestPutUserPasswordRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		NewPassword string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			true,
+		},
+		{
+			"too short password",
+			fields{NewPassword: "password"},
+			true,
+		},
+		{
+			"success",
+			fields{NewPassword: "newPassword"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PutUserPasswordRequest{
+				NewPassword: tt.fields.NewPassword,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_ChangeUserPassword(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/password"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	userSession := env.S(t, user.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, user.GetID()).
+			WithJSON(&PutUserPasswordRequest{NewPassword: "newPassword"}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (empty password)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, user.GetID()).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PutUserPasswordRequest{NewPassword: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, user.GetID()).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PutUserPasswordRequest{NewPassword: "newPassword"}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PutUserPasswordRequest{NewPassword: "newPassword"}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, user.GetID()).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PutUserPasswordRequest{NewPassword: "newPassword"}).
+			Expect().
+			Status(http.StatusNoContent)
+	})
+}
+
+func TestHandlers_GetUser(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		userEquals(t, user, obj)
+		obj.Value("twitterId").String().Empty()
+		obj.Value("lastOnline").Null()
+		obj.Value("tags").Array().Length().Equal(0)
+		obj.Value("groups").Array().Length().Equal(0)
+		obj.Value("bio").String().Empty()
+		obj.Value("homeChannel").Null()
+	})
+}
+
+func TestPatchUserRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		DisplayName optional.String
+		TwitterID   optional.String
+		Role        optional.String
+		State       optional.Int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty",
+			fields{},
+			false,
+		},
+		{
+			"too long display name",
+			fields{DisplayName: optional.StringFrom(strings.Repeat("a", 100))},
+			true,
+		},
+		{
+			"success",
+			fields{DisplayName: optional.StringFrom("ぽ")},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PatchUserRequest{
+				DisplayName: tt.fields.DisplayName,
+				TwitterID:   tt.fields.TwitterID,
+				Role:        tt.fields.Role,
+				State:       tt.fields.State,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_EditUser(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	userSession := env.S(t, user.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID()).
+			WithJSON(&PatchUserRequest{DisplayName: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (too long display name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID()).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PatchUserRequest{DisplayName: optional.StringFrom(strings.Repeat("a", 100))}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID()).
+			WithCookie(session.CookieName, userSession).
+			WithJSON(&PatchUserRequest{DisplayName: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PatchUserRequest{DisplayName: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success (changing user state)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user2.GetID()).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PatchUserRequest{State: optional.IntFrom(int64(model.UserAccountStatusDeactivated))}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		profile, err := env.Repository.GetUser(user2.GetID(), true)
+		require.NoError(t, err)
+		assert.EqualValues(t, model.UserAccountStatusDeactivated, profile.GetState())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, user.GetID()).
+			WithCookie(session.CookieName, adminSession).
+			WithJSON(&PatchUserRequest{DisplayName: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		profile, err := env.Repository.GetUser(user.GetID(), true)
+		require.NoError(t, err)
+		assert.EqualValues(t, "po", profile.GetDisplayName())
+	})
+}
+
+func TestHandlers_GetMyChannelSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/subscriptions"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	err := env.CM.ChangeChannelSubscriptions(ch.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+		user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
+	}, false, user.GetID())
+	require.NoError(t, err)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+
+		first := obj.First().Object()
+		first.Value("channelId").String().Equal(ch.ID.String())
+		first.Value("level").Number().Equal(model.ChannelSubscribeLevelMarkAndNotify)
+	})
+}
+
+func TestPutChannelSubscribeLevelRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Level optional.Int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"invalid level",
+			fields{Level: optional.IntFrom(-1)},
+			true,
+		},
+		{
+			"invalid",
+			fields{},
+			true,
+		},
+		{
+			"success",
+			fields{Level: optional.IntFrom(1)},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PutChannelSubscribeLevelRequest{
+				Level: tt.fields.Level,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_SetChannelSubscribeLevel(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/me/subscriptions/{channelId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	forced := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	err := env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.BoolFrom(true)})
+	require.NoError(t, err)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, ch.ID).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (invalid level)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutChannelSubscribeLevelRequest{Level: optional.IntFrom(-1)}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("forbidden (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, dm.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutChannelSubscribeLevelRequest{Level: optional.IntFrom(2)}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("forbidden (forced)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, forced.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutChannelSubscribeLevelRequest{Level: optional.IntFrom(2)}).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutChannelSubscribeLevelRequest{Level: optional.IntFrom(2)}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PUT(path, ch.ID).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PutChannelSubscribeLevelRequest{Level: optional.IntFrom(2)}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.UUIDFrom(ch.ID)})
+		require.NoError(t, err)
+		if assert.Len(t, subs, 1) {
+			sub := subs[0]
+			assert.EqualValues(t, user.GetID(), sub.UserID)
+			assert.True(t, sub.Mark)
+			assert.True(t, sub.Notify)
+		}
+	})
+}
+
+func TestHandlers_GetUserStats(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/users/{userId}/stats"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	stamp := env.CreateStamp(t, user.GetID(), rand)
+	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, user.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, user.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("totalMessageCount").Number().Equal(1)
+
+		stamps := obj.Value("stamps").Array()
+		stamps.Length().Equal(1)
+		firstStamp := stamps.First().Object()
+		firstStamp.Value("id").String().Equal(stamp.ID.String())
+		firstStamp.Value("count").Number().Equal(1)
+		firstStamp.Value("total").Number().Equal(2)
+
+		obj.Value("datetime").String().NotEmpty()
 	})
 }

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -5,9 +5,14 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
@@ -19,9 +24,6 @@ import (
 	"github.com/traPtitech/traQ/utils/hmac"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/validator"
-	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
 // GetWebhooks GET /webhooks
@@ -123,8 +125,8 @@ type PatchWebhookRequest struct {
 
 func (r PatchWebhookRequest) ValidateWithContext(ctx context.Context) error {
 	return vd.ValidateStructWithContext(ctx, &r,
-		vd.Field(&r.Name, vd.RuneLength(1, 32)),
-		vd.Field(&r.Description, vd.RuneLength(1, 1000)),
+		vd.Field(&r.Name, validator.RequiredIfValid, vd.RuneLength(1, 32)),
+		vd.Field(&r.Description, validator.RequiredIfValid, vd.RuneLength(1, 1000)),
 		vd.Field(&r.ChannelID, validator.NotNilUUID, utils.IsPublicChannelID),
 		vd.Field(&r.Secret, vd.RuneLength(0, 50)),
 		vd.Field(&r.OwnerID, validator.NotNilUUID, utils.IsActiveHumanUserID),

--- a/router/v3/webhooks_test.go
+++ b/router/v3/webhooks_test.go
@@ -1,0 +1,543 @@
+package v3
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"net/http"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/repository"
+	"github.com/traPtitech/traQ/router/session"
+	file2 "github.com/traPtitech/traQ/service/file"
+	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/optional"
+	random2 "github.com/traPtitech/traQ/utils/random"
+)
+
+func webhookEquals(t *testing.T, expect model.Webhook, actual *httpexpect.Object) {
+	t.Helper()
+	actual.Value("id").String().Equal(expect.GetID().String())
+	actual.Value("botUserId").String().Equal(expect.GetBotUserID().String())
+	actual.Value("displayName").String().Equal(expect.GetName())
+	actual.Value("description").String().Equal(expect.GetDescription())
+	actual.Value("secure").Boolean().Equal(len(expect.GetSecret()) > 0)
+	actual.Value("channelId").String().Equal(expect.GetChannelID().String())
+	actual.Value("ownerId").String().Equal(expect.GetCreatorID().String())
+	actual.Value("createdAt").String().NotEmpty()
+	actual.Value("updatedAt").String().NotEmpty()
+}
+
+func TestHandlers_GetWebhooks(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks"
+	env := Setup(t, s1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	admin := env.CreateAdmin(t, rand)
+	ch := env.CreateChannel(t, rand)
+
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+	wh2 := env.CreateWebhook(t, rand, user2.GetID(), ch.ID)
+
+	userSession := env.S(t, user.GetID())
+	adminSession := env.S(t, admin.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success (all=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, userSession).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		webhookEquals(t, wh, obj.First().Object())
+	})
+
+	t.Run("success (all=false without permission)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, userSession).
+			WithQuery("all", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		webhookEquals(t, wh, obj.First().Object())
+	})
+
+	t.Run("success (all=true)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithCookie(session.CookieName, adminSession).
+			WithQuery("all", true).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(2)
+
+		if obj.First().Object().Value("id").Raw() == wh.GetID().String() {
+			webhookEquals(t, wh, obj.Element(0).Object())
+			webhookEquals(t, wh2, obj.Element(1).Object())
+		} else {
+			webhookEquals(t, wh2, obj.Element(0).Object())
+			webhookEquals(t, wh, obj.Element(1).Object())
+		}
+	})
+}
+
+func TestHandlers_GetWebhookIcon(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}/icon"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+
+	file, err := file2.GenerateIconFile(env.FM, "wh")
+	require.NoError(t, err)
+	wh, err := env.Repository.CreateWebhook(random2.AlphaNumeric(20), "", ch.ID, file, user.GetID(), "")
+	require.NoError(t, err)
+
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, wh.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			ContentType("image/png")
+	})
+}
+
+func TestHandlers_CreateWebhook(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	s := env.S(t, user.GetID())
+
+	req := &PostWebhooksRequest{
+		Name:        random2.SecureAlphaNumeric(20),
+		Description: "desc",
+		ChannelID:   ch.ID,
+	}
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (nil uuid)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostWebhooksRequest{Name: "po", Description: "", ChannelID: uuid.Nil}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(req).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("botUserId").String().NotEmpty()
+		obj.Value("displayName").String().Equal(req.Name)
+		obj.Value("description").String().Equal(req.Description)
+		obj.Value("secure").Boolean().False()
+		obj.Value("channelId").String().Equal(req.ChannelID.String())
+		obj.Value("ownerId").String().Equal(user.GetID().String())
+		obj.Value("createdAt").String().NotEmpty()
+		obj.Value("updatedAt").String().NotEmpty()
+	})
+}
+
+func TestHandlers_GetWebhook(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, wh.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		webhookEquals(t, wh, obj)
+	})
+}
+
+func TestHandlers_EditWebhook(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, wh.GetID()).
+			WithJSON(&PatchWebhookRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request (empty name)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchWebhookRequest{Name: optional.StringFrom("")}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchWebhookRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.PATCH(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PatchWebhookRequest{Name: optional.StringFrom("po")}).
+			Expect().
+			Status(http.StatusNoContent)
+
+		wh, err := env.Repository.GetWebhook(wh.GetID())
+		require.NoError(t, err)
+		assert.EqualValues(t, "po", wh.GetName())
+	})
+}
+
+func TestHandlers_PostWebhook(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	ch2 := env.CreateChannel(t, rand)
+	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
+	archived := env.CreateChannel(t, rand)
+	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+
+	calcHMACSHA1 := func(t *testing.T, message, secret string) string {
+		t.Helper()
+		mac := hmac.New(sha1.New, []byte(secret))
+		_, _ = mac.Write([]byte(message))
+		return hex.EncodeToString(mac.Sum(nil))
+	}
+
+	t.Run("bad request (empty body)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "", wh.GetSecret())).
+			WithText("").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (no signature)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithText("test").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (bad signature)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "test", wh.GetSecret())).
+			WithText("testTestTest").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (invalid channel id)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "xxpoxx", wh.GetSecret())).
+			WithHeader("X-TRAQ-Channel-id", "invalid").
+			WithText("xxpoxx").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (dm)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "xxpoxx", wh.GetSecret())).
+			WithHeader("X-TRAQ-Channel-id", dm.ID.String()).
+			WithText("xxpoxx").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (archived)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "xxpoxx", wh.GetSecret())).
+			WithHeader("X-TRAQ-Channel-id", archived.ID.String()).
+			WithText("xxpoxx").
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, uuid.Must(uuid.NewV4())).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "test", wh.GetSecret())).
+			WithText("test").
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("unsupported media type", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "xxpoxx", wh.GetSecret())).
+			WithJSON(map[string]interface{}{"text": "xxpoxx"}).
+			Expect().
+			Status(http.StatusUnsupportedMediaType)
+	})
+
+	t.Run("success with X-TRAQ-Channel-Id", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "xxpoxx", wh.GetSecret())).
+			WithHeader("X-TRAQ-Channel-id", ch2.ID.String()).
+			WithText("xxpoxx").
+			Expect().
+			Status(http.StatusNoContent)
+
+		tl, err := env.MM.GetTimeline(message.TimelineQuery{Channel: ch2.ID})
+		require.NoError(t, err)
+		if assert.Len(t, tl.Records(), 1) {
+			m := tl.Records()[0]
+			assert.EqualValues(t, wh.GetBotUserID(), m.GetUserID())
+			assert.EqualValues(t, "xxpoxx", m.GetText())
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path, wh.GetID()).
+			WithHeader("X-TRAQ-Signature", calcHMACSHA1(t, "test", wh.GetSecret())).
+			WithQuery("embed", 1).
+			WithText("test").
+			Expect().
+			Status(http.StatusNoContent)
+
+		tl, err := env.MM.GetTimeline(message.TimelineQuery{Channel: ch.ID})
+		require.NoError(t, err)
+		if assert.Len(t, tl.Records(), 1) {
+			m := tl.Records()[0]
+			assert.EqualValues(t, wh.GetBotUserID(), m.GetUserID())
+			assert.EqualValues(t, "test", m.GetText())
+		}
+	})
+}
+
+func TestHandlers_DeleteWebhook(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	user2 := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+	wh2 := env.CreateWebhook(t, rand, user2.GetID(), ch.ID)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, wh.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, wh2.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.DELETE(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNoContent)
+
+		_, err := env.Repository.GetWebhook(wh.GetID())
+		assert.ErrorIs(t, err, repository.ErrNotFound)
+	})
+}
+
+func TestHandlers_GetWebhookMessages(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webhooks/{webhookId}/messages"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	ch := env.CreateChannel(t, rand)
+	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
+	m := env.CreateMessage(t, wh.GetBotUserID(), ch.ID, "test")
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, wh.GetID()).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			WithQuery("limit", 500).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path, uuid.Must(uuid.NewV4())).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusNotFound)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path, wh.GetID()).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		messageEquals(t, m, obj.First().Object())
+	})
+}

--- a/router/v3/webrtc_test.go
+++ b/router/v3/webrtc_test.go
@@ -1,0 +1,89 @@
+package v3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/traPtitech/traQ/router/session"
+)
+
+func TestPostWebRTCAuthenticateRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		PeerID string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"empty peer id",
+			fields{PeerID: ""},
+			true,
+		},
+		{
+			"success",
+			fields{PeerID: uuid.Must(uuid.NewV4()).String()},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := PostWebRTCAuthenticateRequest{
+				PeerID: tt.fields.PeerID,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlers_PostWebRTCAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v3/webrtc/authenticate"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	s := env.S(t, user.GetID())
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostWebRTCAuthenticateRequest{PeerID: user.GetID().String()}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostWebRTCAuthenticateRequest{PeerID: ""}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, s).
+			WithJSON(&PostWebRTCAuthenticateRequest{PeerID: user.GetID().String()}).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+
+		obj.Value("peerId").String().Equal(user.GetID().String())
+		obj.Value("ttl").Number()
+		obj.Value("timestamp").Number()
+		obj.Value("authToken").String().NotEmpty()
+	})
+}

--- a/service/search/engine.go
+++ b/service/search/engine.go
@@ -2,11 +2,13 @@ package search
 
 import (
 	"errors"
-	vd "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/traPtitech/traQ/service/message"
-	"github.com/traPtitech/traQ/utils/optional"
 	"regexp"
 	"strings"
+
+	vd "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/optional"
 )
 
 // ErrServiceUnavailable エラー 現在検索サービスが利用できません

--- a/utils/jwt/signer.go
+++ b/utils/jwt/signer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
+
 	"github.com/dgrijalva/jwt-go"
 )
 

--- a/utils/validator/rules.go
+++ b/utils/validator/rules.go
@@ -42,7 +42,7 @@ var BotUserNameRuleRequired = append([]vd.Rule{
 
 // UserGroupNameRule ユーザーグループ名バリデーションルール
 var UserGroupNameRule = []vd.Rule{
-	vd.Match(regexp.MustCompile(`^[^@＠#＃]*[^@＠#＃:]$`)).Error("must not contain [@＠#＃] and the last charactor must not be :"),
+	vd.Match(regexp.MustCompile(`^[^@＠#＃]*[^@＠#＃:]$`)).Error("must not contain [@＠#＃] and the last character must not be :"),
 	vd.RuneLength(1, 30),
 }
 

--- a/utils/validator/rules.go
+++ b/utils/validator/rules.go
@@ -7,6 +7,16 @@ import (
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 )
 
+// RequiredIfValid utils/optional系の値がvalid時に空の値を弾く
+//
+// 仕組み:
+// utils/optional系の値は sql.Valuer を実装している
+// Valid: false の場合、nilがvalidationされるので通る
+// Valid: true かつ空の値の場合、空の値がvalidationされるので通らない
+//
+// 分かりやすいように & このコメントを書くため名前を付けている
+var RequiredIfValid = vd.NilOrNotEmpty
+
 // PasswordRule パスワードバリデーションルール
 var PasswordRule = []vd.Rule{
 	is.PrintableASCII,
@@ -87,11 +97,6 @@ var StampPaletteNameRuleRequired = append([]vd.Rule{
 var StampPaletteDescriptionRule = []vd.Rule{
 	vd.RuneLength(0, 1000),
 }
-
-// StampPaletteDescriptionRuleRequired スタンプパレット説明バリデーションルール with Required
-var StampPaletteDescriptionRuleRequired = append([]vd.Rule{
-	vd.Required,
-}, StampPaletteDescriptionRule...)
 
 // StampPaletteStampsRule スタンプパレット内スタンプバリデーションルール
 var StampPaletteStampsRule = []vd.Rule{


### PR DESCRIPTION
テスト以外のnotableな変更点
Swaggerのレスポンスと実際のレスポンスが乖離していた系
- `getBotLogs` `GET /bot/{botId}/logs` のレスポンスの`datetime`フィールドのcasingが違った
  - swaggerに合わせて`dateTime` -> `datetime`に
  - bot-consoleが利用していたので同時に変更することで対処 https://github.com/traPtitech/traQ-bot-console/pull/308
- `getChannelBots` `GET /channels/{channelId}/bots` のレスポンスの`id`フィールド名が違った
  - swaggerに合わせて`botId` -> `id`に
  - 少なくとも現UI, bot-consoleでは使っていない
- `reissueBot` `POST /bots/{botId}/actions/reissue` のレスポンスの`verificationToken`フィールド名が違った
  - swaggerに合わせて`verificationCode` -> `verificationToken`に
  - 少なくとも現UI, bot-consoleでは使っていない
- `editMessage` `PUT /messages/{messageId}` のレスポンスが違った
  - 実装に合わせて`200 OK` -> `204 No Content`に
  - 少なくとも現UI, bot-consoleでは使っていない
- `editWebhook` `PATCH /webhooks/{webhookId}` のレスポンスが違った
  - 実装に合わせて`200 OK` -> `204 No Content`に
  - 少なくとも現UI, bot-consoleでは使っていない

closes #1203 