### PR TITLE
ESに検索時に渡す時刻をnsec精度に

### DIFF
--- a/service/search/es.go
+++ b/service/search/es.go
@@ -18,7 +18,7 @@ const (
 	esRequiredVersion = "7.10.2"
 	esIndexPrefix     = "traq_"
 	esMessageIndex    = "message"
-	esDateFormat      = "2006-01-02T15:04:05Z"
+	esDateFormat      = "2006-01-02T15:04:05.000000000Z"
 )
 
 func getIndexName(index string) string {


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#missing-date-components

