### PR TITLE
「未読管理+通知」から「未読管理」への変更時もチャンネルイベントへ記録する

### DIFF
--- a/repository/channel_impl.go
+++ b/repository/channel_impl.go
@@ -314,6 +314,9 @@ func (repo *GormRepository) ChangeChannelSubscription(channelID uuid.UUID, args 
 						return err
 					}
 				}
+				if current[uid] == model.ChannelSubscribeLevelMarkAndNotify {
+					off = append(off, uid)
+				}
 
 			case model.ChannelSubscribeLevelMarkAndNotify:
 				if _, ok := current[uid]; ok {


### PR DESCRIPTION
他人のチャンネルの通知を変更するとき指定できるのは、「未読管理+通知」と「それ以外」である
この仕様に沿うと、チャンネルイベントに記録されるのは「未読管理+通知」と「それ以外」間の状態遷移がなされた場合である
→ 「未読管理+通知」から「未読管理」の場合にイベントが記録されないようになっていた

ref: https://q.trap.jp/messages/2a61cf6e-55b7-43d0-8705-23fb125d7bc3