### PR TITLE
shutdown / thread safety fix

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	DevMode bool `mapstructure:"dev" yaml:"dev"`
 	// Pprof pprofを有効にするかどうか (default: false)
 	Pprof bool `mapstructure:"pprof" yaml:"pprof"`
+	// ShutdownTimeout サーバーシャットダウン時のタイムアウトまでの秒数 (default: 9)
+	ShutdownTimeout int64 `mapstructure:"shutdownTimeout" yaml:"shutdownTimeout"`
 
 	// Origin サーバーオリジン (default: http://localhost:3000)
 	Origin string `mapstructure:"origin" yaml:"origin"`
@@ -226,6 +228,7 @@ type Config struct {
 func init() {
 	viper.SetDefault("dev", false)
 	viper.SetDefault("pprof", false)
+	viper.SetDefault("shutdownTimeout", 9)
 	viper.SetDefault("origin", "http://localhost:3000")
 	viper.SetDefault("port", 3000)
 	viper.SetDefault("gzip", true)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,7 +148,7 @@ func waitSIGINT() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	signal.Stop(quit)
+	close(quit)
 	for range quit {
 	}
-	close(quit)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -211,6 +211,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error { return s.Router.Shutdown(ctx) })
 	eg.Go(func() error { return s.SS.WS.Close() })
+	eg.Go(func() error { return s.SS.BotWS.Close() })
 	eg.Go(func() error { return s.SS.BOT.Shutdown(ctx) })
 	eg.Go(func() error { return s.SS.OGP.Shutdown() })
 	eg.Go(func() error {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -167,7 +167,7 @@ func serveCommand() *cobra.Command {
 			waitSIGINT()
 			logger.Info("traQ shutting down...")
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
 			defer cancel()
 			if err := server.Shutdown(ctx); err != nil {
 				logger.Warn("abnormal shutdown", zap.Error(err))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -165,6 +165,7 @@ func serveCommand() *cobra.Command {
 
 			logger.Info("traQ started")
 			waitSIGINT()
+			logger.Info("traQ shutting down...")
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -209,19 +210,45 @@ func (s *Server) Start(address string) error {
 
 func (s *Server) Shutdown(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error { return s.Router.Shutdown(ctx) })
-	eg.Go(func() error { return s.SS.WS.Close() })
-	eg.Go(func() error { return s.SS.BotWS.Close() })
-	eg.Go(func() error { return s.SS.BOT.Shutdown(ctx) })
-	eg.Go(func() error { return s.SS.OGP.Shutdown() })
+	eg.Go(func() error {
+		err := s.Router.Shutdown(ctx)
+		s.L.Info("Router shutdown")
+		return err
+	})
+	eg.Go(func() error {
+		err := s.SS.WS.Close()
+		s.L.Info("WebSocket shutdown")
+		return err
+	})
+	eg.Go(func() error {
+		err := s.SS.BotWS.Close()
+		s.L.Info("Bot WebSocket shutdown")
+		return err
+	})
+	eg.Go(func() error {
+		err := s.SS.BOT.Shutdown(ctx)
+		s.L.Info("Bot shutdown")
+		return err
+	})
+	eg.Go(func() error {
+		err := s.SS.OGP.Shutdown()
+		s.L.Info("OGP shutdown")
+		return err
+	})
 	eg.Go(func() error {
 		s.SS.FCM.Close()
+		s.L.Info("FCM shutdown")
 		return nil
 	})
 	eg.Go(func() error {
 		s.SS.ChannelManager.Wait()
+		s.L.Info("Channel manager shutdown")
 		return nil
 	})
-	eg.Go(func() error { return s.SS.MessageManager.Wait(ctx) })
+	eg.Go(func() error {
+		err := s.SS.MessageManager.Wait(ctx)
+		s.L.Info("Message manager shutdown")
+		return err
+	})
 	return eg.Wait()
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -167,7 +167,7 @@ func serveCommand() *cobra.Command {
 			waitSIGINT()
 			logger.Info("traQ shutting down...")
 
-			ctx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.ShutdownTimeout)*time.Second)
 			defer cancel()
 			if err := server.Shutdown(ctx); err != nil {
 				logger.Warn("abnormal shutdown", zap.Error(err))

--- a/service/bot/service_impl.go
+++ b/service/bot/service_impl.go
@@ -99,7 +99,6 @@ func (p *serviceImpl) Shutdown(ctx context.Context) error {
 	p.hub.Unsubscribe(p.sub)
 	p.logPurger.Stop()
 	p.wg.Wait()
-	p.logger.Info("bot service shutdown")
 	return nil
 }
 

--- a/service/bot/ws/session.go
+++ b/service/bot/ws/session.go
@@ -17,7 +17,7 @@ type session struct {
 
 	req      *http.Request
 	conn     *websocket.Conn
-	open     bool
+	closed   bool
 	streamer *Streamer
 	send     chan *rawMessage
 }
@@ -76,7 +76,7 @@ func (s *session) writeLoop() {
 func (s *session) writeMessage(msg *rawMessage) (err error) {
 	s.RLock()
 	defer s.RUnlock()
-	if !s.open {
+	if s.closed {
 		return ErrAlreadyClosed
 	}
 
@@ -96,8 +96,9 @@ func (s *session) write(messageType int, data []byte) error {
 func (s *session) close() {
 	s.Lock()
 	defer s.Unlock()
-	if s.open {
-		s.open = false
+
+	if !s.closed {
+		s.closed = true
 		s.conn.Close()
 		close(s.send)
 	}

--- a/service/bot/ws/streamer.go
+++ b/service/bot/ws/streamer.go
@@ -130,7 +130,7 @@ func (s *Streamer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		key:      random.AlphaNumeric(20),
 		req:      r,
 		conn:     conn,
-		open:     true,
+		closed:   false,
 		streamer: s,
 		send:     make(chan *rawMessage, messageBufferSize),
 		userID:   r.Context().Value(ctxkey.UserID).(uuid.UUID),

--- a/service/ogp/service_impl.go
+++ b/service/ogp/service_impl.go
@@ -52,7 +52,6 @@ func (s *ServiceImpl) Start() error {
 func (s *ServiceImpl) Shutdown() error {
 	s.cachePurger.Stop()
 	s.wg.Wait()
-	s.logger.Info("OGP service shutdown")
 	return nil
 }
 

--- a/service/ws/session.go
+++ b/service/ws/session.go
@@ -91,19 +91,12 @@ func (s *session) writeLoop() {
 	}
 }
 
-func (s *session) writeMessage(msg *rawMessage) (err error) {
+func (s *session) writeMessage(msg *rawMessage) error {
 	s.RLock()
+	defer s.RUnlock()
 	if s.closed {
-		s.RUnlock()
 		return ErrAlreadyClosed
 	}
-	s.RUnlock()
-	defer func() {
-		// workaround fix https://github.com/traPtitech/traQ/issues/949
-		if perr := recover(); perr != nil {
-			err = ErrAlreadyClosed
-		}
-	}()
 
 	select {
 	case s.send <- msg:

--- a/service/ws/streamer.go
+++ b/service/ws/streamer.go
@@ -110,7 +110,7 @@ func (s *Streamer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		key:      random.AlphaNumeric(20),
 		req:      r,
 		conn:     conn,
-		open:     true,
+		closed:   false,
 		streamer: s,
 		send:     make(chan *rawMessage, messageBufferSize),
 		userID:   r.Context().Value(ctxkey.UserID).(uuid.UUID),


### PR DESCRIPTION
- BOT WSサービスをshutdownしてなかった
- スレッド安全でない箇所を少し直した
- そもそもサービスの正常なshutdownができてなかったっぽい
- shutdownのtimeoutを9sに
  - docker stopでSIGKILLが送られるのが10s後だから