### PR TITLE
未ログイン時に/authorizeを叩いた場合は/loginにリダイレクトするように

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.0
 	github.com/golang/mock v1.6.0
+	github.com/google/go-querystring v1.1.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hajimehoshi/go-mp3 v0.3.2
@@ -75,7 +76,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
-	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/pprof v0.0.0-20220113144219-d25a53d42d00 // indirect
 	github.com/google/subcommands v1.0.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,9 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/router/oauth2/oauth2.go
+++ b/router/oauth2/oauth2.go
@@ -29,7 +29,6 @@ const (
 	errInvalidClient           = "invalid_client"
 	errInvalidGrant            = "invalid_grant"
 	errUnsupportedGrantType    = "unsupported_grant_type"
-	errLoginRequired           = "login_required"
 	errConsentRequired         = "consent_required"
 
 	oauth2ContextSession = "oauth2_context"


### PR DESCRIPTION
## なぜ

https://github.com/traPtitech/traQ_S-UI/issues/762 を解決したい。

## なに

これまでの未ログイン時に`/api/v3/oauth2/authorize`を叩いた場合の動作
1. 未ログインで/authorizeがたたかれる
2. 302で/consentにリダイレクト
3. フロントの(SPA)遷移で/loginに移動
4. ユーザーのログイン操作
5. フロントの(SPA)遷移で/consentに移動
6. ユーザーの同意操作 & /decideへのPOST

これを入れることにより実現したい動作
1. 未ログインで/authorizeがたたかれる
2. 302で/loginにリダイレクト
3. ユーザーのログイン操作
4. (フロントでのリダイレクト(location.hrefの変更)で)/authorizeが叩かれる
5. 302で/consentに移動
6. ユーザーの同意操作 & /decideへのPOST

## つぎ

↑の動作を実現したいが、これだけだと4.でこうなるので
![Screenshot 2022-04-10 174636](https://user-images.githubusercontent.com/18257693/162610579-d0c0cabb-6afa-4df4-8d3f-ed5bdf300ec4.png)
フロントをいじってSPAの遷移ではなく`/api`を叩くようにする必要がある