### PR TITLE
`GET /stamps`にtypeクエリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vagrant
 .envrc
 /.idea/
+/.vscode/
 /vendor/
 /dev/data/
 /dist/

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -809,7 +809,13 @@ paths:
             default: true
           in: query
           name: include-unicode
-          description: Unicode絵文字を含ませるかどうか
+          description: (Duplicated) Unicode絵文字を含ませるかどうか
+        - schema:
+            type: string
+            enum: [unicode, original]
+          in: query
+          name: type
+          description: 取得するスタンプの種類
       description: スタンプのリストを取得します。
   /users/me/stamp-history:
     get:

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -809,7 +809,10 @@ paths:
             default: true
           in: query
           name: include-unicode
-          description: (Duplicated) Unicode絵文字を含ませるかどうか
+          duplicated: true
+          description: |
+            Unicode絵文字を含ませるかどうか
+            Deprecated: typeクエリを指定しなければ全てのスタンプを取得できるため、そちらを利用してください
         - schema:
             type: string
             enum: [unicode, original]

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -809,7 +809,7 @@ paths:
             default: true
           in: query
           name: include-unicode
-          duplicated: true
+          deprecated: true
           description: |
             Unicode絵文字を含ませるかどうか
             Deprecated: typeクエリを指定しなければ全てのスタンプを取得できるため、そちらを利用してください

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -64,9 +64,9 @@ func (r *stampRepository) regenerateJSON() {
 	for _, stamp := range r.stamps {
 		arrAll = append(arrAll, stamp)
 		if stamp.IsUnicode {
-			arrOriginal = append(arrOriginal, stamp)
-		} else {
 			arrUnicode = append(arrUnicode, stamp)
+		} else {
+			arrOriginal = append(arrOriginal, stamp)
 		}
 	}
 

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -296,27 +296,27 @@ func (repo *Repository) DeleteStamp(id uuid.UUID) (err error) {
 }
 
 // GetAllStamps implements StampRepository interface.
-func (repo *Repository) GetAllStamps(stampType int) (stamps []*model.Stamp, err error) {
+func (repo *Repository) GetAllStamps(stampType repository.StampType) (stamps []*model.Stamp, err error) {
 	stamps = make([]*model.Stamp, 0)
 	tx := repo.db
 	switch stampType {
-	case 1:
+	case repository.StampTypeUnicode:
 		tx = tx.Where("is_unicode = TRUE")
-	case 2:
+	case repository.StampTypeOriginal:
 		tx = tx.Where("is_unicode = FALSE")
 	}
 	return stamps, tx.Find(&stamps).Error
 }
 
 // GetStampsJSON implements StampRepository interface.
-func (repo *Repository) GetStampsJSON(stampType int) ([]byte, time.Time, error) {
+func (repo *Repository) GetStampsJSON(stampType repository.StampType) ([]byte, time.Time, error) {
 	if repo.stamps != nil {
 		repo.stamps.RLock()
 		defer repo.stamps.RUnlock()
 		switch stampType {
-		case 1:
+		case repository.StampTypeUnicode:
 			return repo.stamps.unicodeJSON, repo.stamps.updatedAt, nil
-		case 2:
+		case repository.StampTypeOriginal:
 			return repo.stamps.originalJSON, repo.stamps.updatedAt, nil
 		default:
 			return repo.stamps.allJSON, repo.stamps.updatedAt, nil

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -18,10 +18,11 @@ import (
 )
 
 type stampRepository struct {
-	stamps    map[uuid.UUID]*model.Stamp
-	allJSON   []byte
-	json      []byte
-	updatedAt time.Time
+	stamps       map[uuid.UUID]*model.Stamp
+	allJSON      []byte
+	unicodeJSON  []byte
+	originalJSON []byte
+	updatedAt    time.Time
 	sync.RWMutex
 }
 
@@ -57,20 +58,29 @@ func (r *stampRepository) delete(id uuid.UUID) {
 }
 
 func (r *stampRepository) regenerateJSON() {
-	arr := make([]*model.Stamp, 0, len(r.stamps))
+	arrOriginal := make([]*model.Stamp, 0, len(r.stamps))
+	arrUnicode := make([]*model.Stamp, 0, len(r.stamps))
 	arrAll := make([]*model.Stamp, 0, len(r.stamps))
 	for _, stamp := range r.stamps {
 		arrAll = append(arrAll, stamp)
-		if !stamp.IsUnicode {
-			arr = append(arr, stamp)
+		if stamp.IsUnicode {
+			arrOriginal = append(arrOriginal, stamp)
+		} else {
+			arrUnicode = append(arrUnicode, stamp)
 		}
 	}
 
-	b, err := jsoniter.ConfigFastest.Marshal(arr)
+	b, err := jsoniter.ConfigFastest.Marshal(arrUnicode)
 	if err != nil {
 		panic(err)
 	}
-	r.json = b
+	r.unicodeJSON = b
+
+	b, err = jsoniter.ConfigFastest.Marshal(arrOriginal)
+	if err != nil {
+		panic(err)
+	}
+	r.originalJSON = b
 
 	b, err = jsoniter.ConfigFastest.Marshal(arrAll)
 	if err != nil {
@@ -286,27 +296,34 @@ func (repo *Repository) DeleteStamp(id uuid.UUID) (err error) {
 }
 
 // GetAllStamps implements StampRepository interface.
-func (repo *Repository) GetAllStamps(excludeUnicode bool) (stamps []*model.Stamp, err error) {
+func (repo *Repository) GetAllStamps(stampType int) (stamps []*model.Stamp, err error) {
 	stamps = make([]*model.Stamp, 0)
 	tx := repo.db
-	if excludeUnicode {
+	switch stampType {
+	case 1:
+		tx = tx.Where("is_unicode = TRUE")
+	case 2:
 		tx = tx.Where("is_unicode = FALSE")
 	}
 	return stamps, tx.Find(&stamps).Error
 }
 
 // GetStampsJSON implements StampRepository interface.
-func (repo *Repository) GetStampsJSON(excludeUnicode bool) ([]byte, time.Time, error) {
+func (repo *Repository) GetStampsJSON(stampType int) ([]byte, time.Time, error) {
 	if repo.stamps != nil {
 		repo.stamps.RLock()
 		defer repo.stamps.RUnlock()
-		if excludeUnicode {
-			return repo.stamps.json, repo.stamps.updatedAt, nil
+		switch stampType {
+		case 1:
+			return repo.stamps.unicodeJSON, repo.stamps.updatedAt, nil
+		case 2:
+			return repo.stamps.originalJSON, repo.stamps.updatedAt, nil
+		default:
+			return repo.stamps.allJSON, repo.stamps.updatedAt, nil
 		}
-		return repo.stamps.allJSON, repo.stamps.updatedAt, nil
 	}
 
-	stamps, err := repo.GetAllStamps(excludeUnicode)
+	stamps, err := repo.GetAllStamps(stampType)
 	if err != nil {
 		return nil, time.Time{}, err
 	}

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -269,7 +269,7 @@ func TestRepositoryImpl_ExistStamps(t *testing.T) {
 		assert.Error(repo.ExistStamps(stampIDsCopy))
 	})
 
-	t.Run("sucess", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -206,7 +206,7 @@ func TestRepositoryImpl_GetAllStamps(t *testing.T) {
 		mustMakeStamp(t, repo, rand, uuid.Nil)
 	}
 
-	arr, err := repo.GetAllStamps(false)
+	arr, err := repo.GetAllStamps(0)
 	if assert.NoError(err) {
 		assert.Len(arr, n)
 	}

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -206,7 +206,7 @@ func TestRepositoryImpl_GetAllStamps(t *testing.T) {
 		mustMakeStamp(t, repo, rand, uuid.Nil)
 	}
 
-	arr, err := repo.GetAllStamps(0)
+	arr, err := repo.GetAllStamps(repository.StampTypeAll)
 	if assert.NoError(err) {
 		assert.Len(arr, n)
 	}

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -87,13 +87,11 @@ type StampRepository interface {
 	DeleteStamp(id uuid.UUID) (err error)
 	// GetAllStamps 全てのスタンプを取得します
 	//
-	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、スタンプの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
 	GetAllStamps(stampType StampType) (stamps []*model.Stamp, err error)
 	// GetStampsJSON スタンプ一覧のJSON文字列を取得します
 	//
-	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、JSONの[]byte表現とnilを返します。
 	// DBによるエラーを返すことがあります。
 	GetStampsJSON(stampType StampType) ([]byte, time.Time, error)

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -36,6 +36,18 @@ type StampStats struct {
 	TotalCount int64 `json:"totalCount"`
 }
 
+// StampType スタンプの種類
+type StampType string
+
+const (
+	// StampTypeUnicode Unicodeスタンプ
+	StampTypeUnicode StampType = "unicode"
+	// StampTypeOriginal オリジナルスタンプ
+	StampTypeOriginal StampType = "original"
+	// StampTypeAll 全てのスタンプ
+	StampTypeAll StampType = "all"
+)
+
 // StampRepository スタンプリポジトリ
 type StampRepository interface {
 	// CreateStamp スタンプを作成します
@@ -78,13 +90,13 @@ type StampRepository interface {
 	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、スタンプの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllStamps(stampType int) (stamps []*model.Stamp, err error)
+	GetAllStamps(stampType StampType) (stamps []*model.Stamp, err error)
 	// GetStampsJSON スタンプ一覧のJSON文字列を取得します
 	//
 	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、JSONの[]byte表現とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetStampsJSON(stampType int) ([]byte, time.Time, error)
+	GetStampsJSON(stampType StampType) ([]byte, time.Time, error)
 	// StampExists 指定したIDのスタンプが存在するかどうかを返します
 	//
 	// 存在する場合、trueとnilを返します。

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -75,14 +75,16 @@ type StampRepository interface {
 	DeleteStamp(id uuid.UUID) (err error)
 	// GetAllStamps 全てのスタンプを取得します
 	//
+	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、スタンプの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllStamps(excludeUnicode bool) (stamps []*model.Stamp, err error)
+	GetAllStamps(stampType int) (stamps []*model.Stamp, err error)
 	// GetStampsJSON スタンプ一覧のJSON文字列を取得します
 	//
+	// stampTypeが0で全てのスタンプ、1でunicodeスタンプのみ、2でoriginalスタンプのみを取得します。
 	// 成功した場合、JSONの[]byte表現とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetStampsJSON(excludeUnicode bool) ([]byte, time.Time, error)
+	GetStampsJSON(stampType int) ([]byte, time.Time, error)
 	// StampExists 指定したIDのスタンプが存在するかどうかを返します
 	//
 	// 存在する場合、trueとnilを返します。

--- a/router/consts/stamp_type.go
+++ b/router/consts/stamp_type.go
@@ -1,0 +1,6 @@
+package consts
+
+const (
+	StampTypeUnicode  = "unicode"
+	StampTypeOriginal = "original"
+)

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -88,7 +88,7 @@ func (h *Handlers) GetPublicEmojiJSON(c echo.Context) error {
 }
 
 func generateEmojiJSON(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(repository.StampTypeOriginal)
+	stamps, err := repo.GetAllStamps(repository.StampTypeAll)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (h *Handlers) GetPublicEmojiCSS(c echo.Context) error {
 }
 
 func generateEmojiCSS(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(repository.StampTypeOriginal)
+	stamps, err := repo.GetAllStamps(repository.StampTypeAll)
 	if err != nil {
 		return err
 	}

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -88,7 +88,7 @@ func (h *Handlers) GetPublicEmojiJSON(c echo.Context) error {
 }
 
 func generateEmojiJSON(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(0)
+	stamps, err := repo.GetAllStamps(repository.StampTypeOriginal)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (h *Handlers) GetPublicEmojiCSS(c echo.Context) error {
 }
 
 func generateEmojiCSS(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(0)
+	stamps, err := repo.GetAllStamps(repository.StampTypeOriginal)
 	if err != nil {
 		return err
 	}

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -88,7 +88,7 @@ func (h *Handlers) GetPublicEmojiJSON(c echo.Context) error {
 }
 
 func generateEmojiJSON(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(false)
+	stamps, err := repo.GetAllStamps(0)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (h *Handlers) GetPublicEmojiCSS(c echo.Context) error {
 }
 
 func generateEmojiCSS(repo repository.StampRepository, buf *bytes.Buffer) error {
-	stamps, err := repo.GetAllStamps(false)
+	stamps, err := repo.GetAllStamps(0)
 	if err != nil {
 		return err
 	}

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -21,11 +21,19 @@ import (
 // GetStamps GET /stamps
 func (h *Handlers) GetStamps(c echo.Context) error {
 	u := c.QueryParam("include-unicode")
-	if len(u) == 0 {
+	t := c.QueryParam("type")
+	if len(u) == 0 && len(t) == 0 {
 		u = "1"
 	}
 
-	b, updatedAt, err := h.Repo.GetStampsJSON(!isTrue(u))
+	stampType := 0
+	if t == consts.StampTypeUnicode {
+		stampType = 1
+	} else if t == consts.StampTypeOriginal || !isTrue(u) {
+		stampType = 2
+	}
+
+	b, updatedAt, err := h.Repo.GetStampsJSON(stampType)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -26,6 +26,9 @@ func (h *Handlers) GetStamps(c echo.Context) error {
 		u = "1"
 	}
 
+	if len(u) > 0 && len(t) > 0 {
+		return herror.BadRequest("can't use both 'include-unicode' and 'type' query parameters")
+	}
 	stampType := repository.StampTypeAll
 	if t == consts.StampTypeUnicode {
 		stampType = repository.StampTypeUnicode

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -22,12 +22,19 @@ import (
 func (h *Handlers) GetStamps(c echo.Context) error {
 	u := c.QueryParam("include-unicode")
 	t := c.QueryParam("type")
-	if len(u) == 0 && len(t) == 0 {
-		u = "1"
-	}
 
 	if len(u) > 0 && len(t) > 0 {
 		return herror.BadRequest("can't use both 'include-unicode' and 'type' query parameters")
+	}
+	if _, err := strconv.ParseBool(u); len(u) > 0 && err != nil {
+		return herror.BadRequest(err)
+	}
+	if len(t) > 0 && t != consts.StampTypeUnicode && t != consts.StampTypeOriginal {
+		return herror.BadRequest("invalid value for 'type' query parameter")
+	}
+
+	if len(u) == 0 && len(t) == 0 {
+		u = "1"
 	}
 	stampType := repository.StampTypeAll
 	if t == consts.StampTypeUnicode {

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -26,11 +26,11 @@ func (h *Handlers) GetStamps(c echo.Context) error {
 		u = "1"
 	}
 
-	stampType := 0
+	stampType := repository.StampTypeAll
 	if t == consts.StampTypeUnicode {
-		stampType = 1
+		stampType = repository.StampTypeUnicode
 	} else if t == consts.StampTypeOriginal || !isTrue(u) {
-		stampType = 2
+		stampType = repository.StampTypeOriginal
 	}
 
 	b, updatedAt, err := h.Repo.GetStampsJSON(stampType)

--- a/router/v3/stamps_test.go
+++ b/router/v3/stamps_test.go
@@ -74,10 +74,54 @@ func TestHandlers_GetStamps(t *testing.T) {
 			Status(http.StatusBadRequest)
 	})
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("success (no query)", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)
 		obj := e.GET(path).
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		stampEquals(t, stamp, obj.First().Object())
+	})
+
+	t.Run("success (type=original)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithQuery("type", "original").
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(1)
+		stampEquals(t, stamp, obj.First().Object())
+	})
+
+	t.Run("success (type=unicode)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithQuery("type", "unicode").
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Array()
+
+		obj.Length().Equal(0)
+	})
+
+	t.Run("success (include-unicode=false)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		obj := e.GET(path).
+			WithQuery("include-unicode", "false").
 			WithCookie(session.CookieName, s).
 			Expect().
 			Status(http.StatusOK).

--- a/router/v3/stamps_test.go
+++ b/router/v3/stamps_test.go
@@ -43,6 +43,37 @@ func TestHandlers_GetStamps(t *testing.T) {
 			Status(http.StatusUnauthorized)
 	})
 
+	t.Run("bad request (invalid include-unicode query)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithQuery("include-unicode", "invalid").
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (invalid type query)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithQuery("type", "invalid").
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	t.Run("bad request (both query)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.GET(path).
+			WithQuery("include-unicode", "true").
+			WithQuery("type", "original").
+			WithCookie(session.CookieName, s).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		e := env.R(t)


### PR DESCRIPTION
`type`は`unicode`/`original`が指定できる
typeを省略すれば今まで通り`include-unicode`でも指定できるようにしてあります