### PR TITLE
ユニコードスタンプの更新

### DIFF
--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -102,6 +102,10 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 		}
 
 		name := strings.Trim(emoji.ShortName, ":")
+		if name == "pi\u00f1ata" { // 英数字以外の文字が含まれているので置き換え
+			name = "pinata"
+		}
+
 		s, err := repo.GetStampByName(name)
 		if err != nil && err != repository.ErrNotFound {
 			return err
@@ -121,7 +125,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 				IsUnicode: true,
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create stamp (name: %s): %w", name, err)
 			}
 
 			logger.Info(fmt.Sprintf("stamp added: %s (%s)", name, s.ID))

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -24,8 +24,8 @@ const (
 		twemoji Copyright 2019 Twitter, Inc and other contributors
 		Graphics licensed under CC-BY 4.0: https://creativecommons.org/licenses/by/4.0/
 	*/
-	emojiZipURL  = "https://github.com/twitter/twemoji/archive/v12.1.5.zip"
-	emojiDir     = "twemoji-12.1.5/assets/svg/"
+	emojiZipURL  = "https://github.com/twitter/twemoji/archive/v14.0.2.zip"
+	emojiDir     = "twemoji-14.0.2/assets/svg/"
 	emojiMetaURL = "https://raw.githubusercontent.com/joypixels/emoji-toolkit/master/emoji.json"
 )
 

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -26,7 +26,7 @@ const (
 	*/
 	emojiZipURL  = "https://github.com/twitter/twemoji/archive/v12.1.5.zip"
 	emojiDir     = "twemoji-12.1.5/assets/svg/"
-	emojiMetaURL = "https://raw.githubusercontent.com/emojione/emojione/master/emoji.json"
+	emojiMetaURL = "https://raw.githubusercontent.com/joypixels/emoji-toolkit/master/emoji.json"
 )
 
 type emojiMeta struct {

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -40,6 +40,14 @@ type emojiMeta struct {
 	} `json:"code_points"`
 }
 
+var replaceNameMap = map[string]string{
+	// 英数字以外の文字が含まれているので置き換え
+	"pi\u00f1ata": "pinata",
+	// 長すぎるので置き換え
+	"face_with_open_eyes_and_hand_over_mouth": "face_with_open_eyes_hand",
+	"hand_with_index_finger_and_thumb_crossed": "hand_index_finger_thumb_crossed",
+}
+
 func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, update bool) error {
 	logger = logger.Named("twemoji_installer")
 
@@ -102,8 +110,8 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 		}
 
 		name := strings.Trim(emoji.ShortName, ":")
-		if name == "pi\u00f1ata" { // 英数字以外の文字が含まれているので置き換え
-			name = "pinata"
+		if replacedName, ok := replaceNameMap[name]; ok {
+			name = replacedName
 		}
 
 		s, err := repo.GetStampByName(name)

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -26,7 +26,7 @@ const (
 	*/
 	emojiZipURL  = "https://github.com/twitter/twemoji/archive/v14.0.2.zip"
 	emojiDir     = "twemoji-14.0.2/assets/svg/"
-	emojiMetaURL = "https://raw.githubusercontent.com/joypixels/emoji-toolkit/master/emoji.json"
+	emojiMetaURL = "https://raw.githubusercontent.com/joypixels/emoji-assets/v7.0.0/emoji.json"
 )
 
 type emojiMeta struct {

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -44,7 +44,7 @@ var replaceNameMap = map[string]string{
 	// 英数字以外の文字が含まれているので置き換え
 	"pi\u00f1ata": "pinata",
 	// 長すぎるので置き換え
-	"face_with_open_eyes_and_hand_over_mouth": "face_with_open_eyes_hand",
+	"face_with_open_eyes_and_hand_over_mouth":  "face_with_open_eyes_hand",
 	"hand_with_index_finger_and_thumb_crossed": "hand_index_finger_thumb_crossed",
 }
 


### PR DESCRIPTION
twemojiは14に対応してるんだけど、メタデータに使ってるjoypixels/emoji-toolkitが13.1までしか対応してないから13.1までしか表示されない

https://unicode.org/Public/emoji/14.0/ をパースするのはメンテコスト高いしかといってよさげなもの見つけられなくてどうしようねになった
