### PR TITLE
OpenAPIの定義の追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4261,6 +4261,9 @@ components:
             read: 読み取りスコープ
             write: 書き込みスコープ
             manage_bot: bot関連読み書きスコープ
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Message:
       title: Message
@@ -7315,3 +7318,4 @@ tags:
     description: OGP API
 security:
   - OAuth2: []
+  - bearerAuth: []


### PR DESCRIPTION
Bearerトークンによる認証が可能だが、OpenAPIの定義ファイルの方には情報がなかったので追加
書き方はこれを参考にした: https://swagger.io/docs/specification/authentication/bearer-authentication/

swagger.yamlは扱いが良く分からなかったのでそのままにした