### PR TITLE
elastic.NewClientにSetSniffを渡すように

### DIFF
--- a/service/search/es.go
+++ b/service/search/es.go
@@ -161,7 +161,7 @@ var esSetting = m{
 // NewESEngine Elasticsearch検索エンジンを生成します
 func NewESEngine(mm message.Manager, cm channel.Manager, repo repository.Repository, logger *zap.Logger, config ESEngineConfig) (Engine, error) {
 	// es接続
-	client, err := elastic.NewClient(elastic.SetURL(config.URL))
+	client, err := elastic.NewClient(elastic.SetURL(config.URL), elastic.SetSniff(false))
 	if err != nil {
 		return nil, fmt.Errorf("failed to init search engine: %w", err)
 	}


### PR DESCRIPTION
Docker compose network外部からだとつながらない

参考：
https://kotaroooo0-dev.hatenablog.com/entry/docker-es-network