### PR TITLE
fixed StampHistoryEntry::stampId format

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4777,7 +4777,7 @@ components:
       properties:
         stampId:
           type: string
-          format: binary
+          format: uuid
           description: スタンプUUID
         datetime:
           type: string


### PR DESCRIPTION
StampHistoryEntry::stampIdのformatがuuidでなくbinaryになっている
おそらくミスだと思われるので修正