### PR TITLE
チャンネル購読変更イベントペイロードのキー名を修正

### DIFF
--- a/event/topic.go
+++ b/event/topic.go
@@ -186,6 +186,7 @@ const (
 	// ChannelSubscribersChanged チャンネルの購読者が変化した
 	// 	Fields:
 	// 		channel_id: uuid.UUID
+	//    subscriber_ids: []uuid.UUID
 	ChannelSubscribersChanged = "channel.subscribers_changed"
 
 	// StampCreated スタンプが作成された

--- a/repository/gorm/channel.go
+++ b/repository/gorm/channel.go
@@ -359,7 +359,7 @@ func (repo *Repository) ChangeChannelSubscription(channelID uuid.UUID, args repo
 			Name: event.ChannelSubscribersChanged,
 			Fields: hub.Fields{
 				"channel_id":     channelID,
-				"subscribers_id": append(on, off...),
+				"subscriber_ids": append(on, off...),
 			},
 		})
 	}


### PR DESCRIPTION
ref #1520 
↑で起こしたバグを修正
https://github.com/traPtitech/traQ/blob/master/service/notification/handlers.go#L418 とキー名を揃えた