### PR TITLE
UserRepositoryのキャッシュ

### DIFF
--- a/repository/gorm/oauth2.go
+++ b/repository/gorm/oauth2.go
@@ -70,7 +70,7 @@ func (repo *Repository) UpdateClient(clientID string, args repository.UpdateClie
 		}
 		if args.DeveloperID.Valid {
 			// 作成者検証
-			user, err := getUser(tx, false, "id = ?", args.DeveloperID.V)
+			user, err := repo.GetUser(args.DeveloperID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.DeveloperID", "the Developer is not found")

--- a/repository/gorm/repository.go
+++ b/repository/gorm/repository.go
@@ -15,6 +15,7 @@ type Repository struct {
 	hub    *hub.Hub
 	logger *zap.Logger
 	repository.StampRepository
+	repository.UserRepository
 }
 
 // NewGormRepository リポジトリ実装を初期化して生成します。
@@ -25,6 +26,7 @@ func NewGormRepository(db *gorm.DB, hub *hub.Hub, logger *zap.Logger, doMigratio
 		hub:             hub,
 		logger:          logger.Named("repository"),
 		StampRepository: makeStampRepository(db, hub),
+		UserRepository:  makeUserRepository(db, hub),
 	}
 	if doMigration {
 		if init, err = migration.Migrate(db); err != nil {

--- a/repository/gorm/repository.go
+++ b/repository/gorm/repository.go
@@ -14,17 +14,17 @@ type Repository struct {
 	db     *gorm.DB
 	hub    *hub.Hub
 	logger *zap.Logger
-	stamps *stampRepository
+	repository.StampRepository
 }
 
 // NewGormRepository リポジトリ実装を初期化して生成します。
 // スキーマが初期化された場合、init: true を返します。
 func NewGormRepository(db *gorm.DB, hub *hub.Hub, logger *zap.Logger, doMigration bool) (repo repository.Repository, init bool, err error) {
 	repo = &Repository{
-		db:     db,
-		hub:    hub,
-		logger: logger.Named("repository"),
-		stamps: makeStampRepository(db),
+		db:              db,
+		hub:             hub,
+		logger:          logger.Named("repository"),
+		StampRepository: makeStampRepository(db, hub),
 	}
 	if doMigration {
 		if init, err = migration.Migrate(db); err != nil {

--- a/repository/gorm/webhook.go
+++ b/repository/gorm/webhook.go
@@ -121,7 +121,7 @@ func (repo *Repository) UpdateWebhook(id uuid.UUID, args repository.UpdateWebhoo
 		}
 		if args.CreatorID.Valid {
 			// 作成者検証
-			user, err := getUser(tx, false, "id = ?", args.CreatorID.V)
+			user, err := repo.GetUser(args.CreatorID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.CreatorID", "the Creator is not found")

--- a/router/middlewares/user_authenticate.go
+++ b/router/middlewares/user_authenticate.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
-	"golang.org/x/sync/singleflight"
 
-	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension/ctxKey"
@@ -19,8 +17,6 @@ const authScheme = "Bearer"
 
 // UserAuthenticate リクエスト認証ミドルウェア
 func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.MiddlewareFunc {
-	var sfUser singleflight.Group
-
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			var uid uuid.UUID
@@ -66,11 +62,10 @@ func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.
 			}
 
 			// ユーザー取得
-			uI, err, _ := sfUser.Do(uid.String(), func() (interface{}, error) { return repo.GetUser(uid, true) })
+			user, err := repo.GetUser(uid, true)
 			if err != nil {
 				return herror.InternalServerError(err)
 			}
-			user := uI.(model.UserInfo)
 
 			// ユーザーアカウント状態を確認
 			if !user.IsActive() {


### PR DESCRIPTION
user_authenticate.goを通すリクエストごとにuser, user_profileの取得が走っているのでそれをキャッシュ
（特にボトルネックになっているわけではないが）

- StampRepositoryのちょっとしたリファクタ
    - interfaceの型に合うようにした
- UserRepositoryでUserInfoをキャッシュするように