### PR TITLE
TwitterのOGP取得修正とテスト追加

### DIFF
--- a/service/ogp/parser/domain_twitter.go
+++ b/service/ogp/parser/domain_twitter.go
@@ -68,7 +68,7 @@ func fetchTwitterSyndicationAPI(statusID string) (*TwitterSyndicationAPIResponse
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	requestURL := fmt.Sprintf("https://syndication.twitter.com/tweet?id=%s", statusID)
+	requestURL := fmt.Sprintf("https://syndication.twitter.com/tweet-result?id=%s", statusID)
 	resp, err := client.Get(requestURL)
 	if err != nil {
 		return nil, ErrNetwork

--- a/service/ogp/parser/domain_twitter_test.go
+++ b/service/ogp/parser/domain_twitter_test.go
@@ -1,0 +1,44 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fetchTwitterSyndicationAPI(t *testing.T) {
+	tests := []struct {
+		name     string
+		statusID string
+		want     func(t *testing.T, res *TwitterSyndicationAPIResponse)
+		wantErr  assert.ErrorAssertionFunc
+	}{
+		{
+			name:     "success",
+			statusID: "990696508403040256",
+			want: func(t *testing.T, res *TwitterSyndicationAPIResponse) {
+				assert.Equal(t, "@_winnie_on は?情緒不安定か?ﾏﾝｺﾞｰうまいぜ", res.Text)
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:     "not found",
+			statusID: "990696508403040257",
+			want: func(t *testing.T, res *TwitterSyndicationAPIResponse) {
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrClient, i...)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchTwitterSyndicationAPI(tt.statusID)
+			if !tt.wantErr(t, err, fmt.Sprintf("fetchTwitterSyndicationAPI(%v)", tt.statusID)) {
+				return
+			}
+			tt.want(t, got)
+		})
+	}
+}

--- a/service/ogp/parser/domain_vrchat_test.go
+++ b/service/ogp/parser/domain_vrchat_test.go
@@ -1,0 +1,48 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fetchVRChatWorldInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		worldID string
+		want    func(t *testing.T, res *VRChatAPIWorldResponse)
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "success",
+			worldID: "wrld_aa762efb-17b3-4302-8f41-09c4db2489ed",
+			want: func(t *testing.T, res *VRChatAPIWorldResponse) {
+				assert.Equal(t, "PROJECT˸ SUMMER FLARE", res.Name)
+				assert.Equal(t, "Break the Summer․ Break the tower․ Complete the Meridian Loop․ A story about reality and humanity․", res.Description)
+				assert.True(t, strings.HasPrefix(res.ImageURL, "https://"))
+				assert.True(t, strings.HasPrefix(res.ThumbnailImageURL, "https://"))
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "not found",
+			worldID: "wrld_aa762efb-17b3-4302-8f41-09c4db2489ee",
+			want: func(t *testing.T, res *VRChatAPIWorldResponse) {
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrClient, i...)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchVRChatWorldInfo(tt.worldID)
+			if !tt.wantErr(t, err, fmt.Sprintf("fetchVRChatWorldInfo(%v)", tt.worldID)) {
+				return
+			}
+			tt.want(t, got)
+		})
+	}
+}


### PR DESCRIPTION
いつの間にかパスが変わっていたので修正。

もともと `syndication.twitter.com` のAPIはツイート埋め込みで使われているやつを勝手に取ってきて使っていて、ドキュメントも特に見つからないのでいつ壊れても文句は言えない。
ただし、壊れたら分かるようにテストを書いておいた。
テストの気になる点（注意すべき点）として、

- 外部APIにリクエストが飛ぶ（インターネット接続が必要 & 外部APIに負荷がかかるため呼び出しすぎ注意 ratelimitとかに気をつけるべき）
- 外部リソースの値（ツイートの中身とか）が変わったときにテストを修正する必要がある
    - なるべく変わらなさそうなものでテストする
 
があると思う。