### PR TITLE
#729 のお気に入りスタンプパーミッション削除忘れ対応

### DIFF
--- a/migration/current.go
+++ b/migration/current.go
@@ -41,6 +41,7 @@ func Migrations() []*gormigrate.Migration {
 		v28(), // v28 ユーザーグループにアイコンを追加
 		v29(), // BotにModeを追加、WebSocket Modeを追加
 		v30(), // bot_event_logsにresultを追加
+		v31(), // お気に入りスタンプパーミッション削除（削除忘れ）
 	}
 }
 

--- a/migration/v31.go
+++ b/migration/v31.go
@@ -1,0 +1,36 @@
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// v31 お気に入りスタンプパーミッション削除（削除忘れ）
+func v31() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "31",
+		Migrate: func(db *gorm.DB) error {
+			removedPermissions := []string{
+				"get_favorite_stamp",
+				"edit_favorite_stamp",
+			}
+			for _, perm := range removedPermissions {
+				if err := db.Delete(&v31RolePermission{}, &v31RolePermission{Permission: perm}).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// v31RolePermission ロール権限構造体
+type v31RolePermission struct {
+	Role       string `gorm:"type:varchar(30);not null;primaryKey"`
+	Permission string `gorm:"type:varchar(30);not null;primaryKey"`
+}
+
+// TableName RolePermission構造体のテーブル名
+func (*v31RolePermission) TableName() string {
+	return "user_role_permissions"
+}


### PR DESCRIPTION
ref: #729 

動作確認
- [x] ローカルで該当permが消える

```
2022-11-26T05:15:55.047005626Z 2022-11-26T05:15:55.046Z	DEBUG	gorm	gormZap/logger.go:68	SELECT count(*) FROM `migrations` WHERE id = '31'	{"file": "/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.2/gormigrate.go:389", "latency(ms)": 0.293836, "rows": 1}
2022-11-26T05:15:55.047657730Z 2022-11-26T05:15:55.047Z	DEBUG	gorm	gormZap/logger.go:68	DELETE FROM `user_role_permissions` WHERE `user_role_permissions`.`permission` = 'get_favorite_stamp'	{"file": "/go/src/github.com/traPtitech/traQ/migration/v31.go:18", "latency(ms)": 0.436217, "rows": 0}
2022-11-26T05:15:55.048168210Z 2022-11-26T05:15:55.048Z	DEBUG	gorm	gormZap/logger.go:68	DELETE FROM `user_role_permissions` WHERE `user_role_permissions`.`permission` = 'edit_favorite_stamp'	{"file": "/go/src/github.com/traPtitech/traQ/migration/v31.go:18", "latency(ms)": 0.517313, "rows": 0}
2022-11-26T05:15:55.049347313Z 2022-11-26T05:15:55.049Z	DEBUG	gorm	gormZap/logger.go:68	INSERT INTO migrations (id) VALUES ('31')	{"file": "/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.2/gormigrate.go:443", "latency(ms)": 1.100725, "rows": 1}
2022-11-26T05:15:55.049359465Z 
```