### PR TITLE
GET /users/me/unreadのレスポンスに、未読の中で最も古いメッセージのidを含める

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5566,6 +5566,10 @@ components:
           type: string
           description: チャンネルの最新の未読メッセージの日時
           format: date-time
+        oldestMessageId:
+          type: string
+          description: そのチャンネルの未読の中で最も古いメッセージのid
+          format: uuid
       required:
         - channelId
         - count
@@ -5573,6 +5577,7 @@ components:
         - since
         - until
         - updatedAt
+        - oldestMessageId
     PostLoginRequest:
       title: PostLoginRequest
       type: object

--- a/repository/gorm/message.go
+++ b/repository/gorm/message.go
@@ -321,23 +321,7 @@ func (repo *Repository) GetUserUnreadChannels(userID uuid.UUID) ([]*repository.U
 	if userID == uuid.Nil {
 		return res, nil
 	}
-	return res, repo.db.Raw(`
-        SELECT
-            m.channel_id AS channel_id,
-            COUNT(m.id) AS COUNT,
-            MAX(u.noticeable) AS noticeable,
-            MIN(m.created_at) AS since,
-            MAX(m.created_at) AS updated_at,
-            (SELECT message_id
-             FROM unreads u2
-             JOIN messages m2 ON u2.message_id = m2.id
-             WHERE u2.user_id = ? AND m2.channel_id = m.channel_id
-             ORDER BY m2.created_at ASC
-             LIMIT 1) AS oldest_message_id
-        FROM unreads u
-        JOIN messages m ON u.message_id = m.id
-        WHERE u.user_id = ?
-        GROUP BY m.channel_id`, userID, userID).Scan(&res).Error
+	return res, repo.db.Raw(`SELECT m.channel_id AS channel_id, COUNT(m.id) AS count, MAX(u.noticeable) AS noticeable, MIN(m.created_at) AS since, MAX(m.created_at) AS updated_at, (SELECT message_id FROM unreads u2 JOIN messages m2 ON u2.message_id = m2.id WHERE u2.user_id = ? AND m2.channel_id = m.channel_id ORDER BY m2.created_at ASC LIMIT 1) AS oldest_message_id FROM unreads u JOIN messages m ON u.message_id = m.id WHERE u.user_id = ? GROUP BY m.channel_id;`, userID, userID).Scan(&res).Error
 }
 
 // DeleteUnreadsByChannelID implements MessageRepository interface.

--- a/repository/gorm/message.go
+++ b/repository/gorm/message.go
@@ -321,7 +321,26 @@ func (repo *Repository) GetUserUnreadChannels(userID uuid.UUID) ([]*repository.U
 	if userID == uuid.Nil {
 		return res, nil
 	}
-	return res, repo.db.Raw(`SELECT m.channel_id AS channel_id, COUNT(m.id) AS count, MAX(u.noticeable) AS noticeable, MIN(m.created_at) AS since, MAX(m.created_at) AS updated_at, (SELECT message_id FROM unreads u2 JOIN messages m2 ON u2.message_id = m2.id WHERE u2.user_id = ? AND m2.channel_id = m.channel_id ORDER BY m2.created_at ASC LIMIT 1) AS oldest_message_id FROM unreads u JOIN messages m ON u.message_id = m.id WHERE u.user_id = ? GROUP BY m.channel_id;`, userID, userID).Scan(&res).Error
+	return res, repo.db.Raw(`
+		SELECT 
+			m.channel_id AS channel_id, 
+			COUNT(m.id) AS count, 
+			MAX(u.noticeable) AS noticeable, 
+			MIN(m.created_at) AS since, 
+			MAX(m.created_at) AS updated_at, 
+			(
+				SELECT message_id 
+				FROM unreads u2 
+				JOIN messages m2 ON u2.message_id = m2.id 
+				WHERE u2.user_id = ? AND m2.channel_id = m.channel_id 
+				ORDER BY m2.created_at ASC 
+				LIMIT 1
+			) AS oldest_message_id 
+		FROM unreads u 
+		JOIN messages m ON u.message_id = m.id 
+		WHERE u.user_id = ? 
+		GROUP BY m.channel_id;
+	`, userID, userID).Scan(&res).Error
 }
 
 // DeleteUnreadsByChannelID implements MessageRepository interface.

--- a/repository/message.go
+++ b/repository/message.go
@@ -131,5 +131,5 @@ type UserUnreadChannel struct {
 	Noticeable      bool      `json:"noticeable"`
 	Since           time.Time `json:"since"`
 	UpdatedAt       time.Time `json:"updatedAt"`
-	OldestMessageId uuid.UUID `json:"oldestMessageId"`
+	OldestMessageID uuid.UUID `json:"oldestMessageId"`
 }

--- a/repository/message.go
+++ b/repository/message.go
@@ -126,9 +126,10 @@ type MessageRepository interface {
 
 // UserUnreadChannel ユーザーの未読チャンネル構造体
 type UserUnreadChannel struct {
-	ChannelID  uuid.UUID `json:"channelId"`
-	Count      int       `json:"count"`
-	Noticeable bool      `json:"noticeable"`
-	Since      time.Time `json:"since"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	ChannelID       uuid.UUID `json:"channelId"`
+	Count           int       `json:"count"`
+	Noticeable      bool      `json:"noticeable"`
+	Since           time.Time `json:"since"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+	OldestMessageId uuid.UUID `json:"oldestMessageId"`
 }

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -50,6 +50,7 @@ func TestHandlers_GetMyUnreadChannels(t *testing.T) {
 		first.Value("noticeable").Boolean().IsFalse()
 		first.Value("since").String().NotEmpty()
 		first.Value("updatedAt").String().NotEmpty()
+		first.Value("oldestMessageId").String().NotEmpty()
 	})
 }
 

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -50,7 +50,7 @@ func TestHandlers_GetMyUnreadChannels(t *testing.T) {
 		first.Value("noticeable").Boolean().IsFalse()
 		first.Value("since").String().NotEmpty()
 		first.Value("updatedAt").String().NotEmpty()
-		first.Value("oldestMessageId").String().NotEmpty()
+		first.Value("oldestMessageId").String().IsEqual(m.GetID().String())
 	})
 }
 


### PR DESCRIPTION
#1736
GET /users/me/unreadのレスポンスに、未読の中で最も古いメッセージのidを含めました。
しかし、まだ手元でちゃんと動くか確かめられていません。
手元の環境だとユーザーがtraqの一人しかいなくて未読がつけられず、どうやって確かめればよいのかわからないです。
また、swagger.yamlなども更新したほうが良いですか？(それとも自動生成されますか？)