### PR TITLE
IECに正確な単位を使用する

### DIFF
--- a/router/middlewares/body_limit.go
+++ b/router/middlewares/body_limit.go
@@ -8,15 +8,15 @@ import (
 )
 
 // RequestBodyLengthLimit リクエストボディのContentLengthで制限をかけるミドルウェア
-func RequestBodyLengthLimit(kb int64) echo.MiddlewareFunc {
-	limit := kb << 10
+func RequestBodyLengthLimit(kib int64) echo.MiddlewareFunc {
+	limit := kib << 10
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if l := c.Request().Header.Get(echo.HeaderContentLength); len(l) == 0 {
 				return echo.NewHTTPError(http.StatusLengthRequired) // ContentLengthを送ってこないリクエストを殺す
 			}
 			if c.Request().ContentLength > limit {
-				return echo.NewHTTPError(http.StatusRequestEntityTooLarge, fmt.Sprintf("the request must be smaller than %dKB", kb))
+				return echo.NewHTTPError(http.StatusRequestEntityTooLarge, fmt.Sprintf("the request must be smaller than %dKiB", kib))
 			}
 			return next(c)
 		}


### PR DESCRIPTION
正確にはKiBを使用するべき部分がKBをとなっていたためKiBに書き換えました。