### PR TITLE
allow path style for some s3-compatible providers

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -136,6 +136,8 @@ type Config struct {
 			AccessKey string `mapstructure:"accessKey" yaml:"accessKey"`
 			// SecretKey シークレットキー
 			SecretKey string `mapstructure:"secretKey" yaml:"secretKey"`
+			// ForcePathStyle Virtual-hosted style の代わりに Path-style でアクセスを行う
+			ForcePathStyle bool `mapstructure:"forcePathStyle" yaml:"forcePathStyle"`
 			// CacheDir キャッシュディレクトリ
 			CacheDir string `mapstructure:"cacheDir" yaml:"cacheDir"`
 		} `mapstructure:"s3" yaml:"s3"`
@@ -283,6 +285,7 @@ func init() {
 	viper.SetDefault("storage.s3.endpoint", "")
 	viper.SetDefault("storage.s3.accessKey", "")
 	viper.SetDefault("storage.s3.secretKey", "")
+	viper.SetDefault("storage.s3.forcePathStyle", false)
 	viper.SetDefault("storage.s3.cacheDir", "")
 	viper.SetDefault("storage.composite.remote", "")
 	viper.SetDefault("gcp.serviceAccount.projectId", "")
@@ -340,6 +343,7 @@ func (c Config) getFileStorage() (storage.FileStorage, error) {
 			c.Storage.S3.Endpoint,
 			c.Storage.S3.AccessKey,
 			c.Storage.S3.SecretKey,
+			c.Storage.S3.ForcePathStyle,
 			c.Storage.S3.CacheDir,
 		)
 	case "composite":
@@ -365,6 +369,7 @@ func (c Config) getFileStorage() (storage.FileStorage, error) {
 				c.Storage.S3.Endpoint,
 				c.Storage.S3.AccessKey,
 				c.Storage.S3.SecretKey,
+				c.Storage.S3.ForcePathStyle,
 				c.Storage.S3.CacheDir,
 			)
 		default:

--- a/utils/storage/s3.go
+++ b/utils/storage/s3.go
@@ -29,7 +29,7 @@ type S3FileStorage struct {
 }
 
 // NewS3FileStorage 引数の情報でS3ストレージを生成します
-func NewS3FileStorage(bucket, region, endpoint, apiKey, apiSecret, cacheDir string) (*S3FileStorage, error) {
+func NewS3FileStorage(bucket, region, endpoint, apiKey, apiSecret string, forcePathStyle bool, cacheDir string) (*S3FileStorage, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion(region),
 		config.WithEndpointResolverWithOptions(
@@ -48,7 +48,9 @@ func NewS3FileStorage(bucket, region, endpoint, apiKey, apiSecret, cacheDir stri
 		return nil, err
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(opt *s3.Options) {
+		opt.UsePathStyle = forcePathStyle
+	})
 
 	m := &S3FileStorage{
 		bucket:   bucket,


### PR DESCRIPTION
Virtual-host styleではアクセスできないs3-compatible（自称）providerがいくつかあるので、path styleでアクセスを行うオプションを追加した。