### PR TITLE
マイグレーションの順序を修正

### DIFF
--- a/migration/v32.go
+++ b/migration/v32.go
@@ -13,10 +13,10 @@ func v32() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "32",
 		Migrate: func(db *gorm.DB) error {
-			if err := db.AutoMigrate(&v32User{}); err != nil {
+			if err := db.Exec("UPDATE `users` SET `display_name` = LEFT(`display_name`, 32) WHERE CHAR_LENGTH(`display_name`) > 32").Error; err != nil {
 				return err
 			}
-			return db.Exec("UPDATE `users` SET `display_name` = LEFT(`display_name`, 32) WHERE CHAR_LENGTH(`display_name`) > 32").Error
+			return db.AutoMigrate(&v32User{})
 		},
 	}
 }


### PR DESCRIPTION
AutoMigrate -> display_nameを縮める
から
display_nameを縮める -> AutoMigrateに

v3.13.0 デプロイログ
```
{"severity":"ERROR","timestamp":"2023-05-16T15:01:36.472137938Z","logger":"gorm","caller":"gormzap/logger.go:61","message":"ALTER TABLE `users` MODIFY COLUMN `display_name` varchar(32) NOT NULL DEFAULT ''","file":"/go/src/github.com/traPtitech/traQ/migration/v32.go:16","error":"Error 1406 (22001): Data too long for column 'display_name' at row 1031","latency(ms)":51.808,"rows":0,"logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"/go/src/github.com/traPtitech/traQ/utils/gormzap/logger.go","line":"61","function":"github.com/traPtitech/traQ/utils/gormzap.(*L).Trace"},"serviceContext":{"service":"traq","version":"v3.13.0.6203c15"},"stacktrace":"github.com/traPtitech/traQ/utils/gormzap.(*L).Trace\n\t/go/src/github.com/traPtitech/traQ/utils/gormzap/logger.go:61\ngorm.io/gorm.(*processor).Execute\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/callbacks.go:134\ngorm.io/gorm.(*DB).Exec\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/finisher_api.go:750\ngorm.io/driver/mysql.Migrator.AlterColumn.func1\n\t/go/pkg/mod/gorm.io/driver/mysql@v1.5.0/migrator.go:58\ngorm.io/gorm/migrator.Migrator.RunWithValue\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator/migrator.go:62\ngorm.io/driver/mysql.Migrator.AlterColumn\n\t/go/pkg/mod/gorm.io/driver/mysql@v1.5.0/migrator.go:51\ngorm.io/gorm/migrator.Migrator.MigrateColumn\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator/migrator.go:527\ngorm.io/gorm/migrator.Migrator.AutoMigrate.func1\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator/migrator.go:143\ngorm.io/gorm/migrator.Migrator.RunWithValue\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator/migrator.go:62\ngorm.io/gorm/migrator.Migrator.AutoMigrate\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator/migrator.go:116\ngorm.io/gorm.(*DB).AutoMigrate\n\t/go/pkg/mod/gorm.io/gorm@v1.25.1/migrator.go:24\ngithub.com/traPtitech/traQ/migration.v32.func1\n\t/go/src/github.com/traPtitech/traQ/migration/v32.go:16\ngithub.com/go-gormigrate/gormigrate/v2.(*Gormigrate).runMigration\n\t/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.2/gormigrate.go:364\ngithub.com/go-gormigrate/gormigrate/v2.(*Gormigrate).migrate\n\t/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.2/gormigrate.go:198\ngithub.com/go-gormigrate/gormigrate/v2.(*Gormigrate).Migrate\n\t/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.2/gormigrate.go:143\ngithub.com/traPtitech/traQ/migration.Migrate\n\t/go/src/github.com/traPtitech/traQ/migration/migrate.go:29\ngithub.com/traPtitech/traQ/repository/gorm.NewGormRepository\n\t/go/src/github.com/traPtitech/traQ/repository/gorm/repository.go:32\ngithub.com/traPtitech/traQ/cmd.serveCommand.func1\n\t/go/src/github.com/traPtitech/traQ/cmd/serve.go:78\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992\ngithub.com/traPtitech/traQ/cmd.Execute\n\t/go/src/github.com/traPtitech/traQ/cmd/root.go:90\nmain.main\n\t/go/src/github.com/traPtitech/traQ/main.go:17\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
{"severity":"EMERGENCY","timestamp":"2023-05-16T15:01:36.472402678Z","caller":"cmd/serve.go:80","message":"failed to initialize repository","error":"Error 1406 (22001): Data too long for column 'display_name' at row 1031","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"/go/src/github.com/traPtitech/traQ/cmd/serve.go","line":"80","function":"github.com/traPtitech/traQ/cmd.serveCommand.func1"},"serviceContext":{"service":"traq","version":"v3.13.0.6203c15"},"stacktrace":"github.com/traPtitech/traQ/cmd.serveCommand.func1\n\t/go/src/github.com/traPtitech/traQ/cmd/serve.go:80\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992\ngithub.com/traPtitech/traQ/cmd.Execute\n\t/go/src/github.com/traPtitech/traQ/cmd/root.go:90\nmain.main\n\t/go/src/github.com/traPtitech/traQ/main.go:17\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```