### PR TITLE
improve message search performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/prometheus/client_golang v1.15.1
+	github.com/samber/lo v1.38.1
 	github.com/sapphi-red/midec v0.5.2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -459,6 +459,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/sapphi-red/midec v0.5.2 h1:7R69uT6BMyWT+XGkBTI14TqgRNCBa5qo+bFgr5OSPIg=

--- a/repository/gorm/message.go
+++ b/repository/gorm/message.go
@@ -217,6 +217,9 @@ func (repo *Repository) GetMessages(query repository.MessagesQuery) (messages []
 		tx = tx.Joins("USE INDEX (`idx_messages_deleted_at_created_at`) INNER JOIN channels ON messages.channel_id = channels.id")
 	}
 
+	if query.IDIn.Valid {
+		tx = tx.Where("messages.id IN ?", query.IDIn.V)
+	}
 	if query.Channel != uuid.Nil {
 		tx = tx.Where("messages.channel_id = ?", query.Channel)
 	}

--- a/repository/gorm/message_test.go
+++ b/repository/gorm/message_test.go
@@ -142,7 +142,8 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 		mustMakeMessage(t, repo, user.GetID(), ch1.ID)
 	}
 	m6 := mustMakeMessage(t, repo, user.GetID(), ch1.ID)
-	m7 := mustMakeMessage(t, repo, user.GetID(), ch2.ID)
+	latestCh1Msg := mustMakeMessage(t, repo, user.GetID(), ch1.ID)
+	latestCh2Msg := mustMakeMessage(t, repo, user.GetID(), ch2.ID)
 
 	messageEquals := func(t *testing.T, expected, actual *model.Message) {
 		t.Helper()
@@ -155,6 +156,20 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 		assert.NotEmpty(t, actual.UpdatedAt)
 	}
 
+	t.Run("id in", func(t *testing.T) {
+		t.Parallel()
+
+		messages, more, err := repo.GetMessages(repository.MessagesQuery{
+			IDIn: optional.From([]uuid.UUID{m6.ID, latestCh1Msg.ID}),
+		})
+
+		if assert.NoError(t, err) {
+			assert.False(t, more)
+			assert.EqualValues(t, 2, len(messages))
+			messageEquals(t, latestCh1Msg, messages[0])
+			messageEquals(t, m6, messages[1])
+		}
+	})
 	t.Run("activity all", func(t *testing.T) {
 		t.Parallel()
 
@@ -167,9 +182,9 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			assert.False(t, more)
-			assert.EqualValues(t, 7, len(messages))
-			messageEquals(t, m7, messages[0])
-			messageEquals(t, m6, messages[1])
+			assert.EqualValues(t, 8, len(messages))
+			messageEquals(t, latestCh2Msg, messages[0])
+			messageEquals(t, latestCh1Msg, messages[1])
 		}
 	})
 
@@ -186,8 +201,8 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.True(t, more)
 			assert.EqualValues(t, 5, len(messages))
-			messageEquals(t, m7, messages[0])
-			messageEquals(t, m6, messages[1])
+			messageEquals(t, latestCh2Msg, messages[0])
+			messageEquals(t, latestCh1Msg, messages[1])
 		}
 	})
 
@@ -204,8 +219,8 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			assert.False(t, more)
-			assert.EqualValues(t, 6, len(messages))
-			messageEquals(t, m6, messages[0])
+			assert.EqualValues(t, 7, len(messages))
+			messageEquals(t, latestCh1Msg, messages[0])
 		}
 	})
 }

--- a/repository/message.go
+++ b/repository/message.go
@@ -13,6 +13,7 @@ import (
 
 // MessagesQuery GetMessages用クエリ
 type MessagesQuery struct {
+	IDIn    optional.Of[[]uuid.UUID]
 	User    uuid.UUID
 	Channel uuid.UUID
 	// ChannelsSubscribedByUser 指定したユーザーが購読しているチャンネルのメッセージを指定

--- a/service/message/manager.go
+++ b/service/message/manager.go
@@ -40,6 +40,13 @@ type Manager interface {
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
 	Get(id uuid.UUID) (Message, error)
+	// GetIn 指定したIDのメッセージをすべて取得します
+	// 存在チェックはせず、存在するメッセージだけを返します。
+	// キャッシュをバイパスすることに気をつけてください。
+	//
+	// 成功した場合、メッセージとnilを返します。
+	// DBによるエラーを返すことがあります。
+	GetIn(ids []uuid.UUID) ([]Message, error)
 	// GetTimeline タイムラインを取得します
 	//
 	// 成功した場合、タイムラインとnilを返します。

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -13,6 +13,8 @@ import (
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/service/channel"
+	"github.com/traPtitech/traQ/utils"
+	"github.com/traPtitech/traQ/utils/optional"
 )
 
 const (
@@ -60,6 +62,17 @@ func (m *manager) get(id uuid.UUID) (*message, error) {
 
 	// メモリキャッシュから取得。キャッシュに無い場合はキャッシュの replaceFn で自動取得し、キャッシュに追加
 	return m.cache.Get(context.Background(), id)
+}
+
+func (m *manager) GetIn(ids []uuid.UUID) ([]Message, error) {
+	messages, _, err := m.R.GetMessages(repository.MessagesQuery{IDIn: optional.From(ids)})
+	if err != nil {
+		return nil, err
+	}
+	ret := utils.Map(messages, func(m *model.Message) Message {
+		return &message{Model: m}
+	})
+	return ret, nil
 }
 
 func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,9 @@
+package utils
+
+func Map[T, R any](s []T, mapper func(item T) R) []R {
+	ret := make([]R, len(s))
+	for i := range s {
+		ret[i] = mapper(s[i])
+	}
+	return ret
+}


### PR DESCRIPTION
検索結果取得時のN+1を潰しました

理由:
実装の容易さとキャッシュが効くかもしれないという理由からmessage managerのGetをN回呼んでいたが、検索結果の取得でキャッシュを効かせる必要はない / Nが20-100と大きめなので、一発で取得するようにした
本番のmetricsではresponse timeは100-250msが支配的であり、このうちいくらかはN回呼び出しに使っていると考えられる（実際細かく測ってはいないが...）
![image](https://github.com/traPtitech/traQ/assets/18257693/5d80aa6d-4d6e-4b1b-8b92-22f9d521ff7d)
