### PR TITLE
チャンネル更新時、Topicが同じ場合のTopicフィールドの無効化

### DIFF
--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -125,11 +125,16 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 		return ErrChannelNotFound
 	}
 
+	// トピックが同じだった場合、トピックの引数自体を無効化
+	if ch.Topic == args.Topic.V {
+		args.Topic = optional.New("", false)
+	}
+
 	m.T.Lock()
 	defer m.T.Unlock()
 
 	eventRecords := map[model.ChannelEventType]model.ChannelEventDetail{}
-	if args.Topic.Valid && ch.Topic != args.Topic.V {
+	if args.Topic.Valid {
 		if ch.IsArchived() {
 			return ErrChannelArchived
 		}

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -505,7 +505,11 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 				newChan.UpdaterID = args.UpdaterID
 				newChan.UpdatedAt = time.Now()
 
-				if args.Topic.Valid && ch.Topic != args.Topic.V {
+				// トピックが同じだった場合、トピックの引数自体を無効化
+				if ch.Topic == args.Topic.V {
+					args.Topic = optional.New("", false)
+				}
+				if args.Topic.Valid {
 					repo.EXPECT().
 						RecordChannelEvent(c.ID, model.ChannelEventTopicChanged, model.ChannelEventDetail{
 							"userId": args.UpdaterID,


### PR DESCRIPTION
fix #1823 
Repositoryにて、TopicフィールドがValidかどうかでイベントを飛ばすかの判定が行われていたので。