### PR TITLE
OGPが存在しないページのOGP取得に対して、typeがemptyのOGP情報をStatusOKで返すように

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4188,10 +4188,10 @@ paths:
                 $ref: '#/components/schemas/Ogp'
         '400':
           description: 指定したURLが不正です。
-        '404':
-          description: 指定したURLに対するOGP情報が見つかりませんでした。
       operationId: getOgp
-      description: OGP情報を取得します。
+      description: |
+        指定されたURLのOGP情報を取得します。
+        指定されたURLに対するOGP情報が見つからなかった場合、typeがemptyに設定された空のOGP情報を返します。
       parameters:
         - schema:
             type: string

--- a/router/v3/ogp.go
+++ b/router/v3/ogp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/router/consts"
 	"github.com/traPtitech/traQ/router/extension/herror"
 )
@@ -32,7 +33,9 @@ func (h *Handlers) GetOgp(c echo.Context) error {
 	}
 
 	if res == nil {
-		return herror.NotFound()
+		return c.JSON(http.StatusOK, model.Ogp{
+			Type: "empty",
+		})
 	}
 	return c.JSON(http.StatusOK, res)
 }


### PR DESCRIPTION
fix #1443 
swaggerもそれに合わせて更新した

https://github.com/traPtitech/traQ_S-UI/pull/3994 と同時に適用する必要がある