### PR TITLE
コンテナスキャンのactionを差し替え

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,2 +1,0 @@
-general:
-  vulnerabilities: []

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -57,6 +57,7 @@ jobs:
         uses: crazy-max/ghaction-container-scan@v2
         with:
           image: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          annotations: true
   deploy-staging:
     name: Deploy staging
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -54,10 +54,9 @@ jobs:
       - name: Pull docker image
         run: docker pull ghcr.io/traptitech/${IMAGE_NAME}:${IMAGE_TAG}
       - name: Container image scan
-        uses: Azure/container-scan@v0
+        uses: crazy-max/ghaction-container-scan@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          image: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
   deploy-staging:
     name: Deploy staging
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/Azure/container-scan がpublic archiveになったことを受けて
https://github.com/crazy-max/ghaction-container-scan にした
バックエンドはどちらもTrivyを使っているので実質変わらない