### PR TITLE
Twitter OGPを無効化

### DIFF
--- a/service/ogp/parser/domain.go
+++ b/service/ogp/parser/domain.go
@@ -16,9 +16,9 @@ const userAgent = "traq-ogp-fetcher; contact: github.com/traPtitech/traQ"
 
 func FetchSpecialDomainInfo(url *url.URL) (og *opengraph.OpenGraph, meta *DefaultPageMeta, isSpecialDomain bool, err error) {
 	switch url.Host {
-	case "twitter.com":
-		og, meta, err = FetchTwitterInfo(url)
-		return og, meta, true, err
+	// case "twitter.com":
+	// 	og, meta, err = FetchTwitterInfo(url)
+	// 	return og, meta, true, err
 	case "vrchat.com":
 		og, meta, err = FetchVRChatInfo(url)
 		return og, meta, true, err

--- a/service/ogp/parser/domain_twitter.go
+++ b/service/ogp/parser/domain_twitter.go
@@ -28,6 +28,9 @@ type TwitterSyndicationAPIResponse struct {
 	} `json:"video"`
 }
 
+// Do Not Use: Twitter APIが使えなくなってしまったため、この関数は使えない
+//
+//	いつかAPIが復活したとき使えるようにとっておく
 func FetchTwitterInfo(url *url.URL) (*opengraph.OpenGraph, *DefaultPageMeta, error) {
 	splitPath := strings.Split(url.Path, "/")
 	if len(splitPath) < 4 || splitPath[2] != "status" {

--- a/service/ogp/parser/domain_twitter_test.go
+++ b/service/ogp/parser/domain_twitter_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func Test_fetchTwitterSyndicationAPI(t *testing.T) {
+	// Twitter APIが使えなくなってしまったため、関数が使えないためスキップ
+	t.SkipNow()
+
 	tests := []struct {
 		name     string
 		statusID string


### PR DESCRIPTION
Twitter APIが使えなくなったせいか、Twitterのメッセージの埋め込み情報がnetwork errorで取得できなくなってしまったので、無効化した
いつかAPIが復活したときに再び使いだせるように、コード自体はとっておく