### PR TITLE
add user-agent bot in ParseMetaForURL

### DIFF
--- a/service/ogp/parser/domain.go
+++ b/service/ogp/parser/domain.go
@@ -12,7 +12,8 @@ var client = http.Client{
 	Timeout: 5 * time.Second,
 }
 
-const userAgent = "traq-ogp-fetcher; contact: github.com/traPtitech/traQ"
+// X(Twitter)のOGPを取得するのにuserAgentの中にbotという文字列が入っている必要がある
+const userAgent = "traq-ogp-fetcher-bot; contact: github.com/traPtitech/traQ"
 
 func FetchSpecialDomainInfo(url *url.URL) (og *opengraph.OpenGraph, meta *DefaultPageMeta, isSpecialDomain bool, err error) {
 	switch url.Host {

--- a/service/ogp/parser/parser.go
+++ b/service/ogp/parser/parser.go
@@ -34,7 +34,15 @@ func ParseMetaForURL(url *url.URL) (*opengraph.OpenGraph, *DefaultPageMeta, erro
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	resp, err := client.Get(url.String())
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, nil, ErrNetwork
+	}
+
+	req.Header.Add("user-agent", `bot`)
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, ErrNetwork
 	}

--- a/service/ogp/parser/parser.go
+++ b/service/ogp/parser/parser.go
@@ -40,7 +40,7 @@ func ParseMetaForURL(url *url.URL) (*opengraph.OpenGraph, *DefaultPageMeta, erro
 		return nil, nil, ErrNetwork
 	}
 
-	req.Header.Add("user-agent", "traq-ogp-bot; contact: github.com/traPtitech/traQ")
+	req.Header.Add("user-agent", userAgent)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/service/ogp/parser/parser.go
+++ b/service/ogp/parser/parser.go
@@ -40,7 +40,7 @@ func ParseMetaForURL(url *url.URL) (*opengraph.OpenGraph, *DefaultPageMeta, erro
 		return nil, nil, ErrNetwork
 	}
 
-	req.Header.Add("user-agent", `bot`)
+	req.Header.Add("user-agent", "traq-ogp-bot; contact: github.com/traPtitech/traQ")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/service/ogp/parser/parser_test.go
+++ b/service/ogp/parser/parser_test.go
@@ -1,9 +1,12 @@
 package parser
 
 import (
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/dyatlov/go-opengraph/opengraph"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/html"
 )
@@ -121,4 +124,40 @@ func TestExtractTitleFromNode(t *testing.T) {
 
 		assert.Equal(t, "", result)
 	})
+}
+
+func TestFetchTwitterOGP(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    func(t *testing.T, res *opengraph.OpenGraph)
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "success",
+			url:  "https://twitter.com/traPtitech/status/1690533645923287040",
+			want: func(t *testing.T, res *opengraph.OpenGraph) {
+				assert.Equal(t, "設営完了しました！\n西え-33aにてお待ちしています！\n#C102", res.Description)
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "not found",
+			url:  "https://twitter.com/traPtitech/status/1690533645923287041",
+			want: func(t *testing.T, res *opengraph.OpenGraph) {
+				assert.Equal(t, "", res.Description)
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.url)
+			got, _, err := ParseMetaForURL(u)
+			if !tt.wantErr(t, err, fmt.Sprintf("ParseMetaForURL(%v)", tt.url)) {
+				return
+			}
+			tt.want(t, got)
+		})
+	}
 }

--- a/service/ogp/parser/parser_test.go
+++ b/service/ogp/parser/parser_test.go
@@ -150,8 +150,11 @@ func TestFetchTwitterOGP(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	t.Parallel()
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			u, _ := url.Parse(tt.url)
 			got, _, err := ParseMetaForURL(u)
 			if !tt.wantErr(t, err, fmt.Sprintf("ParseMetaForURL(%v)", tt.url)) {


### PR DESCRIPTION
TwitterのOGPが表示されないのを解消する目的です。
手元で試したところ投稿やページ、ユーザーによっては表示されないものもあるようです。
ついでにカクヨムのOGPも表示されるようになったようです。

Twitter.com(x.com)のみに絞るべきか悩んだのですが、上のカクヨムの例があったので、一旦OGPのために飛ばすGETすべてに`user-agent:bot`をつけています。