### PR TITLE
スタンプの別名追加の実装

### DIFF
--- a/migration/current.go
+++ b/migration/current.go
@@ -67,6 +67,7 @@ func AllTables() []interface{} {
 		&model.MessageReport{},
 		&model.WebhookBot{},
 		&model.Stamp{},
+		&model.StampAlias{},
 		&model.UsersTag{},
 		&model.Unread{},
 		&model.Star{},

--- a/model/stamps.go
+++ b/model/stamps.go
@@ -18,7 +18,8 @@ type Stamp struct {
 	UpdatedAt time.Time      `gorm:"precision:6"                               json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"precision:6"                               json:"-"`
 
-	File *FileMeta `gorm:"constraint:stamps_file_id_files_id_foreign,OnUpdate:CASCADE,OnDelete:NO ACTION;foreignKey:FileID" json:"-"`
+	Aliases []StampAlias `gorm:"constraint:stamps_id_stamp_aliases_stamp_id_foreign,OnUpdate:CASCADE,OnDelete:CASCADE;foreignKey:StampID" json:"aliases"`
+	File    *FileMeta    `gorm:"constraint:stamps_file_id_files_id_foreign,OnUpdate:CASCADE,OnDelete:NO ACTION;foreignKey:FileID" json:"-"`
 }
 
 // TableName スタンプテーブル名を取得します
@@ -29,4 +30,11 @@ func (*Stamp) TableName() string {
 // IsSystemStamp システムが作成したスタンプかどうか
 func (s *Stamp) IsSystemStamp() bool {
 	return s.CreatorID == uuid.Nil && s.ID != uuid.Nil && len(s.Name) > 0
+}
+
+type StampAlias struct {
+	ID        uuid.UUID `gorm:"type:char(36);primaryKey"         json:"id"`
+	StampID   uuid.UUID `gorm:"type:char(36);not null"           json:"stampId"`
+	Name      string    `gorm:"type:varchar(32);not null;unique" json:"name"`
+	CreatorID uuid.UUID `gorm:"type:char(36);not null"           json:"creatorId"`
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -244,6 +244,16 @@ func mustMakeStamp(t *testing.T, repo repository.Repository, name string, userID
 	return s
 }
 
+func mustMakeStampAlias(t *testing.T, repo repository.Repository, stampID uuid.UUID, name string, userID uuid.UUID) *model.StampAlias {
+	t.Helper()
+	if name == rand {
+		name = random.AlphaNumeric(20)
+	}
+	sa, err := repo.CreateStampAlias(repository.CreateStampAliasArgs{StampID: stampID, Name: name, CreatorID: userID})
+	require.NoError(t, err)
+	return sa
+}
+
 func mustAddMessageStamp(t *testing.T, repo repository.Repository, messageID, stampID, userID uuid.UUID) {
 	t.Helper()
 	_, err := repo.AddStampToMessage(messageID, stampID, userID, 1)

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -24,6 +24,12 @@ type UpdateStampArgs struct {
 	CreatorID optional.Of[uuid.UUID]
 }
 
+type CreateStampAliasArgs struct {
+	Name      string
+	StampID   uuid.UUID
+	CreatorID uuid.UUID
+}
+
 // UserStampHistory スタンプ履歴構造体
 type UserStampHistory struct {
 	StampID  uuid.UUID `json:"stampId"`
@@ -114,4 +120,12 @@ type StampRepository interface {
 	// stampIDにNILを渡した場合、(nil, ErrNilID)を返します。
 	// DBによるエラーを返すことがあります。
 	GetStampStats(stampID uuid.UUID) (*StampStats, error)
+	// CreateStampAlias スタンプのエイリアスを作成します
+	//
+	// 成功した場合、エイリアスとnilを返します。
+	// 引数に問題がある場合、ArgumentErrorを返します。
+	// スタンプが存在しない場合、ErrNotFoundを返します。
+	// 既にNameが使われている場合、ErrAlreadyExistsを返します。
+	// DBによるエラーを返すことがあります。
+	CreateStampAlias(args CreateStampAliasArgs) (*model.StampAlias, error)
 }


### PR DESCRIPTION
#1821
## やったこと
- スタンプにAliasesフィールドを追加した
- POST /stamps/{stampId}/aliases

## わからなかったこと
- modelの定義
    - ユニーク制約や外部キー制約をどうすればいいか
    - 参照しているスタンプが削除されたときどうすればいいか
    - 物理削除か論理削除か
- Cacheについて
    - r.purgeCacheの使い方
- migrationに関すること

### 気になったこと
- model.StampのNameフィールドにはユニーク制約が付いているが、スタンプは論理削除なので削除されたNameを新しいスタンプで使えない

## やってないこと
- routerへの追加
- Create以外のDelete, Updateなどの処理