### PR TITLE
Hubのpayloadの型キャストで起こっていたPanicを修正

### DIFF
--- a/service/bot/event/payload/common.go
+++ b/service/bot/event/payload/common.go
@@ -137,7 +137,7 @@ type UserGroup struct {
 	UpdatedAt   time.Time          `json:"updatedAt"`
 }
 
-func MakeUserGroup(group model.UserGroup) UserGroup {
+func MakeUserGroup(group *model.UserGroup) UserGroup {
 	admins := make([]*UserGroupAdmin, len(group.Admins))
 	for i, admin := range group.Admins {
 		a := MakeUserGroupAdmin(admin.GroupID, admin.UserID)

--- a/service/bot/event/payload/ev_user_group_created.go
+++ b/service/bot/event/payload/ev_user_group_created.go
@@ -12,7 +12,7 @@ type UserGroupCreated struct {
 	Group UserGroup `json:"group"`
 }
 
-func MakeUserGroupCreated(eventTime time.Time, group model.UserGroup) *UserGroupCreated {
+func MakeUserGroupCreated(eventTime time.Time, group *model.UserGroup) *UserGroupCreated {
 	return &UserGroupCreated{
 		Base:  MakeBase(eventTime),
 		Group: MakeUserGroup(group),

--- a/service/bot/event/payload/ev_user_group_deleted.go
+++ b/service/bot/event/payload/ev_user_group_deleted.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/traPtitech/traQ/model"
 )
 
 // UserGroupDeleted USER_GROUP_DELETEDイベントペイロード
@@ -13,9 +12,9 @@ type UserGroupDeleted struct {
 	GroupID uuid.UUID `json:"groupId"`
 }
 
-func MakeUserGroupDeleted(eventTime time.Time, group model.UserGroup) *UserGroupDeleted {
+func MakeUserGroupDeleted(eventTime time.Time, groupID uuid.UUID) *UserGroupDeleted {
 	return &UserGroupDeleted{
 		Base:    MakeBase(eventTime),
-		GroupID: group.ID,
+		GroupID: groupID,
 	}
 }

--- a/service/bot/handler/ev_user_group_created.go
+++ b/service/bot/handler/ev_user_group_created.go
@@ -12,7 +12,7 @@ import (
 )
 
 func UserGroupCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields) error {
-	group := fields["group"].(model.UserGroup)
+	group := fields["group"].(*model.UserGroup)
 	bots, err := ctx.GetBots(event.UserGroupCreated)
 	if err != nil {
 		return fmt.Errorf("failed to GetBots: %w", err)

--- a/service/bot/handler/ev_user_group_created_test.go
+++ b/service/bot/handler/ev_user_group_created_test.go
@@ -38,7 +38,7 @@ func TestUserGroupCreated(t *testing.T) {
 			Status: model.UserAccountStatusActive,
 			Bot:    false,
 		}
-		group := model.UserGroup{
+		group := &model.UserGroup{
 			ID:          uuid.NewV3(uuid.Nil, "g"),
 			Name:        "new_group",
 			Description: "new_group_description",
@@ -74,7 +74,7 @@ func TestUserGroupCreated(t *testing.T) {
 			Status: model.UserAccountStatusActive,
 			Bot:    false,
 		}
-		group := model.UserGroup{
+		group := &model.UserGroup{
 			ID:          uuid.NewV3(uuid.Nil, "g"),
 			Name:        "new_group",
 			Description: "new_group_description",

--- a/service/bot/handler/ev_user_group_deleted.go
+++ b/service/bot/handler/ev_user_group_deleted.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
 
-	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/service/bot/event"
 	"github.com/traPtitech/traQ/service/bot/event/payload"
 )
 
 func UserGroupDeleted(ctx Context, datetime time.Time, _ string, fields hub.Fields) error {
-	group := fields["group"].(model.UserGroup)
+	groupID := fields["group_id"].(uuid.UUID)
 	bots, err := ctx.GetBots(event.UserGroupDeleted)
 	if err != nil {
 		return fmt.Errorf("failed to GetBots: %w", err)
@@ -23,7 +23,7 @@ func UserGroupDeleted(ctx Context, datetime time.Time, _ string, fields hub.Fiel
 
 	if err := ctx.Multicast(
 		event.UserGroupDeleted,
-		payload.MakeUserGroupDeleted(datetime, group),
+		payload.MakeUserGroupDeleted(datetime, groupID),
 		bots,
 	); err != nil {
 		return fmt.Errorf("failed to multicast: %w", err)

--- a/service/bot/handler/ev_user_group_deleted_test.go
+++ b/service/bot/handler/ev_user_group_deleted_test.go
@@ -32,26 +32,12 @@ func TestUserGroupDeleted(t *testing.T) {
 		handlerCtx := mock_handler.NewMockContext(ctrl)
 		registerBot(t, handlerCtx, b)
 
-		user := &model.User{
-			ID:     uuid.NewV3(uuid.Nil, "u"),
-			Name:   "new_user",
-			Status: model.UserAccountStatusActive,
-			Bot:    false,
-		}
-		group := model.UserGroup{
-			ID:          uuid.NewV3(uuid.Nil, "g"),
-			Name:        "new_group",
-			Description: "new_group_description",
-			Type:        "new_group_type",
-		}
-		group.Admins = append(group.Admins, &model.UserGroupAdmin{GroupID: group.ID, UserID: user.ID})
-		group.Members = append(group.Members, &model.UserGroupMember{GroupID: group.ID, UserID: user.ID})
+		groupID := uuid.NewV3(uuid.Nil, "g")
 		et := time.Now()
 
-		expectMulticast(handlerCtx, event.UserGroupDeleted, payload.MakeUserGroupDeleted(et, group), []*model.Bot{b})
+		expectMulticast(handlerCtx, event.UserGroupDeleted, payload.MakeUserGroupDeleted(et, groupID), []*model.Bot{b})
 		assert.NoError(t, UserGroupDeleted(handlerCtx, et, intevent.UserGroupDeleted, hub.Fields{
-			"group_id": group.ID,
-			"group":    group,
+			"group_id": groupID,
 		}))
 	})
 
@@ -68,26 +54,12 @@ func TestUserGroupDeleted(t *testing.T) {
 		registerBot(t, handlerCtx, b)
 		registerBot(t, handlerCtx, b2)
 
-		user := &model.User{
-			ID:     uuid.NewV3(uuid.Nil, "u"),
-			Name:   "new_user",
-			Status: model.UserAccountStatusActive,
-			Bot:    false,
-		}
-		group := model.UserGroup{
-			ID:          uuid.NewV3(uuid.Nil, "g"),
-			Name:        "new_group",
-			Description: "new_group_description",
-			Type:        "new_group_type",
-		}
-		group.Admins = append(group.Admins, &model.UserGroupAdmin{GroupID: group.ID, UserID: user.ID})
-		group.Members = append(group.Members, &model.UserGroupMember{GroupID: group.ID, UserID: user.ID})
+		groupID := uuid.NewV3(uuid.Nil, "g")
 		et := time.Now()
 
-		expectMulticast(handlerCtx, event.UserGroupDeleted, payload.MakeUserGroupDeleted(et, group), []*model.Bot{b})
+		expectMulticast(handlerCtx, event.UserGroupDeleted, payload.MakeUserGroupDeleted(et, groupID), []*model.Bot{b})
 		assert.NoError(t, UserGroupDeleted(handlerCtx, et, intevent.UserGroupDeleted, hub.Fields{
-			"group_id": group.ID,
-			"group":    group,
+			"group_id": groupID,
 		}))
 	})
 }


### PR DESCRIPTION
グループ追加 / グループ削除で、Hubのpayloadの型キャストが適切に行われておらず、Bot ServiceインスタンスがPanicを起こしてtraQが落ちるというバグが確認された
そのため、以下の二つのPanicを直した

### Created
参考: https://github.com/traPtitech/traQ/blob/867e671ec1f18e802e9f510a880c7f1b9c13be17/repository/gorm/user_group.go#L39-L45
```
panic: interface conversion: interface {} is *model.UserGroup, not model.UserGroup

goroutine 1811903 [running]:
github.com/traPtitech/traQ/service/bot/handler.UserGroupCreated({0x1e99010, 0xc000092090}, {0x1c17bf5?, 0x12?, 0x2d6dae0?}, {0x50?, 0x1ad6280?}, 0x4e3bc0?)
        /go/src/github.com/traPtitech/traQ/service/bot/handler/ev_user_group_created.go:15 +0x36e
github.com/traPtitech/traQ/service/bot.(*serviceImpl).start.func1.1({{0x1c17bf5, 0x12}, {0x0, 0x0, 0x0}, 0xc000400d80})
        /go/src/github.com/traPtitech/traQ/service/bot/service_impl.go:72 +0x10b
created by github.com/traPtitech/traQ/service/bot.(*serviceImpl).start.func1 in goroutine 43
        /go/src/github.com/traPtitech/traQ/service/bot/service_impl.go:68 +0xc7
```

### Deleted
参考: https://github.com/traPtitech/traQ/blob/867e671ec1f18e802e9f510a880c7f1b9c13be17/repository/gorm/user_group.go#L126-L131
```
panic: interface conversion: interface {} is nil, not model.UserGroup

goroutine 123999 [running]:
github.com/traPtitech/traQ/service/bot/handler.UserGroupDeleted({0x1e99010, 0xc000404090}, {0x1c17c19?, 0x12?, 0x2d6dae0?}, {0xc000b40ef0?, 0x415f50?}, 0x7fcf69ff15b8?)
        /go/src/github.com/traPtitech/traQ/service/bot/handler/ev_user_group_deleted.go:15 +0x2c5
github.com/traPtitech/traQ/service/bot.(*serviceImpl).start.func1.1({{0x1c17c19, 0x12}, {0x0, 0x0, 0x0}, 0xc001328ff0})
        /go/src/github.com/traPtitech/traQ/service/bot/service_impl.go:72 +0x10b
created by github.com/traPtitech/traQ/service/bot.(*serviceImpl).start.func1 in goroutine 42
        /go/src/github.com/traPtitech/traQ/service/bot/service_impl.go:68 +0xc7
```