### PR TITLE
elastic search v8にアップデート

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -64,15 +64,19 @@ services:
       retries: 60
 
   es:
-    image: ghcr.io/traptitech/es-with-sudachi:7.17.9-3.0.1
+    image: ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0
     restart: always
     environment:
       - discovery.type=single-node
+      - cluster.name=docker-cluster
+      # elastic search v8でhttpsがデフォルトで有効になったので、ローカルで動かすとき必要
+      - xpack.security.enabled=false
+      - xpack.security.audit.enabled=false
+      - xpack.security.transport.ssl.enabled=false
     ports:
       - "9200:9200"
       - "9300:9300"
     volumes:
-      - ./dev/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./dev/es_jvm.options:/usr/share/elasticsearch/config/jvm.options.d/es_jvm.options
       - es:/usr/share/elasticsearch/data
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -67,12 +67,10 @@ services:
     image: ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0
     restart: always
     environment:
-      - discovery.type=single-node
-      - cluster.name=docker-cluster
-      # elastic search v8でhttpsがデフォルトで有効になったので、ローカルで動かすとき必要
-      - xpack.security.enabled=false
-      - xpack.security.audit.enabled=false
-      - xpack.security.transport.ssl.enabled=false
+      discovery.type: single-node
+      cluster.name: docker-cluster
+      # デフォルトではオンになっているので、セキュリティをオフにする
+      xpack.security.enabled: false
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/disintegration/imaging v1.6.2
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a
-	github.com/elastic/go-elasticsearch/v7 v7.17.10
+	github.com/elastic/go-elasticsearch/v8 v8.8.1
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/go-audio/audio v1.0.0
 	github.com/go-audio/wav v1.1.0
@@ -102,6 +102,7 @@ require (
 	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,10 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a h1:etIrTD8BQqzColk9nKRusM9um5+1q0iOEJLqfBMIK64=
 github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a/go.mod h1:emQhSYTXqB0xxjLITTw4EaWZ+8IIQYw+kx9GqNUKdLg=
-github.com/elastic/go-elasticsearch/v7 v7.17.10 h1:TCQ8i4PmIJuBunvBS6bwT2ybzVFxxUhhltAs3Gyu1yo=
-github.com/elastic/go-elasticsearch/v7 v7.17.10/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/elastic-transport-go/v8 v8.3.0 h1:DJGxovyQLXGr62e9nDMPSxRyWION0Bh6d9eCFBriiHo=
+github.com/elastic/elastic-transport-go/v8 v8.3.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/go-elasticsearch/v8 v8.8.1 h1:/OiP5Yex40q5eWpzFVQIS8jRE7SaEZrFkG9JbE6TXtY=
+github.com/elastic/go-elasticsearch/v8 v8.8.1/go.mod h1:GU1BJHO7WeamP7UhuElYwzzHtvf9SDmeVpSSy9+o6Qg=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -10,7 +10,7 @@ import (
 
 	json "github.com/json-iterator/go"
 
-	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	esRequiredVersionPrefix = "7."
+	esRequiredVersionPrefix = "8."
 	esIndexPrefix           = "traq_"
 	esMessageIndex          = "message"
 	esDateFormat            = "2006-01-02T15:04:05.000000000Z"

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -408,7 +408,7 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 }
 
 func (e *esEngine) Available() bool {
-	//このクライアントにはライフサイクルが無いので、常にtrueを返す。
+	// このクライアントにはライフサイクルが無いので、常にtrueを返す。
 	return true
 }
 

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -1,13 +1,14 @@
 package search
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v7/esutil"
+	"github.com/elastic/go-elasticsearch/v8/esutil"
 	"github.com/gofrs/uuid"
 	json "github.com/json-iterator/go"
 	"go.uber.org/zap"
@@ -183,20 +184,29 @@ func (e *esEngine) sync() error {
 					return err
 				}
 
+				data, err := json.Marshal(*doc)
+				if err != nil {
+					return err
+				}
+
 				err = bulkIndexer.Add(context.Background(), esutil.BulkIndexerItem{
 					Action:     "index",
 					DocumentID: v.ID.String(),
-					Body:       esutil.NewJSONReader(*doc),
+					Body:       bytes.NewReader(data),
 				})
 				if err != nil {
 					return err
 				}
 			} else {
 				doc := e.convertMessageUpdated(v, message.Parse(v.Text))
+				data, err := json.Marshal(map[string]any{"doc": *doc})
+				if err != nil {
+					return err
+				}
 				err = bulkIndexer.Add(context.Background(), esutil.BulkIndexerItem{
 					Action:     "update",
 					DocumentID: v.ID.String(),
-					Body:       esutil.NewJSONReader(map[string]any{"doc": doc}),
+					Body:       bytes.NewReader(data),
 				})
 				if err != nil {
 					return err

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -199,10 +199,12 @@ func (e *esEngine) sync() error {
 				}
 			} else {
 				doc := e.convertMessageUpdated(v, message.Parse(v.Text))
+
 				data, err := json.Marshal(map[string]any{"doc": *doc})
 				if err != nil {
 					return err
 				}
+
 				err = bulkIndexer.Add(context.Background(), esutil.BulkIndexerItem{
 					Action:     "update",
 					DocumentID: v.ID.String(),


### PR DESCRIPTION
elasticsearchの設定ファイル(elasticsearch.yml)をbind mountすると動かないので、compose.ymlで環境変数から指定しています。
参考: https://discuss.elastic.co/t/when-mounting-elasticsearch-yml-docker-displays-device-or-resource-busy/300981
elasticsearch.ymlは残してあるのですが、消しちゃってもいいですか？

動作確認は下のように行いました。
1. v7(master)の状態でいくつかメッセージを投稿して、esにデータが入ることを確認
2. v8(このブランチ)にして、`make up`
3. メッセージを検索して問題ないことを確認
4. メッセージを投稿して問題ないことを確認

go-elaasticsearchのv8からは[typedapi](https://pkg.go.dev/github.com/elastic/go-elasticsearch/v8@v8.11.1/typedapi)といういい感じに型がついたAPIクライアントもあるのですが、
- メモリリークでたまにtraQが落ちていてそこそこ影響があるし、対応が遅くなってしまったので早めにやりたい。
- バグったときにtypedapiにしたことによるバグなのかesを上げたことによるバグなのかわかりにくい。
のでこれへの書き換えはまた別の機会でいいでしょうか？