### PR TITLE
Elasticsearchに認証を導入

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -87,7 +87,12 @@ type Config struct {
 
 	// ES Elasticsearch設定
 	ES struct {
+		// URL URL (default: "")
 		URL string `mapstructure:"url" yaml:"url"`
+		// Username ユーザー名 (default: "elastic")
+		Username string `mapstructure:"username" yaml:"username"`
+		// Password パスワード (default: "password")
+		Password string `mapstructure:"password" yaml:"password"`
 	} `mapstructure:"es" yaml:"es"`
 
 	// Storage ファイルストレージ設定
@@ -270,6 +275,8 @@ func init() {
 	viper.SetDefault("mariadb.connection.maxIdle", 2)
 	viper.SetDefault("mariadb.connection.lifetime", 0)
 	viper.SetDefault("es.url", "")
+	viper.SetDefault("es.username", "elastic")
+	viper.SetDefault("es.password", "password")
 	viper.SetDefault("storage.type", "local")
 	viper.SetDefault("storage.local.dir", "./storage")
 	viper.SetDefault("storage.swift.username", "")
@@ -452,7 +459,9 @@ func provideFirebaseCredentialsFilePathString(c *Config) variable.FirebaseCreden
 
 func provideESEngineConfig(c *Config) search.ESEngineConfig {
 	return search.ESEngineConfig{
-		URL: c.ES.URL,
+		URL:      c.ES.URL,
+		Username: c.ES.Username,
+		Password: c.ES.Password,
 	}
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -69,8 +69,7 @@ services:
     environment:
       discovery.type: single-node
       cluster.name: docker-cluster
-      # デフォルトではオンになっているので、セキュリティをオフにする
-      xpack.security.enabled: false
+      ELASTIC_PASSWORD: password
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/dev/elasticsearch.yml
+++ b/dev/elasticsearch.yml
@@ -1,2 +1,0 @@
-cluster.name: "docker-cluster"
-network.host: 0.0.0.0

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -34,6 +34,10 @@ func getIndexName(index string) string {
 type ESEngineConfig struct {
 	// URL ESのURL
 	URL string
+	// Username ESのユーザー名
+	Username string
+	// Password ESのパスワード
+	Password string
 }
 
 // esEngine search.Engine 実装
@@ -173,6 +177,8 @@ func NewESEngine(mm message.Manager, cm channel.Manager, repo repository.Reposit
 	// esクライアント作成
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{config.URL},
+		Username:  config.Username,
+		Password:  config.Password,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to init Elasticsearch: %w", err)


### PR DESCRIPTION
#2036 
- NeoShowcase等、Private Network内からであればESにアクセスできるので、認証を設けないとデータが盗用されてしまう
  - 今のセキュリティはインスタンスへのアクセス制限だより
- ES v8で、デフォルトで認証が必要になったので良い機会だった