### PR TITLE
Distrolessイメージへの乗り換え

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,3 @@
 ignored:
   - DL3018
+  - DL3007

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,2 @@
 ignored:
-  - DL3018
   - DL3007

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5 AS build
+FROM --platform=$BUILDPLATFORM golang:1.21.5 AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir /storage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM --platform=$BUILDPLATFORM golang:1.21.5 AS build
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir /storage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.5-alpine AS build
+FROM golang:1.21.5 AS build
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir /storage
+
 WORKDIR /go/src/github.com/traPtitech/traQ
 
 COPY ./go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-
-COPY . .
 
 ENV GOCACHE=/tmp/go/cache
 ENV CGO_ENABLED=0
@@ -16,19 +18,19 @@ ARG TARGETARCH
 ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
 
+COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/tmp/go/cache \
   go build -o /traQ -ldflags "-s -w -X main.version=$TRAQ_VERSION -X main.revision=$TRAQ_REVISION"
 
-FROM alpine:3.19.0
+FROM gcr.io/distroless/base:latest
 WORKDIR /app
+EXPOSE 3000
 
-RUN apk add --no-cache --update ca-certificates && update-ca-certificates
+COPY --from=build /storage/ /app/storage/
+VOLUME /app/storage
 
 COPY --from=build /traQ ./
 
-VOLUME /app/storage
-EXPOSE 3000
-
-HEALTHCHECK CMD ./traQ healthcheck || exit 1
+HEALTHCHECK CMD ["./traQ", "healthcheck", "||", "exit", "1"]
 ENTRYPOINT ["./traQ"]
 CMD ["serve"]


### PR DESCRIPTION
alpineで出てくるvulnerabilityに辟易することがあるので、よりvulnerabilityを孕む可能性の低いdistrolessに乗り換えようと決意した
- 外部にHTTPS接続するのでopensslまでは必須だった -> baseバージョンを採用
- debianベースになるので、builderイメージもgolangのdebian系統に切り替え
- https://github.com/traPtitech/traQ/pull/1673 で一度頓挫したが、 https://github.com/traPtitech/traQ/pull/2143 によってImagemagickが消え去ったので再挑戦
- 以前はnonrootへの置き換えもやろうとしたが、マウントディレクトリがあるため権限が変更されると事故の可能性があるということで今回はやってない