### PR TITLE
Fix deprecated GoReleaser command option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub Actions の release ワークフローで使われている GoReleaser のコマンドオプション `--rm-dist` が deprecated になっていたので、推奨されている `--clean` に修正しました。

- 参考リンク
  - [Deprecation notices | GoReleaser](https://goreleaser.com/deprecations/?h=rm#-rm-dist)
