### PR TITLE
無名関数のunused-parameters linterに対応

### DIFF
--- a/cmd/conf.go
+++ b/cmd/conf.go
@@ -13,7 +13,7 @@ func confCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "conf",
 		Short: "Print loaded config variables",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			bs, err := yaml.Marshal(c)
 			if err != nil {
 				log.Fatalf("unable to marshal config to YAML: %v", err)

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -45,7 +45,7 @@ func filePruneCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "prune",
 		Short: "delete files which are not used or linked to anywhere",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getCLILogger()
 			defer logger.Sync()
@@ -152,7 +152,7 @@ func genMissingThumbnails() *cobra.Command {
 	return &cobra.Command{
 		Use:   "gen-missing-thumbs",
 		Short: "Generate missing thumbnails",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getCLILogger()
 			defer logger.Sync()
@@ -344,7 +344,7 @@ func genGroupImages() *cobra.Command {
 	return &cobra.Command{
 		Use:   "gen-group-images",
 		Short: "Generate missing icons for user groups",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getCLILogger()
 			defer logger.Sync()

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -13,7 +13,7 @@ func healthcheckCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "healthcheck",
 		Short: "Run healthcheck",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			logger := getCLILogger()
 			defer logger.Sync()
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -13,7 +13,7 @@ func migrateCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "migrate",
 		Short: "Execute database schema migration only",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			engine, err := c.getDatabase()
 			if err != nil {
 				return err

--- a/cmd/migrate_v2_to_v3.go
+++ b/cmd/migrate_v2_to_v3.go
@@ -21,7 +21,7 @@ func migrateV2ToV3Command() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "migrate-v2-to-v3",
 		Short: "migrate from v2 to v3 (messages, files)",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getCLILogger()
 			defer logger.Sync()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var (
 var rootCommand = &cobra.Command{
 	Use: "traQ",
 	// 全コマンド共通の前処理
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
 		// enable pprof http handler
 		if c.Pprof {
 			go func() { _ = http.ListenAndServe("0.0.0.0:6060", nil) }()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -33,7 +33,7 @@ func serveCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "serve",
 		Short: "Serve traQ API",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getLogger()
 			defer logger.Sync()

--- a/cmd/stamp.go
+++ b/cmd/stamp.go
@@ -33,7 +33,7 @@ func stampInstallEmojisCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "install-emojis",
 		Short: "download and install Unicode emojiMeta stamps",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
 			logger := getCLILogger()
 			defer logger.Sync()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ func versionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Printf("traQ %s (revision %s)\n", Version, Revision)
 		},
 	}

--- a/router/extension/precond_test.go
+++ b/router/extension/precond_test.go
@@ -43,7 +43,7 @@ func TestCheckPreconditions(t *testing.T) {
 			Client: &http.Client{
 				Jar:     nil, // クッキーは保持しない
 				Timeout: time.Second * 30,
-				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 					return http.ErrUseLastResponse // リダイレクトを自動処理しない
 				},
 			},

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -92,49 +92,49 @@ func (pr *ParamRetriever) error(err error) error {
 
 // GroupID リクエストURLの`groupID`パラメータからGroupを取り出す
 func (pr *ParamRetriever) GroupID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamGroupID, consts.KeyParamGroup, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamGroupID, consts.KeyParamGroup, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetUserGroup(v)
 	})
 }
 
 // MessageID リクエストURLの`messageID`パラメータからMessageを取り出す
 func (pr *ParamRetriever) MessageID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamMessageID, consts.KeyParamMessage, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamMessageID, consts.KeyParamMessage, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.mm.Get(v)
 	})
 }
 
 // ClientID リクエストURLの`clientID`パラメータからOAuth2Clientを取り出す
 func (pr *ParamRetriever) ClientID() echo.MiddlewareFunc {
-	return pr.byString(consts.ParamClientID, consts.KeyParamClient, func(c echo.Context, v string) (interface{}, error) {
+	return pr.byString(consts.ParamClientID, consts.KeyParamClient, func(_ echo.Context, v string) (interface{}, error) {
 		return pr.repo.GetClient(v)
 	})
 }
 
 // BotID リクエストURLの`botID`パラメータからBotを取り出す
 func (pr *ParamRetriever) BotID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamBotID, consts.KeyParamBot, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamBotID, consts.KeyParamBot, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetBotByID(v)
 	})
 }
 
 // ChannelID リクエストURLの`channelID`パラメータからChannelを取り出す
 func (pr *ParamRetriever) ChannelID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamChannelID, consts.KeyParamChannel, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamChannelID, consts.KeyParamChannel, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.cm.GetChannel(v)
 	})
 }
 
 // FileID リクエストURLの`fileID`パラメータからFileを取り出す
 func (pr *ParamRetriever) FileID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamFileID, consts.KeyParamFile, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamFileID, consts.KeyParamFile, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.fm.Get(v)
 	})
 }
 
 // WebhookID リクエストURLの`webhookID`パラメータからBotを取り出す
 func (pr *ParamRetriever) WebhookID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamWebhookID, consts.KeyParamWebhook, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamWebhookID, consts.KeyParamWebhook, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetWebhook(v)
 	})
 }
@@ -142,18 +142,18 @@ func (pr *ParamRetriever) WebhookID() echo.MiddlewareFunc {
 // StampID リクエストURLの`stampID`パラメータからStampを取り出します
 func (pr *ParamRetriever) StampID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
-		return pr.checkOnlyByUUID(consts.ParamStampID, func(c echo.Context, v uuid.UUID) (bool, error) {
+		return pr.checkOnlyByUUID(consts.ParamStampID, func(_ echo.Context, v uuid.UUID) (bool, error) {
 			return pr.repo.StampExists(v)
 		})
 	}
-	return pr.byUUID(consts.ParamStampID, consts.KeyParamStamp, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamStampID, consts.KeyParamStamp, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetStamp(v)
 	})
 }
 
 // StampPalettesID リクエストURLの`paletteID`パラメータからStampPaletteを取り出す
 func (pr *ParamRetriever) StampPalettesID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamStampPaletteID, consts.KeyParamStampPalette, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamStampPaletteID, consts.KeyParamStampPalette, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetStampPalette(v)
 	})
 }
@@ -161,18 +161,18 @@ func (pr *ParamRetriever) StampPalettesID() echo.MiddlewareFunc {
 // UserID リクエストURLの`userID`パラメータからUserを取り出す
 func (pr *ParamRetriever) UserID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
-		return pr.checkOnlyByUUID(consts.ParamUserID, func(c echo.Context, v uuid.UUID) (bool, error) {
+		return pr.checkOnlyByUUID(consts.ParamUserID, func(_ echo.Context, v uuid.UUID) (bool, error) {
 			return pr.repo.UserExists(v)
 		})
 	}
-	return pr.byUUID(consts.ParamUserID, consts.KeyParamUser, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamUserID, consts.KeyParamUser, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetUser(v, true)
 	})
 }
 
 // ClipFolderID リクエストURLの`folderID`パラメータからClipFolderを取り出す
 func (pr *ParamRetriever) ClipFolderID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamClipFolderID, consts.KeyParamClipFolder, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamClipFolderID, consts.KeyParamClipFolder, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.repo.GetClipFolder(v)
 	})
 }

--- a/router/oauth2/oauth2_test.go
+++ b/router/oauth2/oauth2_test.go
@@ -163,7 +163,7 @@ func (env *Env) R(t *testing.T) *httpexpect.Expect {
 		Client: &http.Client{
 			Jar:     nil, // クッキーは保持しない
 			Timeout: time.Second * 30,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse // リダイレクトを自動処理しない
 			},
 		},

--- a/router/v1/router.go
+++ b/router/v1/router.go
@@ -56,7 +56,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 
 	requiresFileAccessPerm := middlewares.CheckFileAccessPerm(h.FileManager)
 
-	gone := func(c echo.Context) error {
+	gone := func(_ echo.Context) error {
 		return herror.HTTPError(http.StatusGone, "This API has been deleted. Please migrate to v3 or newer API.")
 	}
 

--- a/router/v1/router_test.go
+++ b/router/v1/router_test.go
@@ -143,7 +143,7 @@ func (env *Env) makeExp(t *testing.T) *httpexpect.Expect {
 		Client: &http.Client{
 			Jar:     nil, // クッキーは保持しない
 			Timeout: 10 * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse // リダイレクトを自動処理しない
 			},
 		},

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -206,7 +206,7 @@ func (env *Env) R(t *testing.T) *httpexpect.Expect {
 		Client: &http.Client{
 			Jar:     nil, // クッキーは保持しない
 			Timeout: time.Second * 30,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse // リダイレクトを自動処理しない
 			},
 		},

--- a/service/bot/event/dispatcher_http.go
+++ b/service/bot/event/dispatcher_http.go
@@ -30,7 +30,7 @@ func newHTTPDispatcher(logger *zap.Logger) *httpDispatcher {
 		client: http.Client{
 			Jar:     nil,
 			Timeout: 5 * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		},

--- a/service/bot/ws/config.go
+++ b/service/bot/ws/config.go
@@ -21,6 +21,6 @@ var (
 	upgrader = &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
+		CheckOrigin:     func(_ *http.Request) bool { return true },
 	}
 )

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -90,7 +90,7 @@ func TestInitChannelManager(t *testing.T) {
 func TestManagerImpl_GetChannel(t *testing.T) {
 	t.Parallel()
 
-	must := func(c *model.Channel, err error) *model.Channel { return c }
+	must := func(c *model.Channel, _ error) *model.Channel { return c }
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/service/file/manager_impl_test.go
+++ b/service/file/manager_impl_test.go
@@ -58,14 +58,14 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, _ = io.Copy(io.Discard, src)
 				return nil
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			DoAndReturn(func(meta *model.FileMeta, acl []*model.FileACLEntry) error {
+			DoAndReturn(func(meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
 			}).
@@ -109,21 +109,21 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, _ = io.Copy(io.Discard, src)
 				return nil
 			}).
 			Times(1)
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), gomock.Any(), "image/png", model.FileTypeThumbnail).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, err := png.Decode(src)
 				return err
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			DoAndReturn(func(meta *model.FileMeta, acl []*model.FileACLEntry) error {
+			DoAndReturn(func(meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
 			}).
@@ -172,21 +172,21 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			Do(func(src io.Reader, key, name, contentType string, fileType model.FileType) {
+			Do(func(src io.Reader, _, _, _ string, _ model.FileType) {
 				_, _ = io.Copy(io.Discard, src)
 			}).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), gomock.Any(), "image/png", model.FileTypeThumbnail).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, err := png.Decode(src)
 				return err
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, acl []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -238,21 +238,21 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			Do(func(src io.Reader, key, name, contentType string, fileType model.FileType) {
+			Do(func(src io.Reader, _, _, _ string, _ model.FileType) {
 				_, _ = io.Copy(io.Discard, src)
 			}).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), gomock.Any(), "image/png", model.FileTypeThumbnail).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, err := png.Decode(src)
 				return err
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, acl []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -304,26 +304,26 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			Do(func(src io.Reader, key, name, contentType string, fileType model.FileType) {
+			Do(func(src io.Reader, _, _, _ string, _ model.FileType) {
 				_, _ = io.Copy(io.Discard, src)
 			}).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), gomock.Any(), "image/svg+xml", model.FileTypeThumbnail).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, _ = io.Copy(io.Discard, src)
 				return nil
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, acl []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
 			WaveformMp3(gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(src io.ReadSeeker, width, height int) { _, _ = io.Copy(io.Discard, src) }).
+			Do(func(src io.ReadSeeker, _, _ int) { _, _ = io.Copy(io.Discard, src) }).
 			Return(waveform, nil).
 			Times(1)
 
@@ -368,26 +368,26 @@ func TestManagerImpl_Save(t *testing.T) {
 
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), args.FileName, args.MimeType, args.FileType).
-			Do(func(src io.Reader, key, name, contentType string, fileType model.FileType) {
+			Do(func(src io.Reader, _, _, _ string, _ model.FileType) {
 				_, _ = io.Copy(io.Discard, src)
 			}).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
 			SaveByKey(gomock.Any(), gomock.Any(), gomock.Any(), "image/svg+xml", model.FileTypeThumbnail).
-			DoAndReturn(func(src io.Reader, key, name, contentType string, fileType model.FileType) error {
+			DoAndReturn(func(src io.Reader, _, _, _ string, _ model.FileType) error {
 				_, _ = io.Copy(io.Discard, src)
 				return nil
 			}).
 			Times(1)
 		repo.EXPECT().
 			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, acl []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
 			WaveformWav(gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(src io.ReadSeeker, width, height int) { _, _ = io.Copy(io.Discard, src) }).
+			Do(func(src io.ReadSeeker, _, _ int) { _, _ = io.Copy(io.Discard, src) }).
 			Return(waveform, nil).
 			Times(1)
 

--- a/service/ogp/parser/domain_vrchat_test.go
+++ b/service/ogp/parser/domain_vrchat_test.go
@@ -29,7 +29,7 @@ func Test_fetchVRChatWorldInfo(t *testing.T) {
 		{
 			name:    "not found",
 			worldID: "wrld_aa762efb-17b3-4302-8f41-09c4db2489ee",
-			want: func(t *testing.T, res *VRChatAPIWorldResponse) {
+			want: func(_ *testing.T, _ *VRChatAPIWorldResponse) {
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrClient, i...)

--- a/service/ws/config.go
+++ b/service/ws/config.go
@@ -21,6 +21,6 @@ var (
 	upgrader = &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
+		CheckOrigin:     func(_ *http.Request) bool { return true },
 	}
 )

--- a/service/ws/target_func.go
+++ b/service/ws/target_func.go
@@ -57,7 +57,7 @@ func TargetTimelineStreamingEnabled() TargetFunc {
 
 // TargetNone いずれのセッションにも送信しません
 func TargetNone() TargetFunc {
-	return func(s Session) bool {
+	return func(_ Session) bool {
 		return false
 	}
 }

--- a/utils/storage/s3.go
+++ b/utils/storage/s3.go
@@ -34,7 +34,7 @@ func NewS3FileStorage(bucket, region, endpoint, apiKey, apiSecret string, forceP
 		config.WithRegion(region),
 		config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(
-				func(service string, region string, options ...interface{}) (aws.Endpoint, error) {
+				func(_ string, region string, _ ...interface{}) (aws.Endpoint, error) {
 					return aws.Endpoint{
 						URL:           endpoint,
 						SigningRegion: region,

--- a/utils/storage/s3_object_test.go
+++ b/utils/storage/s3_object_test.go
@@ -132,7 +132,7 @@ func tests3ObjectSeek(t *testing.T) {
 				offset: 1024,
 				whence: 0,
 			},
-			wantNewPos: func(len, pos, offset int64) int64 {
+			wantNewPos: func(_, _, offset int64) int64 {
 				return offset
 			},
 		},
@@ -153,7 +153,7 @@ func tests3ObjectSeek(t *testing.T) {
 				offset: 1024,
 				whence: 1,
 			},
-			wantNewPos: func(len, pos, offset int64) int64 {
+			wantNewPos: func(_, pos, offset int64) int64 {
 				return pos + offset
 			},
 		},
@@ -173,7 +173,7 @@ func tests3ObjectSeek(t *testing.T) {
 				offset: -1024,
 				whence: 2,
 			},
-			wantNewPos: func(len, pos, offset int64) int64 {
+			wantNewPos: func(len, _, offset int64) int64 {
 				return len + offset
 			},
 		},

--- a/utils/storage/s3_tester_test.go
+++ b/utils/storage/s3_tester_test.go
@@ -58,7 +58,7 @@ func s3TestConfig(ctx context.Context, port string) (aws.Config, error) {
 		config.WithRegion("ap-northeast-1"),
 		config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(
-				func(service string, region string, options ...interface{}) (aws.Endpoint, error) {
+				func(_ string, region string, _ ...interface{}) (aws.Endpoint, error) {
 					return aws.Endpoint{
 						URL:           ep,
 						SigningRegion: region,


### PR DESCRIPTION
- https://github.com/mgechev/revive/pull/966 が最新バージョンの`golangci-lint`に適用された
- 無名関数の使用されてないパラメーターがリントエラーになるようになったので、全て`_`で置き換えた