### PR TITLE
v3-api.yamlのPasswordのvalidationを修正

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5525,7 +5525,7 @@ components:
           pattern: '^[a-zA-Z0-9_-]{1,32}$'
         password:
           type: string
-          pattern: "^[\\\\x20-\\\\x7E]{10,32}$"
+          pattern: "^[\\x20-\\x7E]{10,32}$"
           description: パスワード
       required:
         - name
@@ -5653,7 +5653,7 @@ components:
         password:
           type: string
           description: パスワード
-          pattern: "^[\\\\x20-\\\\x7E]{10,32}$"
+          pattern: "^[\\x20-\\x7E]{10,32}$"
       required:
         - name
         - password


### PR DESCRIPTION
PostUserRequestとPostLoginRequestの正規表現が間違っており、パスワード入力で英小文字を受け付けないパターンになっていたのを修正

実装に影響はないが、openapi-generatorでクライアントスクリプトを自動生成したときに引っかかる