### PR TITLE
impl ETag to /me

### DIFF
--- a/router/v3/responses.go
+++ b/router/v3/responses.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/traPtitech/traQ/model"
-	"github.com/traPtitech/traQ/service/rbac/permission"
 	"github.com/traPtitech/traQ/utils/optional"
 
 	"github.com/gofrs/uuid"
@@ -623,40 +622,4 @@ func formatStampPalettes(cfs []*model.StampPalette) []*StampPalette {
 	}
 	sort.Slice(res, func(i, j int) bool { return res[i].ID.String() < res[j].ID.String() })
 	return res
-}
-
-type UserInfo struct {
-	ID          uuid.UUID               `json:"id"`
-	Bio         string                  `json:"bio"`
-	Groups      []uuid.UUID             `json:"groups"`
-	Tags        []UserTag               `json:"tags"`
-	UpdatedAt   time.Time               `json:"updatedAt"`
-	LastOnline  optional.Of[time.Time]  `json:"lastOnline"`
-	TwitterID   string                  `json:"twitterId"`
-	Name        string                  `json:"name"`
-	DisplayName string                  `json:"displayName"`
-	IconFileID  uuid.UUID               `json:"iconFileId"`
-	Bot         bool                    `json:"bot"`
-	State       int                     `json:"state"`
-	Permissions []permission.Permission `json:"permissions"`
-	HomeChannel optional.Of[uuid.UUID]  `json:"homeChannel"`
-}
-
-func FormatUserInfo(ui model.UserInfo, tags []model.UserTag, groups []uuid.UUID, permissions []permission.Permission) *UserInfo {
-	return &UserInfo{
-		ID:          ui.GetID(),
-		Bio:         ui.GetBio(),
-		Groups:      groups,
-		Tags:        formatUserTags(tags),
-		UpdatedAt:   ui.GetUpdatedAt(),
-		LastOnline:  ui.GetLastOnline(),
-		TwitterID:   ui.GetTwitterID(),
-		Name:        ui.GetName(),
-		DisplayName: ui.GetResponseDisplayName(),
-		IconFileID:  ui.GetIconFileID(),
-		Bot:         ui.IsBot(),
-		State:       ui.GetState().Int(),
-		Permissions: permissions,
-		HomeChannel: ui.GetHomeChannel(),
-	}
 }

--- a/router/v3/responses.go
+++ b/router/v3/responses.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/traPtitech/traQ/model"
+	"github.com/traPtitech/traQ/service/rbac/permission"
 	"github.com/traPtitech/traQ/utils/optional"
 
 	"github.com/gofrs/uuid"
@@ -622,4 +623,40 @@ func formatStampPalettes(cfs []*model.StampPalette) []*StampPalette {
 	}
 	sort.Slice(res, func(i, j int) bool { return res[i].ID.String() < res[j].ID.String() })
 	return res
+}
+
+type UserInfo struct {
+	ID          uuid.UUID               `json:"id"`
+	Bio         string                  `json:"bio"`
+	Groups      []uuid.UUID             `json:"groups"`
+	Tags        []UserTag               `json:"tags"`
+	UpdatedAt   time.Time               `json:"updatedAt"`
+	LastOnline  optional.Of[time.Time]  `json:"lastOnline"`
+	TwitterID   string                  `json:"twitterId"`
+	Name        string                  `json:"name"`
+	DisplayName string                  `json:"displayName"`
+	IconFileID  uuid.UUID               `json:"iconFileId"`
+	Bot         bool                    `json:"bot"`
+	State       int                     `json:"state"`
+	Permissions []permission.Permission `json:"permissions"`
+	HomeChannel optional.Of[uuid.UUID]  `json:"homeChannel"`
+}
+
+func FormatUserInfo(ui model.UserInfo, tags []model.UserTag, groups []uuid.UUID, permissions []permission.Permission) *UserInfo {
+	return &UserInfo{
+		ID:          ui.GetID(),
+		Bio:         ui.GetBio(),
+		Groups:      groups,
+		Tags:        formatUserTags(tags),
+		UpdatedAt:   ui.GetUpdatedAt(),
+		LastOnline:  ui.GetLastOnline(),
+		TwitterID:   ui.GetTwitterID(),
+		Name:        ui.GetName(),
+		DisplayName: ui.GetResponseDisplayName(),
+		IconFileID:  ui.GetIconFileID(),
+		Bot:         ui.IsBot(),
+		State:       ui.GetState().Int(),
+		Permissions: permissions,
+		HomeChannel: ui.GetHomeChannel(),
+	}
 }

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -6,12 +6,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/samber/lo"
-
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
+	"github.com/samber/lo"
 	"github.com/skip2/go-qrcode"
 
 	"github.com/traPtitech/traQ/model"
@@ -101,7 +100,22 @@ func (h *Handlers) GetMe(c echo.Context) error {
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
-	return extension.ServeJSONWithETag(c, FormatUserInfo(me, tags, groups, h.RBAC.GetGrantedPermissions(me.GetRole())))
+	return extension.ServeJSONWithETag(c, echo.Map{
+		"id":          me.GetID(),
+		"bio":         me.GetBio(),
+		"groups":      groups,
+		"tags":        formatUserTags(tags),
+		"updatedAt":   me.GetUpdatedAt(),
+		"lastOnline":  me.GetLastOnline(),
+		"twitterId":   me.GetTwitterID(),
+		"name":        me.GetName(),
+		"displayName": me.GetResponseDisplayName(),
+		"iconFileId":  me.GetIconFileID(),
+		"bot":         me.IsBot(),
+		"state":       me.GetState().Int(),
+		"permissions": h.RBAC.GetGrantedPermissions(me.GetRole()),
+		"homeChannel": me.GetHomeChannel(),
+	})
 }
 
 type userAccessScopes struct{}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -2,10 +2,11 @@ package v3
 
 import (
 	"context"
-	"github.com/samber/lo"
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/samber/lo"
 
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
@@ -100,23 +101,7 @@ func (h *Handlers) GetMe(c echo.Context) error {
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
-
-	return c.JSON(http.StatusOK, echo.Map{
-		"id":          me.GetID(),
-		"bio":         me.GetBio(),
-		"groups":      groups,
-		"tags":        formatUserTags(tags),
-		"updatedAt":   me.GetUpdatedAt(),
-		"lastOnline":  me.GetLastOnline(),
-		"twitterId":   me.GetTwitterID(),
-		"name":        me.GetName(),
-		"displayName": me.GetResponseDisplayName(),
-		"iconFileId":  me.GetIconFileID(),
-		"bot":         me.IsBot(),
-		"state":       me.GetState().Int(),
-		"permissions": h.RBAC.GetGrantedPermissions(me.GetRole()),
-		"homeChannel": me.GetHomeChannel(),
-	})
+	return extension.ServeJSONWithETag(c, FormatUserInfo(me, tags, groups, h.RBAC.GetGrantedPermissions(me.GetRole())))
 }
 
 type userAccessScopes struct{}


### PR DESCRIPTION
resolves #1055
キャッシュされないエンドポイントの中で最も平均のレスポンスボディが長さが長いエンドポイントである`/me`にETagを追加しました。これにより、リロード時の転送量の30%程度が削減できます。

https://q.trap.jp/messages/4c4ceb48-9c54-4cba-b6f4-c70224b6bfac