### PR TITLE
adminでなくても自分のスタンプを削除できるように

### DIFF
--- a/migration/current.go
+++ b/migration/current.go
@@ -46,6 +46,7 @@ func Migrations() []*gormigrate.Migration {
 		v33(), // 未読テーブルにチャンネルIDカラムを追加 / インデックス類の更新 / 不要なレコードの削除
 		v34(), // 未読テーブルのcreated_atカラムをメッセージテーブルを元に更新 / カラム名を変更
 		v35(), // OIDC実装のため、openid, profileロール、get_oidc_userinfo権限を追加
+		v36(), // delete_my_stampパーミッションを追加
 	}
 }
 

--- a/migration/v36.go
+++ b/migration/v36.go
@@ -5,7 +5,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// v16 パーミッション修正
+// v36 delete_my_stampパーミッションを追加
 func v36() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "36",

--- a/migration/v36.go
+++ b/migration/v36.go
@@ -14,7 +14,7 @@ func v36() *gormigrate.Migration {
 				"user": {
 					"delete_my_stamp",
 				},
-				"write":{
+				"write": {
 					"delete_my_stamp",
 				},
 			}

--- a/migration/v36.go
+++ b/migration/v36.go
@@ -1,0 +1,40 @@
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// v16 パーミッション修正
+func v36() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "36",
+		Migrate: func(db *gorm.DB) error {
+			addedRolePermissions := map[string][]string{
+				"user": {
+					"delete_my_stamp",
+				},
+				"write":{
+					"delete_my_stamp",
+				},
+			}
+			for role, perms := range addedRolePermissions {
+				for _, perm := range perms {
+					if err := db.Create(&v36RolePermission{Role: role, Permission: perm}).Error; err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+type v36RolePermission struct {
+	Role       string `gorm:"type:varchar(30);not null;primaryKey"`
+	Permission string `gorm:"type:varchar(30);not null;primaryKey"`
+}
+
+func (*v36RolePermission) TableName() string {
+	return "user_role_permissions"
+}

--- a/router/middlewares/access_control.go
+++ b/router/middlewares/access_control.go
@@ -221,3 +221,21 @@ func CheckClipFolderAccessPerm() echo.MiddlewareFunc {
 		}
 	}
 }
+
+// CheckDeleteStampPerm スタンプ削除権限を確認するミドルウェア
+func CheckDeleteStampPerm(rbac rbac.RBAC) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			user := c.Get(consts.KeyUser).(model.UserInfo)
+
+			if rbac.IsGranted(user.GetRole(), permission.DeleteStamp) {
+				return next(c) //adminのアクセス
+			}
+			stamp := c.Get(consts.KeyParamStamp).(*model.Stamp)
+			if rbac.IsGranted(user.GetRole(), permission.DeleteMyStamp) && stamp.CreatorID == user.GetID() {
+				return next(c) //スタンプ作成者のアクセス
+			}
+			return herror.Forbidden()
+		}
+	}
+}

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -80,6 +80,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 	requiresChannelAccessPerm := middlewares.CheckChannelAccessPerm(h.ChannelManager)
 	requiresGroupAdminPerm := middlewares.CheckUserGroupAdminPerm(h.RBAC)
 	requiresClipFolderAccessPerm := middlewares.CheckClipFolderAccessPerm()
+	requiresDeleteStampPerm := middlewares.CheckDeleteStampPerm(h.RBAC)
 
 	api := e.Group("/v3", middlewares.UserAuthenticate(h.Repo, h.SessStore))
 	{
@@ -245,7 +246,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 			{
 				apiStampsSID.GET("", h.GetStamp, requires(permission.GetStamp))
 				apiStampsSID.PATCH("", h.EditStamp, requires(permission.EditStamp))
-				apiStampsSID.DELETE("", h.DeleteStamp, requires(permission.DeleteStamp))
+				apiStampsSID.DELETE("", h.DeleteStamp, requiresDeleteStampPerm)
 				apiStampsSID.GET("/stats", h.GetStampStats, requires(permission.GetStamp))
 				apiStampsSID.GET("/image", h.GetStampImage, requires(permission.GetStamp, permission.DownloadFile))
 				apiStampsSID.PUT("/image", h.ChangeStampImage, requires(permission.EditStamp))

--- a/service/rbac/permission/permission.go
+++ b/service/rbac/permission/permission.go
@@ -108,6 +108,7 @@ var List = []Permission{
 	AddMessageStamp,
 	RemoveMessageStamp,
 	GetMyStampHistory,
+	DeleteMyStamp,
 
 	GetChannelStar,
 	EditChannelStar,

--- a/service/rbac/permission/stamp.go
+++ b/service/rbac/permission/stamp.go
@@ -11,6 +11,8 @@ const (
 	EditStampCreatedByOthers = Permission("edit_stamp_created_by_others")
 	// DeleteStamp スタンプ削除権限
 	DeleteStamp = Permission("delete_stamp")
+	// DeleteMyStamp 自分のスタンプ削除権限
+	DeleteMyStamp = Permission("delete_my_stamp")
 	// AddMessageStamp メッセージスタンプ追加権限
 	AddMessageStamp = Permission("add_message_stamp")
 	// RemoveMessageStamp メッセージスタンプ削除権限

--- a/service/rbac/role/write.go
+++ b/service/rbac/role/write.go
@@ -27,6 +27,7 @@ var writePerms = []permission.Permission{
 	permission.EditUserGroup,
 	permission.DeleteUserGroup,
 	permission.CreateStamp,
+	permission.DeleteMyStamp,
 	permission.AddMessageStamp,
 	permission.RemoveMessageStamp,
 	permission.EditStamp,


### PR DESCRIPTION
close #2471
一般ユーザーとwrite権限を持つoauthクライアントが自身の持つスタンプを削除できるように変更しました。