### PR TITLE
自分が許可している指定したOAuthクライアントのアクセストークンを全てRevokeできるようにする

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -2896,6 +2896,25 @@ paths:
         指定したOAuth2クライアントの情報を変更します。
         対象のクライアントの管理権限が必要です。
         クライアント開発者UUIDを変更した場合は、変更先ユーザーにクライアント管理権限が移譲され、自分自身は権限を失います。
+  '/clients/{clientId}/tokens':
+    delete:
+      summary: OAuthクライアントのトークンを削除
+      parameters:
+        - $ref: '#/components/parameters/clientIdInPath'
+      responses:
+        '204':
+          description: |-
+            No Content
+            削除できました。
+        '404':
+          description: |-
+            Not Found
+            OAuth2クライアントが見つかりません。
+      tags:
+        - oauth2
+      operationId: revokeClientTokens
+      description: |-
+        自分が許可している指定したOAuthクライアントのアクセストークンを全てRevokeします。
   /clients:
     get:
       summary: OAuth2クライアントのリストを取得

--- a/repository/gorm/oauth2.go
+++ b/repository/gorm/oauth2.go
@@ -240,3 +240,10 @@ func (repo *Repository) DeleteTokenByClient(clientID string) error {
 	}
 	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{ClientID: clientID}).Error
 }
+
+func (repo *Repository) DeleteUserTokensByClient(userID uuid.UUID, clientID string) error {
+	if userID == uuid.Nil || len(clientID) == 0 {
+		return nil
+	}
+	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{UserID: userID, ClientID: clientID}).Error
+}

--- a/repository/oauth2.go
+++ b/repository/oauth2.go
@@ -127,4 +127,9 @@ type OAuth2Repository interface {
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
 	DeleteTokenByClient(clientID string) error
+	// DeleteUserTokensByClient 指定したユーザーの指定したクライアントのトークンをすべて削除します
+	//
+	// 成功した場合、nilを返します。
+	// DBによるエラーを返すことがあります。
+	DeleteUserTokensByClient(userID uuid.UUID, clientID string) error
 }

--- a/router/v3/clients.go
+++ b/router/v3/clients.go
@@ -140,3 +140,16 @@ func (h *Handlers) DeleteClient(c echo.Context) error {
 
 	return c.NoContent(http.StatusNoContent)
 }
+
+// RevokeClientTokens /clients/:clientID/tokens
+func (h *Handlers) RevokeClientTokens(c echo.Context) error {
+	oc := getParamClient(c)
+	userID := getRequestUserID(c)
+
+	err := h.Repo.DeleteUserTokensByClient(userID, oc.ID)
+	if err != nil {
+		return herror.InternalServerError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -320,6 +320,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 				apiClientsCID.GET("", h.GetClient, requires(permission.GetClients))
 				apiClientsCID.PATCH("", h.EditClient, requiresClientAccessPerm, requires(permission.EditMyClient))
 				apiClientsCID.DELETE("", h.DeleteClient, requiresClientAccessPerm, requires(permission.DeleteMyClient))
+				apiClientsCID.DELETE("/tokens", h.RevokeClientTokens, requires(permission.RevokeMyToken))
 			}
 		}
 		apiBots := api.Group("/bots")


### PR DESCRIPTION
resolve #1092

- `/api/v3/clients/:clientID/tokens` (DELETE) を作った
- マージ後に、フロント側の実装のissueを立てたい