### PR TITLE
OpenAPI.yamlのPutUserIconRequestのDescriptionを2MBに修正

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5563,7 +5563,7 @@ components:
         file:
           type: string
           format: binary
-          description: 'アイコン画像(1MBまでのpng, jpeg, gif)'
+          description: 'アイコン画像(2MBまでのpng, jpeg, gif)'
       required:
         - file
     PutMyPasswordRequest:


### PR DESCRIPTION
close #2468 

実装において2MBを指定しているのに合わせて表記を修正
https://github.com/traPtitech/traQ/blob/master/router/utils/process_image.go#L27