### PR TITLE
凍結時にunreadの削除がデカすぎてサーバーが落ちる問題を一時的に修正

### DIFF
--- a/repository/gorm/user.go
+++ b/repository/gorm/user.go
@@ -290,11 +290,11 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 			count += len(changes)
 		}
 		// 凍結の際は未読を削除
-		if deactivate {
-			if err := tx.Delete(&model.Unread{}, "user_id = ?", id).Error; err != nil {
-				return err
-			}
-		}
+		// if deactivate {
+		// 	if err := tx.Delete(&model.Unread{}, "user_id = ?", id).Error; err != nil {
+		// 		return err
+		// 	}
+		// }
 		return nil
 	})
 	if err != nil {

--- a/repository/gorm/user.go
+++ b/repository/gorm/user.go
@@ -219,11 +219,11 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 	}
 
 	var (
-		u          model.User
-		activate   bool
-		deactivate bool
-		changed    bool
-		count      int
+		u        model.User
+		activate bool
+		//deactivate bool
+		changed bool
+		count   int
 	)
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Preload("Profile").First(&u, model.User{ID: id}).Error; err != nil {
@@ -243,7 +243,7 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 			case model.UserAccountStatusActive.Int():
 				activate = true
 			case model.UserAccountStatusDeactivated.Int():
-				deactivate = true
+				//deactivate = true
 			}
 		}
 		if args.IconFileID.Valid {


### PR DESCRIPTION
凍結時にunreadの削除がデカすぎてサーバーが落ちる問題を一時的に修正