### PR TITLE
feat(service/search): from/toの複数指定を可能に

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -119,14 +119,18 @@ paths:
           name: in
           description: メッセージが投稿されたチャンネル
         - schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
           in: query
           name: to
           description: メンションされたユーザー
         - schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
           in: query
           name: from
           description: メッセージを投稿したユーザー

--- a/service/search/engine.go
+++ b/service/search/engine.go
@@ -32,8 +32,8 @@ type Query struct {
 	After          optional.Of[time.Time] `query:"after"`          // 以降(投稿日時) 2020-06-20T00:00:00Z
 	Before         optional.Of[time.Time] `query:"before"`         // 以前(投稿日時)
 	In             optional.Of[uuid.UUID] `query:"in"`             // 投稿チャンネル
-	To             optional.Of[uuid.UUID] `query:"to"`             // メンション先
-	From           optional.Of[uuid.UUID] `query:"from"`           // 投稿者
+	To             []uuid.UUID            `query:"to"`             // メンション先
+	From           []uuid.UUID            `query:"from"`           // 投稿者
 	Citation       optional.Of[uuid.UUID] `query:"citation"`       // 引用しているメッセージ
 	Bot            optional.Of[bool]      `query:"bot"`            // 投稿者がBotか
 	HasURL         optional.Of[bool]      `query:"hasURL"`         // URLの存在


### PR DESCRIPTION
related to #2526

- `?to={userID}&to={userID2}&to={groupID}`のような指定ができるようになる
    - これはechoのパースの方式に従った書き方だが、実際はORなのにANDのように見えてしまうことを懸念している
    - `?to={userID},{userID2},{groupID}`を実装するなら一旦生文字列で受け取って自前でスライスする必要がある
- フロントエンド側では`to:me`や`to:@Ras`をuserIDとuserが所属するgroupIDsのORに変換することでグループメンションも受け取れる
    - 毎回グループメンションが必要かは議論の余地がありそうだが、そっちはフロントエンド側に任せます
- 指定が1つの場合は従来通りの検索結果が返るのでAPIの形式自体に破壊的変更はない
    - OpenAPIから生成したAPI Clientの型がuuidから[]uuidに修正する必要は出てくるかも

<details>

<summary>API Response</summary>

```js
await (await fetch("/api/v3/messages?to=0193e6e1-e122-73e5-9ab8-73fc58c532c8&to=0193e82c-369e-70f0-a516-805ae8b32bb9&to=0193e82c-4ce0-70f0-bb2a-f8c46abd0934&to=0193e82c-6103-70f0-ac48-a14b7818d311")).json();

{
    "totalHits": 4,
    "hits": [
        {
            "id": "0193e82c-9baf-70f0-ae41-79014de010a8",
            "userId": "0193e6e1-e122-73e5-9ab8-73fc58c532c8",
            "channelId": "0193e6e1-e177-73e5-a6fd-53f5e498f897",
            "content": "!{\"type\":\"group\",\"raw\":\"@traq4\",\"id\":\"0193e82c-6103-70f0-ac48-a14b7818d311\"} グループメンション",
            "createdAt": "2024-12-21T07:44:17.839708Z",
            "updatedAt": "2024-12-21T07:44:17.839708Z",
            "pinned": false,
            "stamps": [],
            "threadId": null
        },
        {
            "id": "0193e82c-8f9b-70f0-8613-73144963643a",
            "userId": "0193e6e1-e122-73e5-9ab8-73fc58c532c8",
            "channelId": "0193e6e1-e177-73e5-a6fd-53f5e498f897",
            "content": "!{\"type\":\"group\",\"raw\":\"@traq3\",\"id\":\"0193e82c-4ce0-70f0-bb2a-f8c46abd0934\"} グループメンション",
            "createdAt": "2024-12-21T07:44:14.748326Z",
            "updatedAt": "2024-12-21T07:44:14.748326Z",
            "pinned": false,
            "stamps": [],
            "threadId": null
        },
        {
            "id": "0193e82c-7ec7-70f0-a481-866a5e33a6d6",
            "userId": "0193e6e1-e122-73e5-9ab8-73fc58c532c8",
            "channelId": "0193e6e1-e177-73e5-a6fd-53f5e498f897",
            "content": "!{\"type\":\"group\",\"raw\":\"@traq2\",\"id\":\"0193e82c-369e-70f0-a516-805ae8b32bb9\"} グループメンション",
            "createdAt": "2024-12-21T07:44:10.43953Z",
            "updatedAt": "2024-12-21T07:44:10.43953Z",
            "pinned": false,
            "stamps": [],
            "threadId": null
        },
        {
            "id": "0193e82c-0a61-70f0-9719-698c4ce78325",
            "userId": "0193e6e1-e122-73e5-9ab8-73fc58c532c8",
            "channelId": "0193e6e1-e177-73e5-a6fd-53f5e498f897",
            "content": "!{\"type\":\"user\",\"raw\":\"@traq\",\"id\":\"0193e6e1-e122-73e5-9ab8-73fc58c532c8\"}",
            "createdAt": "2024-12-21T07:43:40.642202Z",
            "updatedAt": "2024-12-21T07:43:40.642202Z",
            "pinned": false,
            "stamps": [],
            "threadId": null
        }
    ]
}
```

</details>