### PR TITLE
feat: frontend containerのビルド時にtraQ-S_UIをダウンロードしてくる

### DIFF
--- a/.github/renovate/regex-manager.json5
+++ b/.github/renovate/regex-manager.json5
@@ -47,7 +47,7 @@
     {
       "description": "GitHub URL dependencies",
       "fileMatch": [
-        ".+\\.ya?ml$", "(^|/)Makefile$"
+        ".+\\.ya?ml$", "(^|/)Makefile$", "^Dockerfile.*"
       ],
       "matchStrings": [
         // Example: kustomize build https://github.com/argoproj/argo-cd//manifests/crds?ref=v2.7.6 | kubectl create -f -

--- a/Makefile
+++ b/Makefile
@@ -66,17 +66,6 @@ db-lint: ## Lint db docs according to .tbls.yml
 	TRAQ_MARIADB_PORT=$(TEST_DB_PORT) go run main.go migrate --reset
 	docker run --rm --net=host -e TBLS_DSN="mariadb://root:password@127.0.0.1:$(TEST_DB_PORT)/traq" -v $$PWD:/work -w /work ghcr.io/k1low/tbls:$(TBLS_VERSION) lint -c .tbls.yml
 
-.PHONY: update-frontend
-update-frontend: ## Update frontend files in dev/frontend
-	@mkdir -p ./dev/frontend
-# renovate:github-url
-	@curl -L -Ss https://github.com/traPtitech/traQ_S-UI/releases/download/v3.22.1/dist.tar.gz | tar zxv -C ./dev/frontend/ --strip-components=2
-
-.PHONY: reset-frontend
-reset-frontend: ## Completely replace frontend files in dev/frontend
-	rm -rf ./dev/frontend
-	@make update-frontend
-
 .PHONY: up
 up: ## Build and start the app containers
 	@docker compose up -d --build

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,9 @@ services:
       - app:/app/storage
 
   frontend:
-    image: caddy:2.9.1-alpine
+    build:
+      context: ./dev
+      dockerfile: Dockerfile-frontend
     restart: always
     expose:
       - "80"
@@ -39,9 +41,6 @@ services:
       - "3000:80"
     depends_on:
       - backend
-    volumes:
-      - ./dev/Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./dev/frontend:/usr/share/caddy:ro
 
   mysql:
     image: mariadb:10.11.10

--- a/dev/Dockerfile-frontend
+++ b/dev/Dockerfile-frontend
@@ -1,4 +1,4 @@
-FROM caddy:2.8.4-alpine
+FROM caddy:2.9.1-alpine
 
 COPY ./Caddyfile /etc/caddy/Caddyfile
 

--- a/dev/Dockerfile-frontend
+++ b/dev/Dockerfile-frontend
@@ -2,4 +2,4 @@ FROM caddy:2.8.4-alpine
 
 COPY ./Caddyfile /etc/caddy/Caddyfile
 
-RUN wget -O - https://github.com/traPtitech/traQ_S-UI/releases/latest/download/dist.tar.gz | tar zxv -C /usr/share/caddy/ --strip-components=2
+RUN wget -O - https://github.com/traPtitech/traQ_S-UI/releases/download/v3.22.1/dist.tar.gz | tar zxv -C /usr/share/caddy/ --strip-components=2

--- a/dev/Dockerfile-frontend
+++ b/dev/Dockerfile-frontend
@@ -1,0 +1,5 @@
+FROM caddy:2.8.4-alpine
+
+COPY ./Caddyfile /etc/caddy/Caddyfile
+
+RUN wget -O - https://github.com/traPtitech/traQ_S-UI/releases/latest/download/dist.tar.gz | tar zxv -C /usr/share/caddy/ --strip-components=2

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ If you want to contribute to traQ, then follow this section.
 ### Setup Local Server with Docker
 
 #### First Up (or entirely rebuild)
-`make update-frontend && make up`
+`make up`
 
 Now you can access to
 + `http://localhost:3000` for traQ

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,9 +30,6 @@ Now you can access to
 #### Rebuild traQ
 `make up`
 
-#### Update frontend
-`make update-frontend` or `make reset-frontend`
-
 #### Destroy Containers
 `make down`
 


### PR DESCRIPTION
`make up` (`docker compose up --build -d`)の前に`make update-frontend`をし忘れるとフロントエンドが立ち上がらないのでDocker Composeのビルド時に引っ張ってくるようにしました
