### PR TITLE
リリースノートの作成に失敗していたのを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,6 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - run: gh release create ${{ github.ref_name }} --generate-notes
+      - run: gh release create ${{ github.ref_name }} --generate-notes --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#2544 でactions/checkoutを消したせいでリリースノートを打つべきリポジトリが特定できない状態になっていたので、オプションで指定するようにしました