### PR TITLE
サムネがなかった時にDBのメタデータを更新するように

### DIFF
--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,6 +18,7 @@ import (
 	"github.com/traPtitech/traQ/service/file"
 	imaging2 "github.com/traPtitech/traQ/service/imaging"
 	"github.com/traPtitech/traQ/utils/optional"
+	"github.com/traPtitech/traQ/utils/storage"
 )
 
 // ChangeUserIcon userIDのユーザーのアイコン画像を変更する
@@ -87,6 +89,36 @@ func ServeFileThumbnail(c echo.Context, meta model.File) error {
 
 	file, err := meta.OpenThumbnail(thumbnailType)
 	if err != nil {
+		// Check if the error is because the file doesn't exist in S3
+		if errors.Is(err, storage.ErrFileNotFound) {
+			// サムネイルが実際には存在しないのでDBの情報を更新する
+			repo := c.Get("repository").(repository.Repository)
+			fileID := meta.GetID()
+
+			// Delete the thumbnail record from the database by re-saving the file meta without this thumbnail
+			fileMeta, err := repo.GetFileMeta(fileID)
+			if err != nil {
+				c.Logger().Warnf("failed to get file meta for thumbnail cleanup: %v", err)
+			} else {
+				// Remove the thumbnail from the list
+				var newThumbnails []model.FileThumbnail
+				for _, t := range fileMeta.Thumbnails {
+					if t.Type != thumbnailType {
+						newThumbnails = append(newThumbnails, t)
+					}
+				}
+				fileMeta.Thumbnails = newThumbnails
+
+				// Save the updated file meta
+				if err := repo.SaveFileMeta(fileMeta, []*model.FileACLEntry{}); err != nil {
+					c.Logger().Warnf("failed to update file meta for thumbnail cleanup: %v", err)
+				} else {
+					c.Logger().Infof("removed non-existent thumbnail from database for file %s type %s", fileID, thumbnailType)
+				}
+			}
+
+			return herror.NotFound()
+		}
 		return herror.InternalServerError(err)
 	}
 	defer file.Close()

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -72,7 +72,7 @@ func ChangeUserPassword(c echo.Context, repo repository.Repository, seStore sess
 }
 
 // ServeFileThumbnail metaのファイルのサムネイルをレスポンスとして返す
-func ServeFileThumbnail(c echo.Context, meta model.File) error {
+func ServeFileThumbnail(c echo.Context, meta model.File, repo repository.Repository) error {
 	typeStr := c.QueryParam("type")
 	if len(typeStr) == 0 {
 		typeStr = "image"
@@ -92,7 +92,6 @@ func ServeFileThumbnail(c echo.Context, meta model.File) error {
 		// Check if the error is because the file doesn't exist in S3
 		if errors.Is(err, storage.ErrFileNotFound) {
 			// サムネイルが実際には存在しないのでDBの情報を更新する
-			repo := c.Get("repository").(repository.Repository)
 			fileID := meta.GetID()
 
 			// Delete the thumbnail record from the database by re-saving the file meta without this thumbnail

--- a/router/v1/files.go
+++ b/router/v1/files.go
@@ -23,5 +23,5 @@ func (h *Handlers) GetMetaDataByFileID(c echo.Context) error {
 
 // GetThumbnailByID GET /files/:fileID/thumbnail
 func (h *Handlers) GetThumbnailByID(c echo.Context) error {
-	return utils.ServeFileThumbnail(c, getFileFromContext(c))
+	return utils.ServeFileThumbnail(c, getFileFromContext(c), h.Repo)
 }

--- a/router/v3/files.go
+++ b/router/v3/files.go
@@ -146,7 +146,7 @@ func (h *Handlers) GetFileMeta(c echo.Context) error {
 
 // GetThumbnailImage GET /files/:fileID/thumbnail
 func (h *Handlers) GetThumbnailImage(c echo.Context) error {
-	return utils.ServeFileThumbnail(c, getParamFile(c))
+	return utils.ServeFileThumbnail(c, getParamFile(c), h.Repo)
 }
 
 // GetFile GET /files/:fileID


### PR DESCRIPTION
DBのデータ上はサムネイルがあるとなっているが、ストレージに実際にはサムネイルがなかった不整合発生時にDBのデータを更新することで不整合を解消するようにした