### PR TITLE
🔊 zap.Logger を使う

### DIFF
--- a/router/v1/files.go
+++ b/router/v1/files.go
@@ -23,5 +23,5 @@ func (h *Handlers) GetMetaDataByFileID(c echo.Context) error {
 
 // GetThumbnailByID GET /files/:fileID/thumbnail
 func (h *Handlers) GetThumbnailByID(c echo.Context) error {
-	return utils.ServeFileThumbnail(c, getFileFromContext(c), h.Repo)
+	return utils.ServeFileThumbnail(c, getFileFromContext(c), h.Repo, h.Logger)
 }

--- a/router/v3/files.go
+++ b/router/v3/files.go
@@ -146,7 +146,7 @@ func (h *Handlers) GetFileMeta(c echo.Context) error {
 
 // GetThumbnailImage GET /files/:fileID/thumbnail
 func (h *Handlers) GetThumbnailImage(c echo.Context) error {
-	return utils.ServeFileThumbnail(c, getParamFile(c), h.Repo)
+	return utils.ServeFileThumbnail(c, getParamFile(c), h.Repo, h.Logger)
 }
 
 // GetFile GET /files/:fileID


### PR DESCRIPTION
`(*echo.Echo).Logger()` を使ってもログに残らない可能性が高かったため, 他と揃えて `zap.Logger` を使うようにした.