### PR TITLE
✨ DeleteFileThumbnail の定義と実装

### DIFF
--- a/repository/file.go
+++ b/repository/file.go
@@ -55,4 +55,10 @@ type FileRepository interface {
 	// ファイルもしくはユーザーが存在しない場合は、falseを返します。
 	// DBによるエラーを返すことがあります。
 	IsFileAccessible(fileID, userID uuid.UUID) (bool, error)
+	// DeleteFileThumbnail サムネイル情報を削除します
+	//
+	// 成功した場合、nilを返します。
+	// 存在しないサムネイルを指定した場合, ErrNotFoundを返します。
+	// DBによるエラーを返すことがあります。
+	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType)
 }

--- a/repository/file.go
+++ b/repository/file.go
@@ -60,5 +60,5 @@ type FileRepository interface {
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType) error
+	DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error
 }

--- a/repository/file.go
+++ b/repository/file.go
@@ -58,7 +58,8 @@ type FileRepository interface {
 	// DeleteFileThumbnail サムネイル情報を削除します
 	//
 	// 成功した場合、nilを返します。
-	// 存在しないサムネイルを指定した場合, ErrNotFoundを返します。
+	// 引数にuuid.Nilを指定するとErrNilIDを返します。
+	// 存在しないファイル, またはサムネイルを指定した場合, ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
 	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType)
 }

--- a/repository/file.go
+++ b/repository/file.go
@@ -61,5 +61,5 @@ type FileRepository interface {
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// 存在しないファイル, またはサムネイルを指定した場合, ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType)
+	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType) error
 }

--- a/repository/file.go
+++ b/repository/file.go
@@ -59,7 +59,6 @@ type FileRepository interface {
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
-	// 存在しないファイル, またはサムネイルを指定した場合, ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
 	DeleteFileThumbnail(fileId uuid.UUID, thumbnailType model.ThumbnailType) error
 }

--- a/repository/gorm/file.go
+++ b/repository/gorm/file.go
@@ -131,3 +131,14 @@ func (repo *Repository) IsFileAccessible(fileID, userID uuid.UUID) (bool, error)
 func filePreloads(db *gorm.DB) *gorm.DB {
 	return db.Preload("Thumbnails")
 }
+
+// DeleteFileThumbnail implements FileRepository interface.
+func (repo *Repository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
+	if err := repo.db.Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID, Type: thumbnailType}).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return repository.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}

--- a/repository/gorm/file.go
+++ b/repository/gorm/file.go
@@ -138,9 +138,6 @@ func (repo *Repository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType mode
 		return repository.ErrNilID
 	}
 	if err := repo.db.Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID, Type: thumbnailType}).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return repository.ErrNotFound
-		}
 		return err
 	}
 	return nil

--- a/repository/gorm/file.go
+++ b/repository/gorm/file.go
@@ -134,6 +134,9 @@ func filePreloads(db *gorm.DB) *gorm.DB {
 
 // DeleteFileThumbnail implements FileRepository interface.
 func (repo *Repository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
+	if fileID == uuid.Nil {
+		return repository.ErrNilID
+	}
 	if err := repo.db.Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID, Type: thumbnailType}).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return repository.ErrNotFound

--- a/repository/gorm/file_test.go
+++ b/repository/gorm/file_test.go
@@ -310,36 +310,36 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 	repo, _, _ := setup(t, common)
 
 	tests := map[string]struct {
-		createsFile         bool
-		deletesExistingFile bool
-		thumbnailType       model.ThumbnailType
+		createsFile           bool
+		deletesExistingFile   bool
+		thumbnailTypeToDelete model.ThumbnailType
 	}{
 		"nil id": {
-			createsFile:         false,
-			deletesExistingFile: false,
-			thumbnailType:       model.ThumbnailTypeImage,
+			createsFile:           false,
+			deletesExistingFile:   false,
+			thumbnailTypeToDelete: model.ThumbnailTypeImage,
 		},
 		"file not found": {
-			createsFile:         true,
-			deletesExistingFile: false,
-			thumbnailType:       model.ThumbnailTypeImage,
+			createsFile:           true,
+			deletesExistingFile:   false,
+			thumbnailTypeToDelete: model.ThumbnailTypeImage,
 		},
 		"thumbnail type not found": {
-			createsFile:         true,
-			deletesExistingFile: true,
-			thumbnailType:       model.ThumbnailTypeWaveform,
+			createsFile:           true,
+			deletesExistingFile:   true,
+			thumbnailTypeToDelete: model.ThumbnailTypeWaveform,
 		},
 		"success": {
-			createsFile:         true,
-			deletesExistingFile: true,
-			thumbnailType:       model.ThumbnailTypeImage,
+			createsFile:           true,
+			deletesExistingFile:   true,
+			thumbnailTypeToDelete: model.ThumbnailTypeImage,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			if !tt.createsFile {
-				err := repo.DeleteFileThumbnail(uuid.Nil, tt.thumbnailType)
+				err := repo.DeleteFileThumbnail(uuid.Nil, tt.thumbnailTypeToDelete)
 				assert.EqualError(t, err, repository.ErrNilID.Error())
 				return
 			}
@@ -347,7 +347,7 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 			f := mustMakeDummyFile(t, repo)
 
 			if !tt.deletesExistingFile { // 存在しないファイルの場合, 変更なしを検証
-				err := repo.DeleteFileThumbnail(uuid.Must(uuid.NewV7()), tt.thumbnailType)
+				err := repo.DeleteFileThumbnail(uuid.Must(uuid.NewV7()), tt.thumbnailTypeToDelete)
 				assert.NoError(t, err)
 				ff, err := repo.GetFileMeta(f.ID)
 				assert.NoError(t, err)
@@ -355,9 +355,9 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 				return
 			}
 
-			err := repo.DeleteFileThumbnail(f.ID, tt.thumbnailType)
+			err := repo.DeleteFileThumbnail(f.ID, tt.thumbnailTypeToDelete)
 			assert.NoError(t, err)
-			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailType)) { // f.Thumbnails が tt.thumbnailType を含まない場合, 変更なしを検証
+			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete)) { // f.Thumbnails が tt.thumbnailType を含まない場合, 変更なしを検証
 				ff, err := repo.GetFileMeta(f.ID)
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
@@ -365,7 +365,7 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 			}
 			f, err = repo.GetFileMeta(f.ID)
 			assert.NoError(t, err)
-			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailType))) // f.Thumbnails が tt.thumbnailType を含まない
+			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete))) // f.Thumbnails が tt.thumbnailType を含まない
 		})
 	}
 }

--- a/repository/gorm/file_test.go
+++ b/repository/gorm/file_test.go
@@ -357,7 +357,7 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 
 			err := repo.DeleteFileThumbnail(f.ID, tt.thumbnailTypeToDelete)
 			assert.NoError(t, err)
-			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete)) { // f.Thumbnails が tt.thumbnailType を含まない場合, 変更なしを検証
+			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete)) { // f.Thumbnails が tt.thumbnailTypeToDelete を含まない場合, 変更なしを検証
 				ff, err := repo.GetFileMeta(f.ID)
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
@@ -365,7 +365,7 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 			}
 			f, err = repo.GetFileMeta(f.ID)
 			assert.NoError(t, err)
-			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete))) // f.Thumbnails が tt.thumbnailType を含まない
+			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete))) // f.Thumbnails が tt.thumbnailTypeToDelete を含まない
 		})
 	}
 }

--- a/repository/gorm/file_test.go
+++ b/repository/gorm/file_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -295,4 +296,76 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			}
 		})
 	})
+}
+
+// model.FileThumbnail の Type が指定されたものと等価であるか比較する関数を取得する.
+func getThumbnailEqualityComparerByType(tt model.ThumbnailType) func(model.FileThumbnail) bool {
+	return func(t model.FileThumbnail) bool {
+		return t.Type == tt
+	}
+}
+
+func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
+	t.Parallel()
+	repo, _, _ := setup(t, common)
+
+	tests := map[string]struct {
+		createsFile         bool
+		deletesExistingFile bool
+		thumbnailType       model.ThumbnailType
+	}{
+		"nil id": {
+			createsFile:         false,
+			deletesExistingFile: false,
+			thumbnailType:       model.ThumbnailTypeImage,
+		},
+		"file not found": {
+			createsFile:         true,
+			deletesExistingFile: false,
+			thumbnailType:       model.ThumbnailTypeImage,
+		},
+		"thumbnail type not found": {
+			createsFile:         true,
+			deletesExistingFile: true,
+			thumbnailType:       model.ThumbnailTypeWaveform,
+		},
+		"success": {
+			createsFile:         true,
+			deletesExistingFile: true,
+			thumbnailType:       model.ThumbnailTypeImage,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !tt.createsFile {
+				err := repo.DeleteFileThumbnail(uuid.Nil, tt.thumbnailType)
+				assert.EqualError(t, err, repository.ErrNilID.Error())
+				return
+			}
+
+			f := mustMakeDummyFile(t, repo)
+
+			if !tt.deletesExistingFile { // 存在しないファイルの場合, 変更なしを検証
+				err := repo.DeleteFileThumbnail(uuid.Must(uuid.NewV7()), tt.thumbnailType)
+				assert.NoError(t, err)
+				ff, err := repo.GetFileMeta(f.ID)
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
+				return
+			}
+
+			err := repo.DeleteFileThumbnail(f.ID, tt.thumbnailType)
+			assert.NoError(t, err)
+			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailType)) { // f.Thumbnails が tt.thumbnailType を含まない場合, 変更なしを検証
+				ff, err := repo.GetFileMeta(f.ID)
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
+				return
+			}
+			f, err = repo.GetFileMeta(f.ID)
+			assert.NoError(t, err)
+			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailType))) // f.Thumbnails が tt.thumbnailType を含まない
+		})
+	}
 }

--- a/repository/mock_repository/mock_file.go
+++ b/repository/mock_repository/mock_file.go
@@ -50,6 +50,20 @@ func (mr *MockFileRepositoryMockRecorder) DeleteFileMeta(fileID interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileMeta", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileMeta), fileID)
 }
 
+// DeleteFileThumbnail mocks base method.
+func (m *MockFileRepository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFileThumbnail", fileID, thumbnailType)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteFileThumbnail indicates an expected call of DeleteFileThumbnail.
+func (mr *MockFileRepositoryMockRecorder) DeleteFileThumbnail(fileID, thumbnailType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileThumbnail", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileThumbnail), fileID, thumbnailType)
+}
+
 // GetFileMeta mocks base method.
 func (m *MockFileRepository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- ファイルのサムネイル情報を削除する `FileRepository.DeleteFileThumbnail` メソッドの定義と実装を追加.
- `DeleteFileThumbnail` のテストを追加.
- モックリポジトリを再生成して更新.