### PR TITLE
🐛 GetChannels のテストの検証ロジックを修正

### DIFF
--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -75,10 +75,10 @@ func channelListElementEquals(t *testing.T, expect []*model.Channel, actual *htt
 	// do not use `expect`, use `expectCopy` instead
 	for i := 0; i < channelCount; i++ {
 		channelObj := actual.Value(i).Object()
-		channelIdString := channelObj.Value("id").String().Raw()
+		channelIDString := channelObj.Value("id").String().Raw()
 
 		j := slices.IndexFunc(expectCopy, func(c *model.Channel) bool {
-			return c.ID.String() == channelIdString
+			return c.ID.String() == channelIDString
 		})
 		assert.NotEqual(t, -1, j, "channel not found in expect list")
 		expectObj := expectCopy[j]

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -68,10 +68,11 @@ func channelEquals(t *testing.T, expect *model.Channel, actual *httpexpect.Objec
 
 func channelListElementEquals(t *testing.T, expect []*model.Channel, actual *httpexpect.Array) {
 	t.Helper()
+	// copy to avoid modifying `expect`
 	expectCopy := make([]*model.Channel, len(expect))
 	copy(expectCopy, expect)
-	channelCount := int(actual.Length().IsEqual(len(expect)).Raw())
 
+	channelCount := int(actual.Length().IsEqual(len(expect)).Raw())
 	// do not use `expect`, use `expectCopy` instead
 	for i := 0; i < channelCount; i++ {
 		channelObj := actual.Value(i).Object()

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -74,7 +74,7 @@ func channelListElementEquals(t *testing.T, expect []*model.Channel, actual *htt
 
 	channelCount := int(actual.Length().IsEqual(len(expect)).Raw())
 	// do not use `expect`, use `expectCopy` instead
-	for i := 0; i < channelCount; i++ {
+	for i := range channelCount {
 		channelObj := actual.Value(i).Object()
 		channelIDString := channelObj.Value("id").String().Raw()
 

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -121,10 +121,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 			Object()
 
 		public := obj.Value("public").Array()
-		public.Length().IsEqual(2)
-
-		channelEquals(t, channel, public.Value(0).Object())
-		channelEquals(t, subchannel, public.Value(1).Object())
+		channelListElementEquals(t, []*model.Channel{channel, subchannel}, public)
 	})
 
 	t.Run("success (include-dm=true, user1)", func(t *testing.T) {
@@ -139,9 +136,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 			Object()
 
 		public := obj.Value("public").Array()
-		public.Length().IsEqual(2)
-		channelEquals(t, channel, public.Value(0).Object())
-		channelEquals(t, subchannel, public.Value(1).Object())
+		channelListElementEquals(t, []*model.Channel{channel, subchannel}, public)
 
 		dms := obj.Value("dm").Array()
 		dms.Length().IsEqual(1)
@@ -162,9 +157,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 			Object()
 
 		public := obj.Value("public").Array()
-		public.Length().IsEqual(2)
-		channelEquals(t, channel, public.Value(0).Object())
-		channelEquals(t, subchannel, public.Value(1).Object())
+		channelListElementEquals(t, []*model.Channel{channel, subchannel}, public)
 
 		dms := obj.Value("dm").Array()
 		dms.Length().IsEqual(1)
@@ -185,9 +178,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 			Object()
 
 		public := obj.Value("public").Array()
-		public.Length().IsEqual(2)
-		channelEquals(t, channel, public.Value(0).Object())
-		channelEquals(t, subchannel, public.Value(1).Object())
+		channelListElementEquals(t, []*model.Channel{channel, subchannel}, public)
 
 		dms := obj.Value("dm").Array()
 		dms.Length().IsEqual(0)


### PR DESCRIPTION
close #2611 

- #2611 の原因は, テスト時に配列内の要素の順序も含めて検証してしまっていたこと.
- 順序は関係なく配列に含まれている要素が一致していればよいので, そのように検証ロジックを修正した.