### PR TITLE
/channels/{channelId}/statsから削除済みメッセージを除外するためのクエリパラメータを追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -8138,7 +8138,7 @@ components:
       description: ウェビナールームかどうか(デフォルト false)
     excludeDeletedMessagesInQuery:
       in: query
-      name: excludeDeletedMessages
+      name: exclude-deleted-messages
       schema:
         type: boolean
       required: false

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -352,6 +352,7 @@ paths:
   '/channels/{channelId}/stats':
     parameters:
       - $ref: '#/components/parameters/channelIdInPath'
+      - $ref: '#/components/parameters/excludeDeletedMessagesInQuery'
     get:
       summary: チャンネル統計情報を取得
       tags:
@@ -8135,6 +8136,13 @@ components:
         type: boolean
       required: false
       description: ウェビナールームかどうか(デフォルト false)
+    excludeDeletedMessagesInQuery:
+      in: query
+      name: excludeDeletedMessages
+      schema:
+        type: boolean
+      required: false
+      description: 削除されたメッセージを除外するかどうか(デフォルト false)
 
 tags:
   - name: user

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -116,7 +116,7 @@ type ChannelRepository interface {
 	// GetChannelStats 指定したチャンネルの統計情報を取得します
 	//
 	// 存在しないチャンネルを指定した場合、ErrNotFoundを返します。
-	GetChannelStats(channelID uuid.UUID) (*ChannelStats, error)
+	GetChannelStats(channelID uuid.UUID, excludeDeletedMessages bool) (*ChannelStats, error)
 	// RecordChannelEvent チャンネルイベントを記録します
 	RecordChannelEvent(channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error
 }

--- a/repository/gorm/channel.go
+++ b/repository/gorm/channel.go
@@ -498,6 +498,7 @@ func (repo *Repository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessa
 	}
 
 	if err := query.
+		Group("user_id").
 		Order("message_count DESC").
 		Find(&stats.Users).
 		Error; err != nil {

--- a/repository/gorm/channel_test.go
+++ b/repository/gorm/channel_test.go
@@ -137,14 +137,14 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetChannelStats(uuid.Nil)
+		_, err := repo.GetChannelStats(uuid.Nil, false)
 		assert.Error(t, err)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetChannelStats(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetChannelStats(uuid.Must(uuid.NewV7()), false)
 		assert.Error(t, err)
 	})
 
@@ -180,7 +180,7 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, u2Messages[i].ID, stamp2.ID, user1.GetID())
 		}
 
-		stats, err := repo.GetChannelStats(channel.ID)
+		stats, err := repo.GetChannelStats(channel.ID, false)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 

--- a/repository/mock_repository/mock_channel.go
+++ b/repository/mock_repository/mock_channel.go
@@ -116,18 +116,18 @@ func (mr *MockChannelRepositoryMockRecorder) GetChannelEvents(query interface{})
 }
 
 // GetChannelStats mocks base method.
-func (m *MockChannelRepository) GetChannelStats(channelID uuid.UUID) (*repository.ChannelStats, error) {
+func (m *MockChannelRepository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessages bool) (*repository.ChannelStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelStats", channelID)
+	ret := m.ctrl.Call(m, "GetChannelStats", channelID, excludeDeletedMessages)
 	ret0, _ := ret[0].(*repository.ChannelStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannelStats indicates an expected call of GetChannelStats.
-func (mr *MockChannelRepositoryMockRecorder) GetChannelStats(channelID interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetChannelStats(channelID, excludeDeletedMessages interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelStats", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelStats), channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelStats", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelStats), channelID, excludeDeletedMessages)
 }
 
 // GetChannelSubscriptions mocks base method.

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -187,7 +187,7 @@ func (h *Handlers) GetChannelViewers(c echo.Context) error {
 // GetChannelStats GET /channels/:channelID/stats
 func (h *Handlers) GetChannelStats(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
-	excludeDeletedMessages := isTrue(c.QueryParam("excludeDeletedMessages"))
+	excludeDeletedMessages := isTrue(c.QueryParam("exclude-deleted-messages"))
 	stats, err := h.Repo.GetChannelStats(channelID, excludeDeletedMessages)
 	if err != nil {
 		return herror.InternalServerError(err)

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -187,7 +187,8 @@ func (h *Handlers) GetChannelViewers(c echo.Context) error {
 // GetChannelStats GET /channels/:channelID/stats
 func (h *Handlers) GetChannelStats(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
-	stats, err := h.Repo.GetChannelStats(channelID)
+	excludeDeletedMessages := isTrue(c.QueryParam("excludeDeletedMessages"))
+	stats, err := h.Repo.GetChannelStats(channelID, excludeDeletedMessages)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gorm"
 
 	driverMysql "github.com/go-sql-driver/mysql"
+
 	"github.com/traPtitech/traQ/migration"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
@@ -329,6 +330,12 @@ func (env *Env) CreateMessage(t *testing.T, userID, channelID uuid.UUID, text st
 	m, err := env.MM.Create(channelID, userID, text)
 	require.NoError(t, err)
 	return m
+}
+
+// DeleteMessage メッセージを必ず削除します
+func (env *Env) DeleteMessage(t *testing.T, messageID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, env.MM.Delete(messageID))
 }
 
 // MakeMessageUnread 指定したメッセージを未読にします


### PR DESCRIPTION
Closes #2357
> 現状のAPIドキュメントからはこのAPIの値が「削除済みメッセージも含んでいる」というのは非自明に思える

デフォルトでは削除済みメッセージを含むままですが、パラメータが存在すればこの問題はマシになるんじゃないかと思っています