### PR TITLE
fix: optimize room state retrieval by using index access

### DIFF
--- a/service/qall/roomstate_impl.go
+++ b/service/qall/roomstate_impl.go
@@ -276,9 +276,9 @@ func (r *Repository) GetRoomsWithParticipantsByLiveKitServer(ctx context.Context
 
 // GetRoomState ルーム状態を取得
 func (r *Repository) GetRoomState(roomID string) *RoomWithParticipants {
-	for _, roomState := range r.RoomState {
-		if roomState.RoomID.String() == roomID {
-			return &roomState
+	for i := range r.RoomState {
+		if r.RoomState[i].RoomID.String() == roomID {
+			return &r.RoomState[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
for ループ内で一時にコピーされた構造体のアドレスを返すこととなっておりました
このとき、フィールドがすべてポインタ型であったときは特に問題が起きませんでした (コピーされた構造体のフィールドはすべてコピー元の構造体のフィールドと同じ部分を指すため)
しかし、値型となったことで、もとのスライスとは異なる部分に値が保持され、 for ループを抜けた際に値が消去され、それにより ws イベント発行時に nil 参照が起きていたのではないかと推測しました

先にマージして、 staging で環境したさがあります