### PR TITLE
Update livekit config in deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,12 +162,12 @@ skyway:
 # LiveKit settings.
 # You must set these to enable the call ('Qall') feature.
 livekit:
-  # LiveKit host url
-  livekitHost: livekitHost
+  # LiveKit host url (ex: `https://...`)
+  host: livekitHost
   # LiveKit api key
-  livekitAPIKey: livekitAPIKey
+  apiKey: livekitAPIKey
   # LiveKit api secret
-  livekitAPISecret: livekitAPISecret
+  apiSecret: livekitAPISecret
 
 # (optional) JWT settings.
 # Used to issue QR codes to authenticate user.


### PR DESCRIPTION
## 変更点

- `/cmd/config.go` のコードを参考に、 `deployment.md` の LiveKit 周りのコンフィグを更新
- `livekit.host` の設定例を追加（ `wss` ではなく `https` を指定する必要があることがわかりやすいように）

↓ 参考にした `/cmd/config.go` のコード
https://github.com/traPtitech/traQ/blob/a3e09111674849f8388c64442cbecdb09309489f/cmd/config.go#L214-L222

## 確認事項

ex-traQ 環境にて、この設定で正常に Qall を開始できることを確認しました
