### PR TITLE
チャンネル閲覧者状態のスロットル実装

### DIFF
--- a/service/exevent/stamp_throttler.go
+++ b/service/exevent/stamp_throttler.go
@@ -16,7 +16,7 @@ const eventPublishInterval = 1 * time.Second
 type StampThrottler struct {
 	bus       *hub.Hub
 	mm        message.Manager
-	throttles *throttle.ThrottleMap[uuid.UUID]
+	throttles *throttle.Map[uuid.UUID]
 }
 
 func NewStampThrottler(bus *hub.Hub, mm message.Manager) *StampThrottler {

--- a/service/exevent/stamp_throttler.go
+++ b/service/exevent/stamp_throttler.go
@@ -1,94 +1,62 @@
 package exevent
 
 import (
-	"sync"
 	"time"
 
-	"github.com/boz/go-throttle"
 	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
 
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/throttle"
 )
+
+const eventPublishInterval = 1 * time.Second
+
+type StampThrottler struct {
+	bus       *hub.Hub
+	mm        message.Manager
+	throttles *throttle.ThrottleMap[uuid.UUID]
+}
 
 func NewStampThrottler(bus *hub.Hub, mm message.Manager) *StampThrottler {
 	st := &StampThrottler{
 		bus: bus,
 		mm:  mm,
-		m:   map[uuid.UUID]*stampThrottlerEntry{},
 	}
+	st.throttles = throttle.NewThrottleMap(eventPublishInterval, 5*time.Second, st.publishMessageStampsUpdated)
+
 	return st
 }
 
-type StampThrottler struct {
-	bus   *hub.Hub
-	mm    message.Manager
-	m     map[uuid.UUID]*stampThrottlerEntry
-	mLock sync.Mutex
-}
-
 func (st *StampThrottler) Start() {
-	go st.loop()
+	go st.run()
 }
 
-func (st *StampThrottler) loop() {
-	clean := time.NewTicker(5 * time.Second)
-	defer clean.Stop()
+func (st *StampThrottler) run() {
 	sub := st.bus.Subscribe(100, event.MessageStamped, event.MessageUnstamped)
 	defer st.bus.Unsubscribe(sub)
 
-	for {
-		select {
-		case msg := <-sub.Receiver:
-			mid := msg.Fields["message_id"].(uuid.UUID)
-			st.mLock.Lock()
-			ent, ok := st.m[mid]
-			if !ok {
-				ent = &stampThrottlerEntry{
-					t: throttle.ThrottleFunc(time.Second, true, func() {
-						m, err := st.mm.Get(mid)
-						if err != nil {
-							return // 無視
-						}
-
-						st.bus.Publish(hub.Message{
-							Name: event.MessageStampsUpdated,
-							Fields: hub.Fields{
-								"message_id": mid,
-								"message":    m,
-							},
-						})
-					}),
-				}
-				st.m[mid] = ent
-			}
-			ent.trigger()
-			st.mLock.Unlock()
-
-		case <-clean.C:
-			st.mLock.Lock()
-			for mid, ent := range st.m {
-				if ent.lastCall.Add(10 * time.Second).Before(time.Now()) {
-					ent.dispose()
-					delete(st.m, mid)
-				}
-			}
-			st.mLock.Unlock()
+	for msg := range sub.Receiver {
+		messageID, ok := msg.Fields["message_id"].(uuid.UUID)
+		if !ok {
+			continue // ignore invalid message
 		}
+		st.throttles.Trigger(messageID)
 	}
 }
 
-type stampThrottlerEntry struct {
-	lastCall time.Time
-	t        throttle.ThrottleDriver
-}
+func (st *StampThrottler) publishMessageStampsUpdated(messageID uuid.UUID) {
+	msg, err := st.mm.Get(messageID)
+	if err != nil {
+		return // ignore error
+	}
 
-func (ste *stampThrottlerEntry) dispose() {
-	ste.t.Stop()
-}
-
-func (ste *stampThrottlerEntry) trigger() {
-	ste.lastCall = time.Now()
-	ste.t.Trigger()
+	st.bus.Publish(hub.Message{
+		Name: event.MessageStampsUpdated,
+		Fields: hub.Fields{
+			"message_id": messageID,
+			"message":    msg,
+		},
+	})
 }

--- a/service/viewer/manager.go
+++ b/service/viewer/manager.go
@@ -172,6 +172,7 @@ func (vm *Manager) notifyChannelViewers(channelID uuid.UUID) {
 	if cv.Len() > throttleThreshold {
 		vm.channelThrottle.Trigger(channelID)
 	} else {
+		vm.channelThrottle.Stop(channelID)
 		vm.publishChannelChanged(channelID)
 	}
 }
@@ -181,6 +182,7 @@ func (vm *Manager) notifyUserViewStateChanged(userID uuid.UUID) {
 	if uv.Len() > throttleThreshold {
 		vm.userThrottle.Trigger(userID)
 	} else {
+		vm.userThrottle.Stop(userID)
 		vm.publishUserViewStateChanged(userID)
 	}
 }

--- a/service/viewer/manager.go
+++ b/service/viewer/manager.go
@@ -20,8 +20,8 @@ type Manager struct {
 	channels        map[uuid.UUID]*viewerSet
 	users           map[uuid.UUID]*viewerSet
 	viewers         map[any]*viewer
-	channelThrottle *throttle.ThrottleMap[uuid.UUID]
-	userThrottle    *throttle.ThrottleMap[uuid.UUID]
+	channelThrottle *throttle.Map[uuid.UUID]
+	userThrottle    *throttle.Map[uuid.UUID]
 	mu              sync.RWMutex
 }
 

--- a/service/viewer/manager.go
+++ b/service/viewer/manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/traPtitech/traQ/utils/throttle"
 )
 
-const throttleInterval = 3 * time.Second
+const throttleInterval = 1 * time.Second
 
 // if the number of viewers is greater than the threshold, throttle the event
 // otherwise, publish the event immediately

--- a/service/viewer/manager.go
+++ b/service/viewer/manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/traPtitech/traQ/utils/throttle"
 )
 
-const throttleInterval = 3 * time.Minute
+const throttleInterval = 3 * time.Second
 
 // if the number of viewers is greater than the threshold, throttle the event
 // otherwise, publish the event immediately

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -1,0 +1,44 @@
+package set
+
+import "iter"
+
+type Set[T comparable] struct {
+	set map[T]struct{}
+}
+
+func New[T comparable]() *Set[T] {
+	return &Set[T]{
+		set: make(map[T]struct{}),
+	}
+}
+
+func (set *Set[T]) Add(v ...T) {
+	for _, v := range v {
+		set.set[v] = struct{}{}
+	}
+}
+
+func (set *Set[T]) Remove(v ...T) {
+	for _, v := range v {
+		delete(set.set, v)
+	}
+}
+
+func (set *Set[T]) Contains(v T) bool {
+	_, ok := set.set[v]
+	return ok
+}
+
+func (set *Set[T]) Len() int {
+	return len(set.set)
+}
+
+func (set *Set[T]) Values() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range set.set {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}

--- a/utils/throttle/throttlemap.go
+++ b/utils/throttle/throttlemap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/boz/go-throttle"
 )
 
-type ThrottleMap[K comparable] struct {
+type Map[K comparable] struct {
 	throttles map[K]*throttleEntry
 	interval  time.Duration
 	ttl       time.Duration
@@ -24,8 +24,8 @@ type throttleEntry struct {
 // The callback function will be called with the key when the throttle is triggered.
 // The interval is the time period in which the callback can be triggered.
 // The ttl is the time to live for each key in the map, after which it will be removed.
-func NewThrottleMap[K comparable](interval, ttl time.Duration, callback func(K)) *ThrottleMap[K] {
-	t := &ThrottleMap[K]{
+func NewThrottleMap[K comparable](interval, ttl time.Duration, callback func(K)) *Map[K] {
+	t := &Map[K]{
 		throttles: make(map[K]*throttleEntry),
 		interval:  interval,
 		ttl:       ttl,
@@ -37,7 +37,7 @@ func NewThrottleMap[K comparable](interval, ttl time.Duration, callback func(K))
 
 // Trigger triggers the throttle for the given key.
 // The callback will be scheduled to be called after the interval.
-func (tm *ThrottleMap[K]) Trigger(key K) {
+func (tm *Map[K]) Trigger(key K) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
@@ -54,7 +54,7 @@ func (tm *ThrottleMap[K]) Trigger(key K) {
 	entry.driver.Trigger()
 }
 
-func (tm *ThrottleMap[K]) gcLoop() {
+func (tm *Map[K]) gcLoop() {
 	for range time.Tick(tm.ttl / 2) {
 		tm.mu.Lock()
 		now := time.Now()

--- a/utils/throttle/throttlemap.go
+++ b/utils/throttle/throttlemap.go
@@ -60,6 +60,7 @@ func (tm *Map[K]) gcLoop() {
 		now := time.Now()
 		for key, entry := range tm.throttles {
 			if now.Sub(entry.lastTriggered) > tm.ttl {
+				entry.driver.Stop()
 				delete(tm.throttles, key)
 			}
 		}

--- a/utils/throttle/throttlemap.go
+++ b/utils/throttle/throttlemap.go
@@ -54,6 +54,16 @@ func (tm *Map[K]) Trigger(key K) {
 	entry.driver.Trigger()
 }
 
+func (tm *Map[K]) Stop(key K) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if entry, exists := tm.throttles[key]; exists {
+		entry.driver.Stop()
+		delete(tm.throttles, key)
+	}
+}
+
 func (tm *Map[K]) gcLoop() {
 	for range time.Tick(tm.ttl / 2) {
 		tm.mu.Lock()

--- a/utils/throttle/throttlemap.go
+++ b/utils/throttle/throttlemap.go
@@ -1,0 +1,68 @@
+package throttle
+
+import (
+	"sync"
+	"time"
+
+	"github.com/boz/go-throttle"
+)
+
+type ThrottleMap[K comparable] struct {
+	throttles map[K]*throttleEntry
+	interval  time.Duration
+	ttl       time.Duration
+	mu        sync.Mutex
+	callback  func(K)
+}
+
+type throttleEntry struct {
+	driver        throttle.ThrottleDriver
+	lastTriggered time.Time
+}
+
+// NewThrottleMap creates a new ThrottleMap.
+// The callback function will be called with the key when the throttle is triggered.
+// The interval is the time period in which the callback can be triggered.
+// The ttl is the time to live for each key in the map, after which it will be removed.
+func NewThrottleMap[K comparable](interval, ttl time.Duration, callback func(K)) *ThrottleMap[K] {
+	t := &ThrottleMap[K]{
+		throttles: make(map[K]*throttleEntry),
+		interval:  interval,
+		ttl:       ttl,
+		callback:  callback,
+	}
+	go t.gcLoop()
+	return t
+}
+
+// Trigger triggers the throttle for the given key.
+// The callback will be scheduled to be called after the interval.
+func (tm *ThrottleMap[K]) Trigger(key K) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	entry, exists := tm.throttles[key]
+	if !exists {
+		entry = &throttleEntry{
+			driver: throttle.ThrottleFunc(tm.interval, true, func() {
+				tm.callback(key)
+			}),
+		}
+		tm.throttles[key] = entry
+	}
+	entry.lastTriggered = time.Now()
+	entry.driver.Trigger()
+}
+
+func (tm *ThrottleMap[K]) gcLoop() {
+	for range time.Tick(tm.ttl / 2) {
+		tm.mu.Lock()
+		now := time.Now()
+		for key, entry := range tm.throttles {
+			if now.Sub(entry.lastTriggered) > tm.ttl {
+				delete(tm.throttles, key)
+			}
+		}
+		tm.mu.Unlock()
+	}
+}


### PR DESCRIPTION
Botのスタンプ受け取りの実装を参考に、チャンネル閲覧者の更新イベントをスロットリングするようにしました。
Botのスタンプ受け取りと処理が共通化したので、`utils/throttle`に実装を分けました。

動作確認の方法について教えてほしいです。