### PR TITLE
fix: 閲覧者のスロットリング処理の中でSetをpointerではなくvalueとして持つ

### DIFF
--- a/service/exevent/stamp_throttler.go
+++ b/service/exevent/stamp_throttler.go
@@ -1,94 +1,62 @@
 package exevent
 
 import (
-	"sync"
 	"time"
 
-	"github.com/boz/go-throttle"
 	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
 
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/service/message"
+	"github.com/traPtitech/traQ/utils/throttle"
 )
+
+const eventPublishInterval = 1 * time.Second
+
+type StampThrottler struct {
+	bus       *hub.Hub
+	mm        message.Manager
+	throttles *throttle.Map[uuid.UUID]
+}
 
 func NewStampThrottler(bus *hub.Hub, mm message.Manager) *StampThrottler {
 	st := &StampThrottler{
 		bus: bus,
 		mm:  mm,
-		m:   map[uuid.UUID]*stampThrottlerEntry{},
 	}
+	st.throttles = throttle.NewThrottleMap(eventPublishInterval, 5*time.Second, st.publishMessageStampsUpdated)
+
 	return st
 }
 
-type StampThrottler struct {
-	bus   *hub.Hub
-	mm    message.Manager
-	m     map[uuid.UUID]*stampThrottlerEntry
-	mLock sync.Mutex
-}
-
 func (st *StampThrottler) Start() {
-	go st.loop()
+	go st.run()
 }
 
-func (st *StampThrottler) loop() {
-	clean := time.NewTicker(5 * time.Second)
-	defer clean.Stop()
+func (st *StampThrottler) run() {
 	sub := st.bus.Subscribe(100, event.MessageStamped, event.MessageUnstamped)
 	defer st.bus.Unsubscribe(sub)
 
-	for {
-		select {
-		case msg := <-sub.Receiver:
-			mid := msg.Fields["message_id"].(uuid.UUID)
-			st.mLock.Lock()
-			ent, ok := st.m[mid]
-			if !ok {
-				ent = &stampThrottlerEntry{
-					t: throttle.ThrottleFunc(time.Second, true, func() {
-						m, err := st.mm.Get(mid)
-						if err != nil {
-							return // 無視
-						}
-
-						st.bus.Publish(hub.Message{
-							Name: event.MessageStampsUpdated,
-							Fields: hub.Fields{
-								"message_id": mid,
-								"message":    m,
-							},
-						})
-					}),
-				}
-				st.m[mid] = ent
-			}
-			ent.trigger()
-			st.mLock.Unlock()
-
-		case <-clean.C:
-			st.mLock.Lock()
-			for mid, ent := range st.m {
-				if ent.lastCall.Add(10 * time.Second).Before(time.Now()) {
-					ent.dispose()
-					delete(st.m, mid)
-				}
-			}
-			st.mLock.Unlock()
+	for msg := range sub.Receiver {
+		messageID, ok := msg.Fields["message_id"].(uuid.UUID)
+		if !ok {
+			continue // ignore invalid message
 		}
+		st.throttles.Trigger(messageID)
 	}
 }
 
-type stampThrottlerEntry struct {
-	lastCall time.Time
-	t        throttle.ThrottleDriver
-}
+func (st *StampThrottler) publishMessageStampsUpdated(messageID uuid.UUID) {
+	msg, err := st.mm.Get(messageID)
+	if err != nil {
+		return // ignore error
+	}
 
-func (ste *stampThrottlerEntry) dispose() {
-	ste.t.Stop()
-}
-
-func (ste *stampThrottlerEntry) trigger() {
-	ste.lastCall = time.Now()
-	ste.t.Trigger()
+	st.bus.Publish(hub.Message{
+		Name: event.MessageStampsUpdated,
+		Fields: hub.Fields{
+			"message_id": messageID,
+			"message":    msg,
+		},
+	})
 }

--- a/service/viewer/manager.go
+++ b/service/viewer/manager.go
@@ -21,8 +21,8 @@ const throttleThreshold = 30
 // Manager チャンネル閲覧者マネージャ
 type Manager struct {
 	hub             *hub.Hub
-	channels        map[uuid.UUID]*set.Set[*viewer]
-	users           map[uuid.UUID]*set.Set[*viewer]
+	channels        map[uuid.UUID]set.Set[*viewer]
+	users           map[uuid.UUID]set.Set[*viewer]
 	viewers         map[any]*viewer
 	channelThrottle *throttle.Map[uuid.UUID]
 	userThrottle    *throttle.Map[uuid.UUID]
@@ -41,8 +41,8 @@ type viewer struct {
 func NewManager(hub *hub.Hub) *Manager {
 	vm := &Manager{
 		hub:      hub,
-		channels: make(map[uuid.UUID]*set.Set[*viewer]),
-		users:    make(map[uuid.UUID]*set.Set[*viewer]),
+		channels: make(map[uuid.UUID]set.Set[*viewer]),
+		users:    make(map[uuid.UUID]set.Set[*viewer]),
 		viewers:  make(map[any]*viewer),
 	}
 	vm.channelThrottle = throttle.NewThrottleMap(throttleInterval, 5*time.Minute, func(cid uuid.UUID) {
@@ -210,7 +210,7 @@ func (vm *Manager) publishUserViewStateChanged(userID uuid.UUID) {
 }
 
 // calculateUserViewStates ユーザーのviewerのsetからmap[conn_key]StateWithChannelを計算する
-func calculateUserViewStates(uv *set.Set[*viewer]) map[string]StateWithChannel {
+func calculateUserViewStates(uv set.Set[*viewer]) map[string]StateWithChannel {
 	result := make(map[string]StateWithChannel, uv.Len())
 	for v := range uv.Values() {
 		result[v.connKey] = StateWithChannel{
@@ -221,7 +221,7 @@ func calculateUserViewStates(uv *set.Set[*viewer]) map[string]StateWithChannel {
 	return result
 }
 
-func calculateChannelViewers(vs *set.Set[*viewer]) map[uuid.UUID]StateWithTime {
+func calculateChannelViewers(vs set.Set[*viewer]) map[uuid.UUID]StateWithTime {
 	result := make(map[uuid.UUID]StateWithTime, vs.Len())
 	for v := range vs.Values() {
 		if s, ok := result[v.userID]; ok && s.State > v.state.State {

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -6,8 +6,8 @@ type Set[T comparable] struct {
 	set map[T]struct{}
 }
 
-func New[T comparable]() *Set[T] {
-	return &Set[T]{
+func New[T comparable]() Set[T] {
+	return Set[T]{
 		set: make(map[T]struct{}),
 	}
 }

--- a/utils/set/set.go
+++ b/utils/set/set.go
@@ -1,0 +1,44 @@
+package set
+
+import "iter"
+
+type Set[T comparable] struct {
+	set map[T]struct{}
+}
+
+func New[T comparable]() *Set[T] {
+	return &Set[T]{
+		set: make(map[T]struct{}),
+	}
+}
+
+func (set *Set[T]) Add(v ...T) {
+	for _, v := range v {
+		set.set[v] = struct{}{}
+	}
+}
+
+func (set *Set[T]) Remove(v ...T) {
+	for _, v := range v {
+		delete(set.set, v)
+	}
+}
+
+func (set *Set[T]) Contains(v T) bool {
+	_, ok := set.set[v]
+	return ok
+}
+
+func (set *Set[T]) Len() int {
+	return len(set.set)
+}
+
+func (set *Set[T]) Values() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range set.set {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}

--- a/utils/throttle/throttlemap.go
+++ b/utils/throttle/throttlemap.go
@@ -1,0 +1,79 @@
+package throttle
+
+import (
+	"sync"
+	"time"
+
+	"github.com/boz/go-throttle"
+)
+
+type Map[K comparable] struct {
+	throttles map[K]*throttleEntry
+	interval  time.Duration
+	ttl       time.Duration
+	mu        sync.Mutex
+	callback  func(K)
+}
+
+type throttleEntry struct {
+	driver        throttle.ThrottleDriver
+	lastTriggered time.Time
+}
+
+// NewThrottleMap creates a new ThrottleMap.
+// The callback function will be called with the key when the throttle is triggered.
+// The interval is the time period in which the callback can be triggered.
+// The ttl is the time to live for each key in the map, after which it will be removed.
+func NewThrottleMap[K comparable](interval, ttl time.Duration, callback func(K)) *Map[K] {
+	t := &Map[K]{
+		throttles: make(map[K]*throttleEntry),
+		interval:  interval,
+		ttl:       ttl,
+		callback:  callback,
+	}
+	go t.gcLoop()
+	return t
+}
+
+// Trigger triggers the throttle for the given key.
+// The callback will be scheduled to be called after the interval.
+func (tm *Map[K]) Trigger(key K) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	entry, exists := tm.throttles[key]
+	if !exists {
+		entry = &throttleEntry{
+			driver: throttle.ThrottleFunc(tm.interval, true, func() {
+				tm.callback(key)
+			}),
+		}
+		tm.throttles[key] = entry
+	}
+	entry.lastTriggered = time.Now()
+	entry.driver.Trigger()
+}
+
+func (tm *Map[K]) Stop(key K) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if entry, exists := tm.throttles[key]; exists {
+		entry.driver.Stop()
+		delete(tm.throttles, key)
+	}
+}
+
+func (tm *Map[K]) gcLoop() {
+	for range time.Tick(tm.ttl / 2) {
+		tm.mu.Lock()
+		now := time.Now()
+		for key, entry := range tm.throttles {
+			if now.Sub(entry.lastTriggered) > tm.ttl {
+				entry.driver.Stop()
+				delete(tm.throttles, key)
+			}
+		}
+		tm.mu.Unlock()
+	}
+}


### PR DESCRIPTION
#2639 でSetViewer される前に GetChannelViewer されると map から nil(*set.Set) が返ってきてしまうようになっていた。`*set.Set`ではなく`set.Set`として扱うように修正した。