### PR TITLE
chores: セキュリティ窓口を明示する

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security issue, **do not** open a public issue.
+Instead, email us at **info@trap.jp**.  
+
+_Optionally_:
+- Include as much detail as possible: steps to reproduce, affected versions, and proof-of-concept code.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 To report a security issue, **do not** open a public issue.
-Instead, email us at **info@trap.jp**.  
+Instead, email us at **info@trap.jp** or fill a form at https://trap.jp/request.
 
 _Optionally_:
 - Include as much detail as possible: steps to reproduce, affected versions, and proof-of-concept code.

--- a/router/router.go
+++ b/router/router.go
@@ -43,6 +43,8 @@ func Setup(hub *hub.Hub, db *gorm.DB, repo repository.Repository, ss *service.Se
 			return c.Redirect(http.StatusFound, "/api/v3/oauth2/oidc/discovery")
 		})
 		wellKnown.GET("/security.txt", func(c echo.Context) error {
+			// Contactなどの情報が古くなっていないかを定期的に確認し、Expiresを*手動で*更新すること
+			// See: https://www.rfc-editor.org/rfc/rfc9116.html#section-5.3
 			return c.String(http.StatusOK, `Contact: mailto:info@trap.jp
 Contact: https://trap.jp/request
 Expires: 2026-03-31T23:59:59+09:00

--- a/router/router.go
+++ b/router/router.go
@@ -44,6 +44,7 @@ func Setup(hub *hub.Hub, db *gorm.DB, repo repository.Repository, ss *service.Se
 		})
 		wellKnown.GET("/security.txt", func(c echo.Context) error {
 			return c.String(http.StatusOK, `Contact: mailto:info@trap.jp
+Contact: https://trap.jp/request
 Expires: 2026-03-31T23:59:59+09:00
 Preferred-Languages: ja,en`)
 		})

--- a/router/router.go
+++ b/router/router.go
@@ -42,6 +42,11 @@ func Setup(hub *hub.Hub, db *gorm.DB, repo repository.Repository, ss *service.Se
 		wellKnown.GET("/openid-configuration", func(c echo.Context) error {
 			return c.Redirect(http.StatusFound, "/api/v3/oauth2/oidc/discovery")
 		})
+		wellKnown.GET("/security.txt", func(c echo.Context) error {
+			return c.String(http.StatusOK, `Contact: mailto:info@trap.jp
+Expires: 2026-03-31T23:59:59+09:00
+Preferred-Languages: ja,en`)
+		})
 	}
 
 	api := r.e.Group("/api")


### PR DESCRIPTION
無かったので、追加しました
お好みで編集・マージしてください。

Expiresは1年ごと程度に更新することを想定しています（情報がstaleになるとよくないので）
https://www.rfc-editor.org/rfc/rfc9116.html#:~:text=It%20is%20RECOMMENDED%20that%20the%20value%20of%20this%20field%20be%20less%20than%20a%20year%20into%20the%20future%20to%20avoid%20staleness.%C2%B6