### PR TITLE
fix: (security) ユーザー凍結後のセッションの扱いを修正

### DIFF
--- a/repository/gorm/user.go
+++ b/repository/gorm/user.go
@@ -289,12 +289,6 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 			changed = true
 			count += len(changes)
 		}
-		// 凍結の際は未読を削除
-		// if deactivate {
-		// 	if err := tx.Delete(&model.Unread{}, "user_id = ?", id).Error; err != nil {
-		// 		return err
-		// 	}
-		// }
 		return nil
 	})
 	if err != nil {

--- a/router/oauth2/authorization_endpoint.go
+++ b/router/oauth2/authorization_endpoint.go
@@ -177,7 +177,9 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 		}
 		// ユーザーアカウント状態を確認
 		if !u.IsActive() {
-			return herror.Forbidden("this account is currently suspended")
+			q.Set("error", errAccessDenied)
+			redirectURI.RawQuery = q.Encode()
+			return c.Redirect(http.StatusFound, redirectURI.String())
 		}
 	}
 


### PR DESCRIPTION
1. 凍結時に有効なセッションを削除するように
    - なぜしてなかったんだ
2. OAuth2の/authorizeエンドポイントで、アカウントが有効かどうかのチェックが抜けていたので追加
    - 凍結後に何等かの理由（1.）により有効なセッションがある場合、/authorizeかつprompt=noneでチェックをすり抜けられていた
    - 定期的にココにアクセスすることで、GetSession()内のRenewSession()呼び出しにより、無限にセッションを伸ばすことが可能だった

なぜかまだアクセスできるサービスが残っていたことに個人的に気づいたのですが、これで本当におさらばです 👋 
セキュリティにはお気をつけて