### PR TITLE
デプロイ用Actionsをk8s用の適切なものに変更

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,15 +58,10 @@ jobs:
         with:
           image: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           annotations: true
-  deploy-staging:
-    name: Deploy staging
+  run-manifest-renovate:
+    name: Run Renovate on manifest
     runs-on: ubuntu-latest
-    needs: [image]
     steps:
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.STAGING_SSH_KEY }}
-          known_hosts: ${{ secrets.STAGING_KNOWN_HOSTS }}
-      - name: Deploy
-        run: ssh -o LogLevel=QUIET -t ${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }} "sudo sh /srv/traq/deploy.sh traq-backend"
+      - run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -61,6 +61,9 @@ jobs:
   run-manifest-renovate:
     name: Run Renovate on manifest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'
         env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -61,6 +61,7 @@ jobs:
   run-manifest-renovate:
     name: Run Renovate on manifest
     runs-on: ubuntu-latest
+    needs: [image]
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
   run-manifest-renovate:
     name: Run Renovate on manifest
     runs-on: ubuntu-latest
+    needs: [image]
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*.*.*
     branches-ignore:
-      - '**'
+      - "**"
 
 env:
   IMAGE_NAME: traq
@@ -56,3 +56,14 @@ jobs:
       - run: gh release create ${{ github.ref_name }} --generate-notes --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-manifest-renovate:
+    name: Run Renovate on manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/traPtitech/manifest/actions/workflows/renovate.yaml/dispatches -f "ref=main"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
traPtitech/manifestのRenovate用Actionsを呼び出すようにしました。`gh`コマンドは手元でテスト済みです。

Personal Access Tokenが必要で、とりあえず`swagger-change.yml`で参照していたものを書きましたが、もしこれが使えなかったら適切なPATをリポジトリに追加してsecretsの名前の変更をお願いします。🙏