### PR TITLE
OGP部分の検索

### DIFF
--- a/service/search/engine.go
+++ b/service/search/engine.go
@@ -35,6 +35,7 @@ type Query struct {
 	To             []uuid.UUID            `query:"to"`             // メンション先
 	From           []uuid.UUID            `query:"from"`           // 投稿者
 	Citation       optional.Of[uuid.UUID] `query:"citation"`       // 引用しているメッセージ
+	Ogp            optional.Of[bool]      `query:"ogp"`            // OGPコンテンツを含めるか
 	Bot            optional.Of[bool]      `query:"bot"`            // 投稿者がBotか
 	HasURL         optional.Of[bool]      `query:"hasURL"`         // URLの存在
 	HasAttachments optional.Of[bool]      `query:"hasAttachments"` // 添付ファイル

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -309,7 +309,6 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 	var musts []searchQuery
 
 	if q.Word.Valid && q.Ogp.Valid && q.Ogp.V {
-		// q.ogpを出力
 		wordBody := simpleQueryString{
 			Query:           q.Word.V,
 			Fields:          []string{"text"},
@@ -327,14 +326,12 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 		musts = append(musts, searchQuery{"bool": boolQuery{Should: orQueries}})
 
 	} else if q.Word.Valid {
-
 		body := simpleQueryString{
 			Query:           q.Word.V,
 			Fields:          []string{"text"},
 			DefaultOperator: "AND",
 		}
 		musts = append(musts, searchQuery{"simple_query_string": body})
-
 	}
 
 	switch {

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -279,6 +279,17 @@ func newSearchBody(andQueries []searchQuery) searchBody {
 	}
 }
 
+func newSearchBodyWithMustNot(andQueries []searchQuery, notQueries []searchQuery) searchBody {
+	return searchBody{
+		Query: searchQuery{
+			"bool": boolQuery{
+				Must:    andQueries,
+				Mustnot: notQueries,
+			},
+		},
+	}
+}
+
 type simpleQueryString struct {
 	Query           string   `json:"query"`
 	Fields          []string `json:"fields"`
@@ -288,6 +299,7 @@ type simpleQueryString struct {
 type boolQuery struct {
 	Must   []searchQuery `json:"must,omitempty"`
 	Should []searchQuery `json:"should,omitempty"`
+	Mustnot []searchQuery `json:"must_not,omitempty"`
 }
 
 type rangeQuery map[string]rangeParameters
@@ -308,7 +320,7 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 
 	var musts []searchQuery
 
-	if q.Word.Valid && q.Ogp.Valid && q.Ogp.V {
+	if q.Word.Valid  {
 		wordBody := simpleQueryString{
 			Query:           q.Word.V,
 			Fields:          []string{"text"},

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -320,7 +320,7 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 
 	var musts []searchQuery
 
-	if q.Word.Valid  {
+	if q.Word.Valid && q.Ogp.Valid && q.Ogp.V {
 		wordBody := simpleQueryString{
 			Query:           q.Word.V,
 			Fields:          []string{"text"},

--- a/service/search/es.go
+++ b/service/search/es.go
@@ -62,7 +62,7 @@ type esMessageDoc struct {
 	UpdatedAt      time.Time   `json:"updatedAt"`
 	To             []uuid.UUID `json:"to"`
 	Citation       []uuid.UUID `json:"citation"`
-	OgpContent	   []string    `json:"ogpContent"`
+	OgpContent     []string    `json:"ogpContent"`
 	HasURL         bool        `json:"hasURL"`
 	HasAttachments bool        `json:"hasAttachments"`
 	HasImage       bool        `json:"hasImage"`
@@ -75,7 +75,7 @@ type esMessageDocUpdate struct {
 	Text           string      `json:"text"`
 	UpdatedAt      time.Time   `json:"updatedAt"`
 	Citation       []uuid.UUID `json:"citation"`
-	OgpContent	   []string    `json:"ogpContent"`
+	OgpContent     []string    `json:"ogpContent"`
 	HasURL         bool        `json:"hasURL"`
 	HasAttachments bool        `json:"hasAttachments"`
 	HasImage       bool        `json:"hasImage"`
@@ -125,7 +125,7 @@ var esMapping = m{
 			"type": "keyword",
 		},
 		"ogpContent": m{
-			"type": "text",
+			"type":     "text",
 			"analyzer": "sudachi_analyzer",
 		},
 		"hasURL": m{
@@ -297,8 +297,8 @@ type simpleQueryString struct {
 }
 
 type boolQuery struct {
-	Must   []searchQuery `json:"must,omitempty"`
-	Should []searchQuery `json:"should,omitempty"`
+	Must    []searchQuery `json:"must,omitempty"`
+	Should  []searchQuery `json:"should,omitempty"`
 	Mustnot []searchQuery `json:"must_not,omitempty"`
 }
 
@@ -403,7 +403,7 @@ func (e *esEngine) Do(q *Query) (Result, error) {
 	if q.Citation.Valid {
 		musts = append(musts, searchQuery{"term": termQuery{"citation": termQueryParameter{Value: q.Citation}}})
 	}
-	
+
 	if q.Bot.Valid {
 		musts = append(musts, searchQuery{"term": termQuery{"bot": termQueryParameter{Value: q.Bot}}})
 	}

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -29,7 +29,7 @@ const (
 type attributes struct {
 	To             []uuid.UUID
 	Citation       []uuid.UUID
-	OgpContent	   []string
+	OgpContent     []string
 	HasURL         bool
 	HasAttachments bool
 	HasImage       bool
@@ -119,9 +119,8 @@ func (e *esEngine) getAttributes(messageText string, parseResult *message.ParseR
 	urls := lo.Map(urlRegex.FindAllString(messageText, -1), func(url string, _ int) string {
 		if url[0] != 'h' {
 			return url[1:]
-		} else {
-			return url
 		}
+		return url
 	})
 
 	filteredUrls := lo.Filter(urls, func(url string, _ int) bool {
@@ -136,7 +135,7 @@ func (e *esEngine) getAttributes(messageText string, parseResult *message.ParseR
 			continue
 		}
 		if urlCache.Valid {
-			ogpCache = append(ogpCache, urlCache.Content.Title + "\n" + urlCache.Content.Description)
+			ogpCache = append(ogpCache, urlCache.Content.Title+"\n"+urlCache.Content.Description)
 		}
 	}
 	if len(ogpCache) == 0 {
@@ -292,7 +291,7 @@ func syncNewMessages(e *esEngine, messages []*model.Message, noOgpMessage []resM
 		}
 
 		e.l.Info(fmt.Sprintf("indexed %v message(s) to index, updated %v message(s) on index, added ogp field %v message(s), last insert %v",
-			bulkIndexer.Stats().NumIndexed, bulkIndexer.Stats().NumUpdated - uint64(ogpContentUpdateCount), ogpContentUpdateCount, lastInsert))
+			bulkIndexer.Stats().NumIndexed, bulkIndexer.Stats().NumUpdated-uint64(ogpContentUpdateCount), ogpContentUpdateCount, lastInsert))
 	}()
 
 	for _, v := range messages {
@@ -427,14 +426,14 @@ func (e *esEngine) getNoOgpfieldMessage(limit int) (Result, error) {
 	type fieldQuery struct {
 		Field string `json:"field"`
 	}
-	
+
 	var mustNots = []searchQuery{
-		searchQuery{"exists": fieldQuery{Field: "ogpContent"}},
+		{"exists": fieldQuery{Field: "ogpContent"}},
 	}
 	var musts = []searchQuery{
-		searchQuery{"term": termQuery{"hasURL": termQueryParameter{Value: true}}},
+		{"term": termQuery{"hasURL": termQueryParameter{Value: true}}},
 	}
-	
+
 	body := newSearchBodyWithMustNot(musts, mustNots)
 
 	b, err := json.Marshal(body)


### PR DESCRIPTION
elastic searchに`ogpContent`のフィールドを追加してtitleとdescriptionを保存することで、検索時に`ogp=true`のクエリをつけてogp部分を含めたキーワード検索ができるようにしました

elastic searchのindexに`ogpContent`のフィールドを持たない過去のメッセージは`es_sync.go`の`sync()`で順次更新しています
`:https://~~`などの無効な形式のurlや、file送信やメッセージの引用に利用される`https://q.trap.jp`のリンクの場合は`""`を`ogpContent`フィールドに保存しています

フロントのUIからの検索は対応してません