### PR TITLE
GET /channels/:channelID/pinsにETagを付ける

### DIFF
--- a/repository/gorm/pin.go
+++ b/repository/gorm/pin.go
@@ -79,15 +79,16 @@ func (repo *Repository) GetPinnedMessageByChannelID(channelID uuid.UUID) (pins [
 	if channelID == uuid.Nil {
 		return pins, nil
 	}
-
 	err = repo.db.
-		Preload("Message", &model.Message{ChannelID: channelID}).
-		Preload("Message.Stamps").
+		Scopes(pinPreloads).
+		Joins("INNER JOIN messages ON messages.id = pins.message_id AND messages.channel_id = ?", channelID).
 		Find(&pins).
 		Error
-	if err != nil {
-		return nil, err
-	}
+	return
+}
 
-	return pins, nil
+func pinPreloads(db *gorm.DB) *gorm.DB {
+	return db.
+		Preload("Message").
+		Preload("Message.Stamps")
 }

--- a/repository/gorm/pin.go
+++ b/repository/gorm/pin.go
@@ -79,16 +79,15 @@ func (repo *Repository) GetPinnedMessageByChannelID(channelID uuid.UUID) (pins [
 	if channelID == uuid.Nil {
 		return pins, nil
 	}
+
 	err = repo.db.
-		Scopes(pinPreloads).
-		Joins("INNER JOIN messages ON messages.id = pins.message_id AND messages.channel_id = ?", channelID).
+		Preload("Message", &model.Message{ChannelID: channelID}).
+		Preload("Message.Stamps").
 		Find(&pins).
 		Error
-	return
-}
+	if err != nil {
+		return nil, err
+	}
 
-func pinPreloads(db *gorm.DB) *gorm.DB {
-	return db.
-		Preload("Message").
-		Preload("Message.Stamps")
+	return pins, nil
 }

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -243,7 +243,7 @@ func (h *Handlers) GetChannelPins(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	return c.JSON(http.StatusOK, formatPins(pins))
+	return extension.ServeJSONWithETag(c, formatPins(pins))
 }
 
 type channelEventsQuery struct {


### PR DESCRIPTION
ref https://github.com/traPtitech/traQ/issues/2702

ピンは頻繁に変更されないためEtagを付与する
ピンが100個(チャンネルに追加できる最大)あるとレスポンスが70KB程度になるので効果はあるはず

~~ついでにGORMの`Joins("INNER JOIN ...")`が想定通りに動いていなかったので修正した~~
~~元々JOINを使わずにPreloadだけで動いていたが、それが分かるようなコードに修正~~
