### PR TITLE
refactor: メッセージのアクセス権限チェックを service 層に移行

### DIFF
--- a/router/middlewares/access_control.go
+++ b/router/middlewares/access_control.go
@@ -11,7 +11,6 @@ import (
 	"github.com/traPtitech/traQ/router/extension/herror"
 	"github.com/traPtitech/traQ/service/channel"
 	"github.com/traPtitech/traQ/service/file"
-	"github.com/traPtitech/traQ/service/message"
 	"github.com/traPtitech/traQ/service/rbac"
 	"github.com/traPtitech/traQ/service/rbac/permission"
 	"github.com/traPtitech/traQ/service/rbac/role"
@@ -157,25 +156,6 @@ func CheckClientAccessPerm(rbac rbac.RBAC) echo.MiddlewareFunc {
 			// アクセス権確認
 			if !rbac.IsGranted(user.GetRole(), permission.ManageOthersClient) && oc.CreatorID != user.GetID() {
 				return herror.Forbidden()
-			}
-
-			return next(c)
-		}
-	}
-}
-
-// CheckMessageAccessPerm Messageアクセス権限を確認するミドルウェア
-func CheckMessageAccessPerm(cm channel.Manager) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			userID := c.Get(consts.KeyUser).(model.UserInfo).GetID()
-			channelID := c.Get(consts.KeyParamMessage).(message.Message).GetChannelID()
-
-			// アクセス権確認
-			if ok, err := cm.IsChannelAccessibleToUser(userID, channelID); err != nil {
-				return herror.InternalServerError(err)
-			} else if !ok {
-				return herror.NotFound()
 			}
 
 			return next(c)

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -19,7 +19,7 @@ import (
 // checkMessageAccess メッセージアクセス権限を確認するヘルパー関数
 func (h *Handlers) checkMessageAccess(m message.Message, userID uuid.UUID) error {
 	if ok, err := h.MessageManager.IsAccessible(m, userID); err != nil {
-		if err == message.ErrNotFound {
+		if errors.Is(err, message.ErrNotFound) {
 			return herror.NotFound()
 		}
 		return herror.InternalServerError(err)

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -88,7 +88,6 @@ func (h *Handlers) Setup(e *echo.Group) {
 	requiresWebhookAccessPerm := middlewares.CheckWebhookAccessPerm(h.RBAC)
 	requiresFileAccessPerm := middlewares.CheckFileAccessPerm(h.FileManager)
 	requiresClientAccessPerm := middlewares.CheckClientAccessPerm(h.RBAC)
-	requiresMessageAccessPerm := middlewares.CheckMessageAccessPerm(h.ChannelManager)
 	requiresChannelAccessPerm := middlewares.CheckChannelAccessPerm(h.ChannelManager)
 	requiresGroupAdminPerm := middlewares.CheckUserGroupAdminPerm(h.RBAC)
 	requiresClipFolderAccessPerm := middlewares.CheckClipFolderAccessPerm()
@@ -212,7 +211,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 		apiMessages := api.Group("/messages")
 		{
 			apiMessages.GET("", h.SearchMessages, requires(permission.GetMessage))
-			apiMessagesMID := apiMessages.Group("/:messageID", retrieve.MessageID(), requiresMessageAccessPerm)
+			apiMessagesMID := apiMessages.Group("/:messageID", retrieve.MessageID())
 			{
 				apiMessagesMID.GET("", h.GetMessage, requires(permission.GetMessage))
 				apiMessagesMID.PUT("", h.EditMessage, bodyLimit(100), requires(permission.EditMessage))

--- a/service/message/manager.go
+++ b/service/message/manager.go
@@ -108,6 +108,12 @@ type Manager interface {
 	// 存在しないメッセージを指定した場合は、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
 	RemoveStamps(id, stampID, userID uuid.UUID) error
+	// IsAccessible 指定したユーザーが指定したメッセージにアクセス可能かどうかを確認します
+	//
+	// 成功した場合、アクセス可能かどうかとnilを返します。
+	// 存在しないメッセージを指定した場合、falseとErrNotFoundを返します。
+	// DBによるエラーを返すことがあります。
+	IsAccessible(message Message, userID uuid.UUID) (bool, error)
 
 	Wait(ctx context.Context) error
 }

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -316,6 +316,16 @@ func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
 	return nil
 }
 
+func (m *manager) IsAccessible(msg Message, userID uuid.UUID) (bool, error) {
+	// チャンネルアクセス権を確認
+	accessible, err := m.CM.IsChannelAccessibleToUser(userID, msg.GetChannelID())
+	if err != nil {
+		return false, fmt.Errorf("failed to check channel access: %w", err)
+	}
+
+	return accessible, nil
+}
+
 func (m *manager) Wait(_ context.Context) error {
 	m.P.Wait()
 	return nil


### PR DESCRIPTION
## 概要

タイトルの通り
責務の分離を進めた


## なぜこの PR を入れたいのか

traQ の middleware では多数の処理が行われている
`/router/middlewares/param_retriever.go` のように、単に params から構造体を取り出すだけであれば問題がない

しかし、アクセス権限の確認などは domain / service に関わる内容であり、これは router 層に置くべきではないと考えた
特に、現状の設計は ConnectRPC での api handler 実装を行う際にも障壁となりうるものであると考えている
最終的には `/router/middlewares/access_control.go` をファイルごと削除したい


## 動作確認の手順

テストが通ってるので大丈夫だと思います


## PR を出す前の確認事項

- [ ] (機能の追加なら) 追加することの合意がチームで取れている
    - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

この方針で refactor を進めても大丈夫かをご確認したいです