### PR TITLE
fix: PUT users/me/iconにピクセル制限の説明を追加しました

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5914,7 +5914,7 @@ components:
         file:
           type: string
           format: binary
-          description: 'アイコン画像(2MB,`Config.MaxPixels`(default: 2560*1600)までのpng, jpeg, gif)'
+          description: 'アイコン画像(2MB,`Config.Imaging.MaxPixels`(default: 2560*1600)までのpng, jpeg, gif)'
       required:
         - file
     PutMyPasswordRequest:

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5892,7 +5892,7 @@ components:
         file:
           type: string
           format: binary
-          description: 'アイコン画像(2MBまでのpng, jpeg, gif)'
+          description: 'アイコン画像(2MB,2560*1600までのpng, jpeg, gif)'
       required:
         - file
     PutMyPasswordRequest:

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -5914,7 +5914,7 @@ components:
         file:
           type: string
           format: binary
-          description: 'アイコン画像(2MB,2560*1600までのpng, jpeg, gif)'
+          description: 'アイコン画像(2MB,`Config.MaxPixels`(default: 2560*1600)までのpng, jpeg, gif)'
       required:
         - file
     PutMyPasswordRequest:


### PR DESCRIPTION
close #2685 

以下を参考にしました。
https://github.com/traPtitech/traQ/blob/104c8aa765e92e312ae2332ab609c79057d81bc3/cmd/config.go#L59-L65