### PR TITLE
fix: スタンプのUUID配列にユニークアイテム制約と最大アイテム数を追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -7084,6 +7084,8 @@ components:
         stamps:
           type: array
           description: パレット内のスタンプのUUID配列
+          uniqueItems: true
+          maxItems: 200
           items:
             type: string
             format: uuid


### PR DESCRIPTION
フロントの自動生成のために`StampPallette`の記述を変更しました．
close #2660