### PR TITLE
fix(gorm): SQLクエリのリテラルをパラメタ化する

### DIFF
--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -82,6 +82,7 @@ func TestMain(m *testing.M) {
 		engine.Logger = logger.New(log.New(os.Stdout, "\r\n", log.LstdFlags), logger.Config{
 			SlowThreshold:             200 * time.Millisecond,
 			LogLevel:                  logger.Warn,
+			ParameterizedQueries:      true,
 			Colorful:                  true,
 			IgnoreRecordNotFoundError: true,
 		})


### PR DESCRIPTION
access_tokenなどを平文で保存している(するな)影響で、エラーログにそのままトークンが流れているのを防ぐ暫定対処です。

https://gorm.io/ja_JP/docs/logger.html
