### PR TITLE
fix(gormzap): Add option to prevent SQL query literals from being logged

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -15,7 +15,6 @@ import (
 	"github.com/traPtitech/traQ/repository/gorm"
 	"github.com/traPtitech/traQ/service/file"
 	"github.com/traPtitech/traQ/service/imaging"
-	"github.com/traPtitech/traQ/utils/gormzap"
 	"github.com/traPtitech/traQ/utils/optional"
 )
 
@@ -47,7 +46,7 @@ func filePruneCommand() *cobra.Command {
 		Short: "delete files which are not used or linked to anywhere",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getCLILogger()
+			logger, gormLogger := getCLILoggers()
 			defer logger.Sync()
 
 			// Database
@@ -55,7 +54,7 @@ func filePruneCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			db.Logger = gormzap.New(logger.Named("gorm"))
+			db.Logger = gormLogger
 			sqlDB, err := db.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))
@@ -154,7 +153,7 @@ func genMissingThumbnails() *cobra.Command {
 		Short: "Generate missing thumbnails",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getCLILogger()
+			logger, gormLogger := getCLILoggers()
 			defer logger.Sync()
 
 			// Database
@@ -162,7 +161,7 @@ func genMissingThumbnails() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			db.Logger = gormzap.New(logger.Named("gorm"))
+			db.Logger = gormLogger
 			sqlDB, err := db.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))
@@ -346,7 +345,7 @@ func genGroupImages() *cobra.Command {
 		Short: "Generate missing icons for user groups",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getCLILogger()
+			logger, gormLogger := getCLILoggers()
 			defer logger.Sync()
 
 			// Database
@@ -354,7 +353,7 @@ func genGroupImages() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			db.Logger = gormzap.New(logger.Named("gorm"))
+			db.Logger = gormLogger
 			sqlDB, err := db.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -14,7 +14,7 @@ func healthcheckCommand() *cobra.Command {
 		Use:   "healthcheck",
 		Short: "Run healthcheck",
 		Run: func(_ *cobra.Command, _ []string) {
-			logger := getCLILogger()
+			logger, _ := getCLILoggers()
 			defer logger.Sync()
 
 			resp, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:%d/api/ping", c.Port))

--- a/cmd/migrate_v2_to_v3.go
+++ b/cmd/migrate_v2_to_v3.go
@@ -5,7 +5,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/traPtitech/traQ/migration/v2tov3"
-	"github.com/traPtitech/traQ/utils/gormzap"
 )
 
 // migrateV2ToV3Command traQv2データをv3データに変換するコマンド
@@ -23,7 +22,7 @@ func migrateV2ToV3Command() *cobra.Command {
 		Short: "migrate from v2 to v3 (messages, files)",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getCLILogger()
+			logger, gormLogger := getCLILoggers()
 			defer logger.Sync()
 
 			// Database
@@ -31,7 +30,7 @@ func migrateV2ToV3Command() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			db.Logger = gormzap.New(logger.Named("gorm"))
+			db.Logger = gormLogger
 			sqlDB, err := db.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,8 +103,7 @@ func getLogger() (*zap.Logger, *gormzap.L) {
 	}
 	zapLogger, _ := cfg.Build(zapdriver.WrapCore(zapdriver.ServiceName("traq", fmt.Sprintf("%s.%s", Version, Revision))))
 
-	gormLogger := gormzap.New(zapLogger.Named("gorm"))
-	gormLogger.ParameterizedQueries = true
+	gormLogger := gormzap.New(zapLogger.Named("gorm"), gormzap.WithParameterizedQueries(true))
 
 	return zapLogger, gormLogger
 }
@@ -136,8 +135,7 @@ func getCLILoggers() (*zap.Logger, *gormzap.L) {
 	}
 	zapLogger, _ := cfg.Build()
 
-	gormLogger := gormzap.New(zapLogger.Named("gorm"))
-	gormLogger.ParameterizedQueries = true
+	gormLogger := gormzap.New(zapLogger.Named("gorm"), gormzap.WithParameterizedQueries(true))
 
 	return zapLogger, gormLogger
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,10 +14,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/traPtitech/traQ/utils/gormzap"
+	"github.com/traPtitech/traQ/utils/message"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/traPtitech/traQ/utils/message"
 )
 
 var (
@@ -90,9 +90,9 @@ func Execute() error {
 	return rootCommand.Execute()
 }
 
-func getLogger() (logger *zap.Logger) {
+func getLogger() (*zap.Logger, *gormzap.L) {
 	if c.DevMode {
-		return getCLILogger()
+		return getCLILoggers()
 	}
 	cfg := zap.Config{
 		Level:            zap.NewAtomicLevelAt(zapcore.InfoLevel),
@@ -101,11 +101,15 @@ func getLogger() (logger *zap.Logger) {
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
-	logger, _ = cfg.Build(zapdriver.WrapCore(zapdriver.ServiceName("traq", fmt.Sprintf("%s.%s", Version, Revision))))
-	return
+	zapLogger, _ := cfg.Build(zapdriver.WrapCore(zapdriver.ServiceName("traq", fmt.Sprintf("%s.%s", Version, Revision))))
+
+	gormLogger := gormzap.New(zapLogger.Named("gorm"))
+	gormLogger.ParameterizedQueries = true
+
+	return zapLogger, gormLogger
 }
 
-func getCLILogger() (logger *zap.Logger) {
+func getCLILoggers() (*zap.Logger, *gormzap.L) {
 	level := zap.NewAtomicLevel()
 	if c.DevMode {
 		level = zap.NewAtomicLevelAt(zap.DebugLevel)
@@ -130,8 +134,12 @@ func getCLILogger() (logger *zap.Logger) {
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
-	logger, _ = cfg.Build()
-	return
+	zapLogger, _ := cfg.Build()
+
+	gormLogger := gormzap.New(zapLogger.Named("gorm"))
+	gormLogger.ParameterizedQueries = true
+
+	return zapLogger, gormLogger
 }
 
 func bindPFlag(flags *pflag.FlagSet, key string, flag ...string) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/traPtitech/traQ/event"
 	"github.com/traPtitech/traQ/repository"
@@ -57,7 +56,7 @@ func serveCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			engine.Logger = gormLogger.LogMode(gormlogger.Silent)
+			engine.Logger = gormLogger
 			db, err := engine.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -20,7 +20,6 @@ import (
 	"github.com/traPtitech/traQ/service"
 	"github.com/traPtitech/traQ/service/file"
 	"github.com/traPtitech/traQ/service/rbac/role"
-	"github.com/traPtitech/traQ/utils/gormzap"
 	"github.com/traPtitech/traQ/utils/jwt"
 	"github.com/traPtitech/traQ/utils/optional"
 	"github.com/traPtitech/traQ/utils/random"
@@ -36,7 +35,7 @@ func serveCommand() *cobra.Command {
 		Short: "Serve traQ API",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getLogger()
+			logger, gormLogger := getLogger()
 			defer logger.Sync()
 
 			logger.Info(fmt.Sprintf("traQ %s (revision %s)", Version, Revision))
@@ -58,7 +57,7 @@ func serveCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			engine.Logger = gormzap.New(logger.Named("gorm")).LogMode(gormlogger.Silent)
+			engine.Logger = gormLogger.LogMode(gormlogger.Silent)
 			db, err := engine.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))

--- a/cmd/stamp.go
+++ b/cmd/stamp.go
@@ -8,7 +8,6 @@ import (
 	"github.com/traPtitech/traQ/repository/gorm"
 	"github.com/traPtitech/traQ/service/file"
 	"github.com/traPtitech/traQ/service/imaging"
-	"github.com/traPtitech/traQ/utils/gormzap"
 	"github.com/traPtitech/traQ/utils/twemoji"
 )
 
@@ -35,7 +34,7 @@ func stampInstallEmojisCommand() *cobra.Command {
 		Short: "download and install Unicode emojiMeta stamps",
 		Run: func(_ *cobra.Command, _ []string) {
 			// Logger
-			logger := getCLILogger()
+			logger, gormLogger := getCLILoggers()
 			defer logger.Sync()
 
 			// Database
@@ -44,7 +43,7 @@ func stampInstallEmojisCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatal("failed to connect database", zap.Error(err))
 			}
-			db.Logger = gormzap.New(logger.Named("gorm"))
+			db.Logger = gormLogger
 			sqlDB, err := db.DB()
 			if err != nil {
 				logger.Fatal("failed to get *sql.DB", zap.Error(err))

--- a/utils/gormzap/logger.go
+++ b/utils/gormzap/logger.go
@@ -93,6 +93,7 @@ func (gl *L) Trace(_ context.Context, begin time.Time, fc func() (string, int64)
 
 // ParamsFilter implements [(gorm.io/gorm).ParamsFilter]
 // https://github.com/go-gorm/gorm/blob/4e34a6d21b63e9a9b701a70be9759e5539bf26e9/logger/logger.go#L192-L198
+// TODO: this filter does not applys to (*gorm.DB).Raw(). We need to read the GORM source code for this method and deal with it.
 func (gl *L) ParamsFilter(_ context.Context, sql string, params ...any) (string, []any) {
 	if gl.parameterizedQueries {
 		return sql, nil


### PR DESCRIPTION
- **fix(gormzap): SQLクエリのリテラルをログに出さないオプションを追加**
- **chore(gormzap): serve cmdのGORMログを再び有効化**

GORMのロガーにParamsFilterを実装するとログに出すクエリをカスタムできる機能があったのでそれを使っています
https://github.com/go-gorm/gorm/blob/4e34a6d21b63e9a9b701a70be9759e5539bf26e9/callbacks.go#L136