### PR TITLE
chore: `PostMessageRequest` の定義に nonce を追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4707,7 +4707,7 @@ components:
           nullable: true
         nonce:
           type: string
-          description: メッセージ送信の確認に使うことができる任意の識別子
+          description: メッセージ送信の確認に使うことができる任意の識別子(投稿でのみ使用可)
       required:
         - id
         - userId

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -262,7 +262,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PostMessageRequest"
+              $ref: "#/components/schemas/PutMessageRequest"
       tags:
         - message
       operationId: editMessage
@@ -4705,6 +4705,9 @@ components:
           format: uuid
           description: スレッドUUID
           nullable: true
+        nonce:
+          type: string
+          description: メッセージ送信の確認に使うことができる任意の識別子
       required:
         - id
         - userId
@@ -4826,6 +4829,25 @@ components:
       title: PostMessageRequest
       type: object
       description: メッセージ投稿リクエスト
+      properties:
+        content:
+          type: string
+          description: メッセージ本文
+          minLength: 1
+          maxLength: 10000
+        embed:
+          type: boolean
+          default: false
+          description: メンション・チャンネルリンクを自動埋め込みするか
+        nonce:
+          type: string
+          description: メッセージ送信の確認に使うことができる任意の識別子
+      required:
+        - content
+    PutMessageRequest:
+      title: PutMessageRequest
+      type: object
+      description: メッセージ編集リクエスト
       properties:
         content:
           type: string

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -4707,6 +4707,7 @@ components:
           nullable: true
         nonce:
           type: string
+          pattern: "^[a-zA-Z0-9_-]{1,32}$"
           description: メッセージ送信の確認に使うことができる任意の識別子(投稿でのみ使用可)
       required:
         - id
@@ -4841,6 +4842,7 @@ components:
           description: メンション・チャンネルリンクを自動埋め込みするか
         nonce:
           type: string
+          pattern: "^[a-zA-Z0-9_-]{1,32}$"
           description: メッセージ送信の確認に使うことができる任意の識別子(投稿でのみ使用可)
       required:
         - content

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -262,7 +262,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PutMessageRequest"
+              $ref: "#/components/schemas/PostMessageRequest"
       tags:
         - message
       operationId: editMessage
@@ -4841,23 +4841,7 @@ components:
           description: メンション・チャンネルリンクを自動埋め込みするか
         nonce:
           type: string
-          description: メッセージ送信の確認に使うことができる任意の識別子
-      required:
-        - content
-    PutMessageRequest:
-      title: PutMessageRequest
-      type: object
-      description: メッセージ編集リクエスト
-      properties:
-        content:
-          type: string
-          description: メッセージ本文
-          minLength: 1
-          maxLength: 10000
-        embed:
-          type: boolean
-          default: false
-          description: メンション・チャンネルリンクを自動埋め込みするか
+          description: メッセージ送信の確認に使うことができる任意の識別子(投稿でのみ使用可)
       required:
         - content
     ChannelStats:


### PR DESCRIPTION
close #2798 

- `PostMessageRequest` と `Message` に nonce の定義を追加しました。
- メッセージの編集でも `PostMessageRequest` スキーマを流用していたため、 `PutMessageRequest` に分離しました。 