### PR TITLE
chore(gogen): fix build tag `// +build` -> `//go:build`

### DIFF
--- a/cmd/serve_wire.go
+++ b/cmd/serve_wire.go
@@ -1,5 +1,4 @@
 //go:build wireinject
-// +build wireinject
 
 package cmd
 

--- a/router/router_wire.go
+++ b/router/router_wire.go
@@ -1,5 +1,4 @@
 //go:build wireinject
-// +build wireinject
 
 package router
 

--- a/service/services_wire.go
+++ b/service/services_wire.go
@@ -1,5 +1,4 @@
 //go:build wireinject
-// +build wireinject
 
 package service
 

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 


### PR DESCRIPTION
https://github.com/traPtitech/traQ/actions/runs/18984802701/job/54225890639?pr=2847#step:4:28 で CI が落ちていたので、それに対応

ref: https://zenn.dev/team_soda/articles/golang-build-tags-history