### PR TITLE
fix: allow webhook usernames

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -2863,7 +2863,7 @@ paths:
         description: ユーザー名
         schema:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
     get:
       summary: ユーザーのアイコン画像を取得
       tags:
@@ -5256,7 +5256,7 @@ components:
           format: uuid
         name:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
           description: ユーザー名
         displayName:
           type: string
@@ -5309,7 +5309,7 @@ components:
           maxLength: 32
         name:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
           description: ユーザー名
         twitterId:
           type: string
@@ -5608,7 +5608,7 @@ components:
           pattern: "^[a-zA-Z0-9_]{1,15}$"
         name:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
           description: ユーザー名
         displayName:
           type: string
@@ -5660,11 +5660,11 @@ components:
           format: uuid
         name:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
           description: ユーザー名
         preferred_username:
           type: string
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
           description: ユーザー名
         picture:
           type: string
@@ -6148,7 +6148,7 @@ components:
         name:
           type: string
           description: ユーザー名
-          pattern: "^[a-zA-Z0-9_-]{1,32}$"
+          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
         password:
           type: string
           description: パスワード

--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -2863,7 +2863,7 @@ paths:
         description: ユーザー名
         schema:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
     get:
       summary: ユーザーのアイコン画像を取得
       tags:
@@ -5256,7 +5256,7 @@ components:
           format: uuid
         name:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
           description: ユーザー名
         displayName:
           type: string
@@ -5309,7 +5309,7 @@ components:
           maxLength: 32
         name:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
           description: ユーザー名
         twitterId:
           type: string
@@ -5608,7 +5608,7 @@ components:
           pattern: "^[a-zA-Z0-9_]{1,15}$"
         name:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
           description: ユーザー名
         displayName:
           type: string
@@ -5660,11 +5660,11 @@ components:
           format: uuid
         name:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
           description: ユーザー名
         preferred_username:
           type: string
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
           description: ユーザー名
         picture:
           type: string
@@ -5930,7 +5930,7 @@ components:
         file:
           type: string
           format: binary
-          description: 'アイコン画像(2MB,`Config.Imaging.MaxPixels`(default: 2560*1600)までのpng, jpeg, gif)'
+          description: "アイコン画像(2MB,`Config.Imaging.MaxPixels`(default: 2560*1600)までのpng, jpeg, gif)"
       required:
         - file
     PutMyPasswordRequest:
@@ -6148,7 +6148,7 @@ components:
         name:
           type: string
           description: ユーザー名
-          pattern: "^[#a-zA-Z0-9_-]{1,32}$"
+          pattern: "^([a-zA-Z0-9_-]{1,32}|Webhook#[a-zA-Z0-9_-]{22})$"
         password:
           type: string
           description: パスワード


### PR DESCRIPTION
Webhookのusernameには`#`が入るが、OpenAPIでは許容されていなかったのでユーザー名っぽい正規表現に`#`を追加
ユーザーとBOTの新規追加の正規表現はそのままにしてあります

https://github.com/traPtitech/traQ/blob/69fd946d89fdcea090f3f75dab805917bf3fc885/docs/v3-api.yaml#L6010-L6024

https://github.com/traPtitech/traQ/blob/69fd946d89fdcea090f3f75dab805917bf3fc885/docs/v3-api.yaml#L6588-L6620