### PR TITLE
feat(api)!: include score in stamp recommendations response

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -872,9 +872,19 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
-                  format: uuid
-                  description: スタンプUUID
+                  type: object
+                  properties:
+                    stampId:
+                      type: string
+                      format: uuid
+                      description: スタンプUUID
+                    score:
+                      type: number
+                      format: double
+                      description: レコメンドスコア
+                  required:
+                    - stampId
+                    - score
       operationId: getMyStampRecommendations
       parameters:
         - schema:

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -436,9 +436,9 @@ func TestRepositoryImpl_GetUserStampRecommendations(t *testing.T) {
 		t.Parallel()
 		ms, err := repo.GetUserStampRecommendations(user.GetID(), -1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 3) {
-			assert.Equal(t, ms[0], stamp1.ID)
-			assert.Equal(t, ms[1], stamp2.ID)
-			assert.Equal(t, ms[2], stamp3.ID)
+			assert.Equal(t, stamp1.ID, ms[0].StampID)
+			assert.Equal(t, stamp2.ID, ms[1].StampID)
+			assert.Equal(t, stamp3.ID, ms[2].StampID)
 		}
 	})
 
@@ -446,7 +446,7 @@ func TestRepositoryImpl_GetUserStampRecommendations(t *testing.T) {
 		t.Parallel()
 		ms, err := repo.GetUserStampRecommendations(user.GetID(), 1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 1) {
-			assert.Equal(t, ms[0], stamp1.ID)
+			assert.Equal(t, stamp1.ID, ms[0].StampID)
 		}
 	})
 }

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -30,6 +30,12 @@ type UserStampHistory struct {
 	Datetime time.Time `json:"datetime"`
 }
 
+// UserStampRecommendation スタンプレコメンデーション構造体
+type UserStampRecommendation struct {
+	StampID uuid.UUID `json:"stampId"`
+	Score   float64   `json:"score"`
+}
+
 // StampStats スタンプ統計情報
 type StampStats struct {
 	Count      int64 `json:"count"`
@@ -108,7 +114,7 @@ type StampRepository interface {
 	// 成功した場合、レコメンドスコアの高い順で並んだスタンプIDの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserStampRecommendations(userID uuid.UUID, limit int) (h []uuid.UUID, err error)
+	GetUserStampRecommendations(userID uuid.UUID, limit int) (h []*UserStampRecommendation, err error)
 	// ExistStamps stampIDの配列から指定したスタンプが全て存在するか判定します
 	//
 	// 成功した場合、nilを返します。

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -653,7 +653,8 @@ func TestHandlers_GetMyStampRecommendations(t *testing.T) {
 
 		obj.Length().IsEqual(1)
 
-		obj.Value(0).String().IsEqual(stamp.ID.String())
+		obj.Value(0).Object().Value("stampId").String().IsEqual(stamp.ID.String())
+		obj.Value(0).Object().Value("score").Number()
 	})
 }
 


### PR DESCRIPTION
## 変更内容
* `/users/me/stamp-recommendations` のレスポンス形式を変更しました。
  * 変更前: `[UUID, UUID, ...]`
  * 変更後: `[{ stampId: UUID, score: float }, ...]`
* フロントエンドでの楽観的更新などを容易にするため、レコメンドのスコアを含めるようにしました。

## 破壊的変更
* APIのレスポンス型が変更されています。