### PR TITLE
perf(stamp): optimize messages_stamps index and query to avoid filesort

### DIFF
--- a/docs/dbSchema/messages_stamps.md
+++ b/docs/dbSchema/messages_stamps.md
@@ -18,7 +18,7 @@ CREATE TABLE `messages_stamps` (
   PRIMARY KEY (`message_id`,`stamp_id`,`user_id`),
   KEY `idx_messages_stamps_message_id` (`message_id`),
   KEY `idx_messages_stamps_user_id_stamp_id_updated_at` (`user_id`,`stamp_id`,`updated_at`),
-  KEY `idx_messages_stamps_user_id_updated_at` (`user_id`,`updated_at`),
+  KEY `idx_messages_stamps_user_id_updated_at_stamp_id` (`user_id`,`updated_at`,`stamp_id`),
   KEY `idx_messages_stamps_updated_at` (`updated_at`),
   KEY `messages_stamps_stamp_id_stamps_id_foreign` (`stamp_id`),
   CONSTRAINT `messages_stamps_message_id_messages_id_foreign` FOREIGN KEY (`message_id`) REFERENCES `messages` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -56,7 +56,7 @@ CREATE TABLE `messages_stamps` (
 | idx_messages_stamps_message_id | KEY idx_messages_stamps_message_id (message_id) USING BTREE |
 | idx_messages_stamps_updated_at | KEY idx_messages_stamps_updated_at (updated_at) USING BTREE |
 | idx_messages_stamps_user_id_stamp_id_updated_at | KEY idx_messages_stamps_user_id_stamp_id_updated_at (user_id, stamp_id, updated_at) USING BTREE |
-| idx_messages_stamps_user_id_updated_at | KEY idx_messages_stamps_user_id_updated_at (user_id, updated_at) USING BTREE |
+| idx_messages_stamps_user_id_updated_at_stamp_id | KEY idx_messages_stamps_user_id_updated_at_stamp_id (user_id, updated_at, stamp_id) USING BTREE |
 | messages_stamps_stamp_id_stamps_id_foreign | KEY messages_stamps_stamp_id_stamps_id_foreign (stamp_id) USING BTREE |
 | PRIMARY | PRIMARY KEY (message_id, stamp_id, user_id) USING BTREE |
 

--- a/docs/dbSchema/unreads.md
+++ b/docs/dbSchema/unreads.md
@@ -15,8 +15,8 @@ CREATE TABLE `unreads` (
   `noticeable` tinyint(1) NOT NULL DEFAULT 0,
   `message_created_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`user_id`,`channel_id`,`message_id`),
-  KEY `unreads_channel_id_channels_id_foreign` (`channel_id`),
   KEY `unreads_message_id_messages_id_foreign` (`message_id`),
+  KEY `unreads_channel_id_channels_id_foreign` (`channel_id`),
   CONSTRAINT `unreads_channel_id_channels_id_foreign` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `unreads_message_id_messages_id_foreign` FOREIGN KEY (`message_id`) REFERENCES `messages` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `unreads_user_id_users_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE

--- a/migration/current.go
+++ b/migration/current.go
@@ -53,6 +53,7 @@ func Migrations() []*gormigrate.Migration {
 		v40(), // delete_my_stampパーミッションを削除
 		v41(), // ユーザーグループ名受付規則変更に伴う既存ユーザーグループ名の更新
 		v42(), // get_my_stamp_recommendationsパーミッションの追加とmessages_stampsテーブルへの (user_id, updated_at) の複合インデックスの追加
+		v43(), // messages_stampsテーブルのインデックス (user_id, updated_at) を (user_id, updated_at, stamp_id) に変更
 	}
 }
 

--- a/migration/v43.go
+++ b/migration/v43.go
@@ -1,0 +1,32 @@
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// v43 Fix user stamp history index
+// Avoids filesort in GetUserStampRecommendations by covering (user_id, updated_at, stamp_id)
+func v43() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "43",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Exec("DROP INDEX idx_messages_stamps_user_id_updated_at ON messages_stamps").Error; err != nil {
+				return err
+			}
+			if err := db.Exec("CREATE INDEX idx_messages_stamps_user_id_updated_at_stamp_id ON messages_stamps (user_id, updated_at, stamp_id)").Error; err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(db *gorm.DB) error {
+			if err := db.Exec("DROP INDEX idx_messages_stamps_user_id_updated_at_stamp_id ON messages_stamps").Error; err != nil {
+				return err
+			}
+			if err := db.Exec("CREATE INDEX idx_messages_stamps_user_id_updated_at ON messages_stamps (user_id, updated_at)").Error; err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/model/message_stamp.go
+++ b/model/message_stamp.go
@@ -9,11 +9,11 @@ import (
 // MessageStamp メッセージスタンプ構造体
 type MessageStamp struct {
 	MessageID uuid.UUID `gorm:"type:char(36);not null;primaryKey;index" json:"-"`
-	StampID   uuid.UUID `gorm:"type:char(36);not null;primaryKey;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:2" json:"stampId"`
-	UserID    uuid.UUID `gorm:"type:char(36);not null;primaryKey;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:1;index:idx_messages_stamps_user_id_updated_at,priority:1" json:"userId"`
+	StampID   uuid.UUID `gorm:"type:char(36);not null;primaryKey;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:2;index:idx_messages_stamps_user_id_updated_at_stamp_id,priority:3" json:"stampId"`
+	UserID    uuid.UUID `gorm:"type:char(36);not null;primaryKey;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:1;index:idx_messages_stamps_user_id_updated_at_stamp_id,priority:1" json:"userId"`
 	Count     int       `gorm:"type:int;not null" json:"count"`
 	CreatedAt time.Time `gorm:"precision:6" json:"createdAt"`
-	UpdatedAt time.Time `gorm:"precision:6;index;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:3;index:idx_messages_stamps_user_id_updated_at,priority:2" json:"updatedAt"`
+	UpdatedAt time.Time `gorm:"precision:6;index;index:idx_messages_stamps_user_id_stamp_id_updated_at,priority:3;index:idx_messages_stamps_user_id_updated_at_stamp_id,priority:2" json:"updatedAt"`
 
 	Stamp *Stamp `gorm:"constraint:messages_stamps_stamp_id_stamps_id_foreign,OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	User  *User  `gorm:"constraint:messages_stamps_user_id_users_id_foreign,OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -368,7 +368,7 @@ func (r *stampRepository) GetUserStampRecommendations(userID uuid.UUID, limit in
 	const historyLimit = 10000
 
 	recentStamps := r.db.
-		Model(&model.MessageStamp{}).
+		Table("messages_stamps USE INDEX (idx_messages_stamps_user_id_updated_at_stamp_id)").
 		Select("stamp_id, updated_at").
 		Where("user_id = ?", userID).
 		Order("updated_at DESC").


### PR DESCRIPTION
## 変更内容
- `messages_stamps` テーブルのインデックス `idx_messages_stamps_user_id_updated_at` `(user_id, updated_at)` を削除し、カバリングインデックスとなる `idx_messages_stamps_user_id_updated_at_stamp_id` `(user_id, updated_at, stamp_id)` を作成しました。
- `GetUserStampRecommendations` クエリにおいて、上記インデックスを使用するように `USE INDEX` ヒントを追加しました。

## 理由
- `GetUserStampRecommendations`（スタンプ履歴取得）において、既存のインデックスでは `stamp_id` を取得するためにテーブルアクセスが発生するか、あるいは不適切なインデックスが選択されて `filesort` が発生する問題がありました。
- インデックス構造を `(user_id, updated_at, stamp_id)` に変更することで、ソート済みの状態で必要なカラムをすべて取得できるカバリングインデックスとしました。
- さらに、オプティマイザが統計情報の揺らぎ等により不適切な実行計画を選択するケースを防ぐため、`USE INDEX` を明記して最適なインデックスの使用を強制しました。これにより `filesort` を確実に回避し、パフォーマンスを安定させます。