### PR TITLE
docs: deprecate GET /users/me/stamp-recommendations

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -860,6 +860,7 @@ paths:
         このAPIが返すスタンプ履歴は厳密な履歴ではありません。
   /users/me/stamp-recommendations:
     get:
+      deprecated: true
       summary: スタンプレコメンドを取得
       tags:
         - stamp


### PR DESCRIPTION
GET /users/me/stamp-recommendationsにdeprecatedフラグを追加しました。