### PR TITLE
feat(og-image): `og:image:width` と `og:image:height` のフォールバック

### DIFF
--- a/utils/imaging/size.go
+++ b/utils/imaging/size.go
@@ -1,0 +1,43 @@
+package imaging
+
+import (
+	"context"
+	"fmt"
+	"image"
+
+	"net/http"
+
+	// add gif, jpeg, png support
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	// add webp support
+	_ "golang.org/x/image/webp"
+)
+
+// FetchImageSize 指定されたURLの画像サイズを取得
+func FetchImageSize(ctx context.Context, client *http.Client, imageURL string) (width, height int, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", imageURL, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, 0, fmt.Errorf("failed to fetch image: %s (status code: %d)", imageURL, resp.StatusCode)
+	}
+
+	// ヘッダー部分だけを解釈してサイズを得る
+	cfg, _, err := image.DecodeConfig(resp.Body)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return cfg.Width, cfg.Height, nil
+}

--- a/utils/imaging/size_test.go
+++ b/utils/imaging/size_test.go
@@ -1,0 +1,61 @@
+package imaging
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchImageSize(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 100, 50))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	imgData := buf.Bytes()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/image.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(imgData)
+		case "/not_found":
+			w.WriteHeader(http.StatusNotFound)
+		case "/invalid_image":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("not an image"))
+		}
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	t.Run("success", func(t *testing.T) {
+		w, h, err := FetchImageSize(context.Background(), client, ts.URL+"/image.png")
+		assert.NoError(t, err)
+		assert.Equal(t, 100, w)
+		assert.Equal(t, 50, h)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, _, err := FetchImageSize(context.Background(), client, ts.URL+"/not_found")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid image", func(t *testing.T) {
+		_, _, err := FetchImageSize(context.Background(), client, ts.URL+"/invalid_image")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		_, _, err := FetchImageSize(context.Background(), client, "invalid-url")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
- クライアントのレイアウトシフトを抑制するために事前に OGP 画像の幅と高さを知っている必要がある
- `og:image:{width/height}` の普及率は高くないので，指定されていなければ少なくとも実画像のヘッダ部分を読みにいかなければならない
  - これ自体はおそらくクライアントでも可能だが，キャッシュがブラウザごとにしか効かなかったり OGP 画像の fetch には時間が掛かったりするので，できるならサーバーで実現してほしい
- `image.DecodeConfig` はヘッダ部分だけを解釈するので初回 fetch 時の負荷はそこまで高まらないはず