### PR TITLE
Repository層でctxを受け取るようにする

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"image/png"
 	"io"
@@ -393,7 +394,7 @@ func genGroupImages() *cobra.Command {
 				if err != nil {
 					logger.Fatal("failed to generate image", zap.Stringer("gid", group.ID), zap.String("group", group.Name), zap.Error(err))
 				}
-				if err := repo.UpdateUserGroup(group.ID, repository.UpdateUserGroupArgs{Icon: optional.From(iconFileID)}); err != nil {
+				if err := repo.UpdateUserGroup(context.TODO(), group.ID, repository.UpdateUserGroupArgs{Icon: optional.From(iconFileID)}); err != nil {
 					logger.Fatal("failed to update user group", zap.Stringer("gid", group.ID), zap.String("group", group.Name), zap.Error(err))
 				}
 			}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -107,7 +107,7 @@ func serveCommand() *cobra.Command {
 				logger.Info("data initializing...")
 
 				// システムユーザーロール投入
-				if err := repo.CreateUserRoles(role.SystemRoleModels()...); err != nil {
+				if err := repo.CreateUserRoles(context.TODO(), role.SystemRoleModels()...); err != nil {
 					logger.Fatal("failed to init system user roles", zap.Error(err))
 				}
 				if err := server.SS.RBAC.Reload(); err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -119,7 +119,7 @@ func serveCommand() *cobra.Command {
 				if err != nil {
 					logger.Fatal("failed to generate icon file", zap.Error(err))
 				}
-				u, err := repo.CreateUser(repository.CreateUserArgs{
+				u, err := repo.CreateUser(context.TODO(), repository.CreateUserArgs{
 					Name:       "traq",
 					Password:   "traq",
 					Role:       role.Admin,
@@ -188,7 +188,7 @@ func (s *Server) Start(address string) error {
 		for ev := range sub.Receiver {
 			userID := ev.Fields["user_id"].(uuid.UUID)
 			datetime := ev.Fields["datetime"].(time.Time)
-			_ = s.Repo.UpdateUser(userID, repository.UpdateUserArgs{LastOnline: optional.From(datetime)})
+			_ = s.Repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{LastOnline: optional.From(datetime)})
 		}
 	}()
 	s.SS.StampThrottler.Start()

--- a/repository/bot.go
+++ b/repository/bot.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -88,90 +89,90 @@ type BotRepository interface {
 	//
 	// 成功した場合、Botとnilを返します。
 	// DBによるエラーを返すことがあります。
-	CreateBot(name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error)
+	CreateBot(ctx context.Context, name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error)
 	// UpdateBot 指定したBotの情報を更新します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないBotを指定した場合、ErrNotFoundを返します。
 	// idにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateBot(id uuid.UUID, args UpdateBotArgs) error
+	UpdateBot(ctx context.Context, id uuid.UUID, args UpdateBotArgs) error
 	// GetBots 指定した条件を満たすBotを取得します
 	//
 	// 成功した場合、Botの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetBots(query BotsQuery) ([]*model.Bot, error)
+	GetBots(ctx context.Context, query BotsQuery) ([]*model.Bot, error)
 	// GetBotByID 指定したIDのBotを取得します
 	//
 	// 成功した場合、Botとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetBotByID(id uuid.UUID) (*model.Bot, error)
+	GetBotByID(ctx context.Context, id uuid.UUID) (*model.Bot, error)
 	// GetBotByBotUserID 指定したユーザーIDのBotを取得します
 	//
 	// 成功した場合、Botとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetBotByBotUserID(id uuid.UUID) (*model.Bot, error)
+	GetBotByBotUserID(ctx context.Context, id uuid.UUID) (*model.Bot, error)
 	// GetBotByCode 指定したBotCodeのBotを取得します
 	//
 	// 成功した場合、Botとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetBotByCode(code string) (*model.Bot, error)
+	GetBotByCode(ctx context.Context, code string) (*model.Bot, error)
 	// ChangeBotState Botの状態を変更します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないBotを指定した場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	ChangeBotState(id uuid.UUID, state model.BotState) error
+	ChangeBotState(ctx context.Context, id uuid.UUID, state model.BotState) error
 	// ReissueBotTokens 指定したBotの各種トークンを再発行します
 	//
 	// 成功した場合、Botとnilを返します。
 	// 存在しないBotを指定した場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	ReissueBotTokens(id uuid.UUID) (*model.Bot, error)
+	ReissueBotTokens(ctx context.Context, id uuid.UUID) (*model.Bot, error)
 	// DeleteBot 指定したBotを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないBotを指定した場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteBot(id uuid.UUID) error
+	DeleteBot(ctx context.Context, id uuid.UUID) error
 	// AddBotToChannel 指定したBotをチャンネルに参加させます
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddBotToChannel(botID, channelID uuid.UUID) error
+	AddBotToChannel(ctx context.Context, botID, channelID uuid.UUID) error
 	// RemoveBotFromChannel 指定したBotを指定したチャンネルから退出させます
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveBotFromChannel(botID, channelID uuid.UUID) error
+	RemoveBotFromChannel(ctx context.Context, botID, channelID uuid.UUID) error
 	// GetParticipatingChannelIDsByBot 指定したBotが参加しているチャンネルのIDを取得します
 	//
 	// 成功した場合、チャンネルUUIDの配列とnilを返します。
 	// 存在しないBotを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetParticipatingChannelIDsByBot(botID uuid.UUID) ([]uuid.UUID, error)
+	GetParticipatingChannelIDsByBot(ctx context.Context, botID uuid.UUID) ([]uuid.UUID, error)
 	// WriteBotEventLog Botイベントログを書き込みます
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	WriteBotEventLog(log *model.BotEventLog) error
+	WriteBotEventLog(ctx context.Context, log *model.BotEventLog) error
 	// GetBotEventLogs 指定したBotのイベントログを取得します
 	//
 	// 成功した場合、イベントログの配列とnilを返します。負のoffset, limitは無視されます。
 	// 存在しないBotを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetBotEventLogs(botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error)
+	GetBotEventLogs(ctx context.Context, botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error)
 	// PurgeBotEventLogs 指定した時間以前のBotイベントログを全て消去します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	PurgeBotEventLogs(before time.Time) error
+	PurgeBotEventLogs(ctx context.Context, before time.Time) error
 }

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -78,45 +79,45 @@ type ChannelStats struct {
 // ChannelRepository チャンネルリポジトリ
 type ChannelRepository interface {
 	// GetPublicChannels 全ての公開チャンネルを返します
-	GetPublicChannels() ([]*model.Channel, error)
+	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
 	// dmがtrueの場合、privateMembersに1人または2人のユーザーが入っている必要があります。
-	CreateChannel(ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error)
+	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//
 	// 存在しないチャンネルを指定した場合、ErrNotFoundを返します。
-	UpdateChannel(channelID uuid.UUID, args UpdateChannelArgs) (*model.Channel, error)
+	UpdateChannel(ctx context.Context, channelID uuid.UUID, args UpdateChannelArgs) (*model.Channel, error)
 	// ArchiveChannels 指定したチャンネルをアーカイブします
-	ArchiveChannels(ids []uuid.UUID) ([]*model.Channel, error)
+	ArchiveChannels(ctx context.Context, ids []uuid.UUID) ([]*model.Channel, error)
 	// GetChannel 指定したチャンネルを取得します
 	//
 	// 存在しないチャンネルを指定した場合、ErrNotFoundを返します。
-	GetChannel(channelID uuid.UUID) (*model.Channel, error)
+	GetChannel(ctx context.Context, channelID uuid.UUID) (*model.Channel, error)
 	// GetDirectMessageChannel 指定したユーザー間のDMチャンネル取得します
 	//
 	// 存在しなかった場合、ErrNotFoundを返します。
-	GetDirectMessageChannel(user1, user2 uuid.UUID) (*model.Channel, error)
+	GetDirectMessageChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error)
 	// GetDirectMessageChannelMapping 指定したユーザーのDMチャンネルのマッピングを取得します
-	GetDirectMessageChannelMapping(userID uuid.UUID) ([]*model.DMChannelMapping, error)
+	GetDirectMessageChannelMapping(ctx context.Context, userID uuid.UUID) ([]*model.DMChannelMapping, error)
 	// GetPrivateChannelMemberIDs 指定したプライベートチャンネルのメンバーのUUIDを取得します
-	GetPrivateChannelMemberIDs(channelID uuid.UUID) ([]uuid.UUID, error)
+	GetPrivateChannelMemberIDs(ctx context.Context, channelID uuid.UUID) ([]uuid.UUID, error)
 	// ChangeChannelSubscription ユーザーのチャンネルの購読を変更します
 	//
 	// channelIDにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないユーザーを指定した場合は無視されます。
-	ChangeChannelSubscription(channelID uuid.UUID, args ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error)
+	ChangeChannelSubscription(ctx context.Context, channelID uuid.UUID, args ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error)
 	// GetChannelSubscriptions 指定したクエリに基づいてチャンネル購読情報を取得します
-	GetChannelSubscriptions(query ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error)
+	GetChannelSubscriptions(ctx context.Context, query ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error)
 	// GetChannelEvents 指定したクエリでチャンネルイベントを取得します
 	//
 	// 負のoffset, limitは無視されます。
 	// 指定した範囲内にlimitを超えてイベントが存在していた場合、trueを返します。
-	GetChannelEvents(query ChannelEventsQuery) (events []*model.ChannelEvent, more bool, err error)
+	GetChannelEvents(ctx context.Context, query ChannelEventsQuery) (events []*model.ChannelEvent, more bool, err error)
 	// GetChannelStats 指定したチャンネルの統計情報を取得します
 	//
 	// 存在しないチャンネルを指定した場合、ErrNotFoundを返します。
-	GetChannelStats(channelID uuid.UUID, excludeDeletedMessages bool) (*ChannelStats, error)
+	GetChannelStats(ctx context.Context, channelID uuid.UUID, excludeDeletedMessages bool) (*ChannelStats, error)
 	// RecordChannelEvent チャンネルイベントを記録します
-	RecordChannelEvent(channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error
+	RecordChannelEvent(ctx context.Context, channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error
 }

--- a/repository/clip.go
+++ b/repository/clip.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -22,7 +24,7 @@ type ClipRepository interface {
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	CreateClipFolder(userID uuid.UUID, name, description string) (*model.ClipFolder, error)
+	CreateClipFolder(ctx context.Context, userID uuid.UUID, name, description string) (*model.ClipFolder, error)
 	// UpdateClipFolder 指定したクリップフォルダーの情報を変更します
 	//
 	// 成功した場合、nilを返します。
@@ -30,21 +32,21 @@ type ClipRepository interface {
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないクリップフォルダーを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateClipFolder(folderID uuid.UUID, name, description optional.Of[string]) error
+	UpdateClipFolder(ctx context.Context, folderID uuid.UUID, name, description optional.Of[string]) error
 	// DeleteClipFolder 指定したクリップフォルダーを削除します。
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないクリップフォルダーを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteClipFolder(folderID uuid.UUID) error
+	DeleteClipFolder(ctx context.Context, folderID uuid.UUID) error
 	// DeleteClipFolderMessage 指定したクリップフォルダーのメッセージを削除します。
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないクリップフォルダーメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteClipFolderMessage(folderID, messageID uuid.UUID) error
+	DeleteClipFolderMessage(ctx context.Context, folderID, messageID uuid.UUID) error
 	// AddClipFolderMessage 指定したクリップフォルダーに指定したメッセージを追加します。
 	//
 	// 成功した場合、nilを返します。
@@ -52,20 +54,20 @@ type ClipRepository interface {
 	// 存在しないクリップフォルダーを指定した場合、ErrNotFoundを返します。
 	// 既に存在するフォルダーとメッセージの組み合わせを指定した場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	AddClipFolderMessage(folderID, messageID uuid.UUID) (*model.ClipFolderMessage, error)
+	AddClipFolderMessage(ctx context.Context, folderID, messageID uuid.UUID) (*model.ClipFolderMessage, error)
 	// GetClipFoldersByUserID ユーザーのクリップフォルダーを取得します。
 	//
 	// 成功した場合クリップフォルダーのスライスとnilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	GetClipFoldersByUserID(userID uuid.UUID) ([]*model.ClipFolder, error)
+	GetClipFoldersByUserID(ctx context.Context, userID uuid.UUID) ([]*model.ClipFolder, error)
 	// GetClipFolder クリップフォルダーの情報を取得します。
 	//
 	// 成功した場合クリップフォルダーの情報とnilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないクリップフォルダーを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetClipFolder(folderID uuid.UUID) (*model.ClipFolder, error)
+	GetClipFolder(ctx context.Context, folderID uuid.UUID) (*model.ClipFolder, error)
 	// GetClipFolderMessages 指定したクエリでクリップフォルダー内のメッセージのリストを取得します。
 	//
 	// 成功した場合クリップフォルダー内のメッセージの情報を返します。負のoffset, limitは無視されます。
@@ -73,11 +75,11 @@ type ClipRepository interface {
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないクリップフォルダーを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetClipFolderMessages(folderID uuid.UUID, query ClipFolderMessageQuery) (messages []*model.ClipFolderMessage, more bool, err error)
+	GetClipFolderMessages(ctx context.Context, folderID uuid.UUID, query ClipFolderMessageQuery) (messages []*model.ClipFolderMessage, more bool, err error)
 	// GetMessageClips 指定したユーザーの指定したメッセージのクリップのリストを取得します。
 	//
 	// 成功した場合、クリップの配列とnilを返します。
 	// 存在しないユーザー・メッセージを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetMessageClips(userID, messageID uuid.UUID) ([]*model.ClipFolderMessage, error)
+	GetMessageClips(ctx context.Context, userID, messageID uuid.UUID) ([]*model.ClipFolderMessage, error)
 }

--- a/repository/device.go
+++ b/repository/device.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/utils/set"
@@ -15,15 +17,15 @@ type DeviceRepository interface {
 	// tokenが空文字列の場合、ArgumentErrorを返します。
 	// 登録しようとしたトークンが既に他のユーザーと関連づけられていた場合はArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	RegisterDevice(userID uuid.UUID, token string) error
+	RegisterDevice(ctx context.Context, userID uuid.UUID, token string) error
 	// GetDeviceTokens 指定したユーザーの全デバイストークンを取得します
 	//
 	// 成功した場合、デバイストークンの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetDeviceTokens(userIDs set.UUID) (map[uuid.UUID][]string, error)
+	GetDeviceTokens(ctx context.Context, userIDs set.UUID) (map[uuid.UUID][]string, error)
 	// DeleteDeviceTokens FCMデバイスの登録を解除します
 	//
 	// 成功した、或いは既に登録解除されていた場合にnilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteDeviceTokens(tokens []string) error
+	DeleteDeviceTokens(ctx context.Context, tokens []string) error
 }

--- a/repository/file.go
+++ b/repository/file.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -30,35 +31,35 @@ type FileRepository interface {
 	// 成功した場合、ファイル情報の配列を返します。正でないoffset, limitは無視されます。
 	// 指定した範囲内にlimitを超えてファイルが存在していた場合、trueを返します。
 	// DBによるエラーを返すことがあります。
-	GetFileMetas(q FilesQuery) (result []*model.FileMeta, more bool, err error)
+	GetFileMetas(ctx context.Context, q FilesQuery) (result []*model.FileMeta, more bool, err error)
 	// GetFileMeta 指定したファイル情報を取得します
 	//
 	// 成功した場合、ファイル情報とnilを返します。
 	// 存在しないファイルを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error)
+	GetFileMeta(ctx context.Context, fileID uuid.UUID) (*model.FileMeta, error)
 	// SaveFileMeta ファイル情報と、metaに含まれるサムネイル情報を格納します
 	//
 	// 成功した場合、nilを返します。
 	// metaに指定されたIDがnilの場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	SaveFileMeta(meta *model.FileMeta, acl []*model.FileACLEntry) error
+	SaveFileMeta(ctx context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error
 	// DeleteFileMeta ファイル情報を削除します
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteFileMeta(fileID uuid.UUID) error
+	DeleteFileMeta(ctx context.Context, fileID uuid.UUID) error
 	// IsFileAccessible ユーザーがファイルへのアクセス権限を持っているかを確認します
 	//
 	// ユーザーがアクセス権限を持っている場合、trueを返します。
 	// ファイルもしくはユーザーが存在しない場合は、falseを返します。
 	// DBによるエラーを返すことがあります。
-	IsFileAccessible(fileID, userID uuid.UUID) (bool, error)
+	IsFileAccessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error)
 	// DeleteFileThumbnail サムネイル情報を削除します
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error
+	DeleteFileThumbnail(ctx context.Context, fileID uuid.UUID, thumbnailType model.ThumbnailType) error
 }

--- a/repository/gorm/bot.go
+++ b/repository/gorm/bot.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 )
 
 // CreateBot implements BotRepository interface.
-func (repo *Repository) CreateBot(name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error) {
+func (repo *Repository) CreateBot(ctx context.Context, name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error) {
 	uid := uuid.Must(uuid.NewV7())
 	bid := uuid.Must(uuid.NewV7())
 	tid := uuid.Must(uuid.NewV7())
@@ -58,7 +59,7 @@ func (repo *Repository) CreateBot(name, displayName, description string, iconFil
 		Scopes:         scopes,
 	}
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(u).Error; err != nil {
 			return err
 		}
@@ -88,7 +89,7 @@ func (repo *Repository) CreateBot(name, displayName, description string, iconFil
 }
 
 // UpdateBot implements BotRepository interface.
-func (repo *Repository) UpdateBot(id uuid.UUID, args repository.UpdateBotArgs) error {
+func (repo *Repository) UpdateBot(ctx context.Context, id uuid.UUID, args repository.UpdateBotArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -98,7 +99,7 @@ func (repo *Repository) UpdateBot(id uuid.UUID, args repository.UpdateBotArgs) e
 		updated     bool
 		userUpdated bool
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&b, &model.Bot{ID: id}).Error; err != nil {
 			return convertError(err)
 		}
@@ -175,9 +176,9 @@ func (repo *Repository) UpdateBot(id uuid.UUID, args repository.UpdateBotArgs) e
 }
 
 // GetBots implements BotRepository interface.
-func (repo *Repository) GetBots(query repository.BotsQuery) ([]*model.Bot, error) {
+func (repo *Repository) GetBots(ctx context.Context, query repository.BotsQuery) ([]*model.Bot, error) {
 	bots := make([]*model.Bot, 0)
-	tx := repo.db.Table("bots")
+	tx := repo.db.WithContext(ctx).Table("bots")
 
 	if query.IsPrivileged.Valid {
 		tx = tx.Where("bots.privileged = ?", query.IsPrivileged.V)
@@ -223,27 +224,27 @@ BotsFor:
 }
 
 // GetBotByID implements BotRepository interface.
-func (repo *Repository) GetBotByID(id uuid.UUID) (*model.Bot, error) {
+func (repo *Repository) GetBotByID(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
-	return getBot(repo.db, &model.Bot{ID: id})
+	return getBot(repo.db.WithContext(ctx), &model.Bot{ID: id})
 }
 
 // GetBotByBotUserID implements BotRepository interface.
-func (repo *Repository) GetBotByBotUserID(id uuid.UUID) (*model.Bot, error) {
+func (repo *Repository) GetBotByBotUserID(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
-	return getBot(repo.db, &model.Bot{BotUserID: id})
+	return getBot(repo.db.WithContext(ctx), &model.Bot{BotUserID: id})
 }
 
 // GetBotByCode implements BotRepository interface.
-func (repo *Repository) GetBotByCode(code string) (*model.Bot, error) {
+func (repo *Repository) GetBotByCode(ctx context.Context, code string) (*model.Bot, error) {
 	if len(code) == 0 {
 		return nil, repository.ErrNotFound
 	}
-	return getBot(repo.db, &model.Bot{BotCode: code})
+	return getBot(repo.db.WithContext(ctx), &model.Bot{BotCode: code})
 }
 
 func getBot(tx *gorm.DB, where interface{}) (*model.Bot, error) {
@@ -255,13 +256,13 @@ func getBot(tx *gorm.DB, where interface{}) (*model.Bot, error) {
 }
 
 // ChangeBotState implements BotRepository interface.
-func (repo *Repository) ChangeBotState(id uuid.UUID, state model.BotState) error {
+func (repo *Repository) ChangeBotState(ctx context.Context, id uuid.UUID, state model.BotState) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var changed bool
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var b model.Bot
 		if err := tx.Take(&b, &model.Bot{ID: id}).Error; err != nil {
 			return convertError(err)
@@ -288,12 +289,12 @@ func (repo *Repository) ChangeBotState(id uuid.UUID, state model.BotState) error
 }
 
 // ReissueBotTokens implements BotRepository interface.
-func (repo *Repository) ReissueBotTokens(id uuid.UUID) (*model.Bot, error) {
+func (repo *Repository) ReissueBotTokens(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 	var bot model.Bot
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&bot, &model.Bot{ID: id}).Error; err != nil {
 			return convertError(err)
 		}
@@ -342,11 +343,11 @@ func (repo *Repository) ReissueBotTokens(id uuid.UUID) (*model.Bot, error) {
 }
 
 // DeleteBot implements BotRepository interface.
-func (repo *Repository) DeleteBot(id uuid.UUID) error {
+func (repo *Repository) DeleteBot(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var b model.Bot
 		if err := tx.First(&b, &model.Bot{ID: id}).Error; err != nil {
 			return convertError(err)
@@ -380,12 +381,12 @@ func (repo *Repository) DeleteBot(id uuid.UUID) error {
 }
 
 // AddBotToChannel implements BotRepository interface.
-func (repo *Repository) AddBotToChannel(botID, channelID uuid.UUID) error {
+func (repo *Repository) AddBotToChannel(ctx context.Context, botID, channelID uuid.UUID) error {
 	if botID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var b model.BotJoinChannel
-	result := repo.db.FirstOrCreate(&b, &model.BotJoinChannel{BotID: botID, ChannelID: channelID})
+	result := repo.db.WithContext(ctx).FirstOrCreate(&b, &model.BotJoinChannel{BotID: botID, ChannelID: channelID})
 	if result.RowsAffected > 0 {
 		repo.hub.Publish(hub.Message{
 			Name: event.BotJoined,
@@ -399,11 +400,11 @@ func (repo *Repository) AddBotToChannel(botID, channelID uuid.UUID) error {
 }
 
 // RemoveBotFromChannel implements BotRepository interface.
-func (repo *Repository) RemoveBotFromChannel(botID, channelID uuid.UUID) error {
+func (repo *Repository) RemoveBotFromChannel(ctx context.Context, botID, channelID uuid.UUID) error {
 	if botID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	result := repo.db.Delete(&model.BotJoinChannel{}, &model.BotJoinChannel{BotID: botID, ChannelID: channelID})
+	result := repo.db.WithContext(ctx).Delete(&model.BotJoinChannel{}, &model.BotJoinChannel{BotID: botID, ChannelID: channelID})
 	if result.RowsAffected > 0 {
 		repo.hub.Publish(hub.Message{
 			Name: event.BotLeft,
@@ -417,12 +418,12 @@ func (repo *Repository) RemoveBotFromChannel(botID, channelID uuid.UUID) error {
 }
 
 // GetParticipatingChannelIDsByBot implements BotRepository interface.
-func (repo *Repository) GetParticipatingChannelIDsByBot(botID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *Repository) GetParticipatingChannelIDsByBot(ctx context.Context, botID uuid.UUID) ([]uuid.UUID, error) {
 	channels := make([]uuid.UUID, 0)
 	if botID == uuid.Nil {
 		return channels, nil
 	}
-	return channels, repo.db.
+	return channels, repo.db.WithContext(ctx).
 		Model(&model.BotJoinChannel{}).
 		Where(&model.BotJoinChannel{BotID: botID}).
 		Pluck("channel_id", &channels).
@@ -430,20 +431,20 @@ func (repo *Repository) GetParticipatingChannelIDsByBot(botID uuid.UUID) ([]uuid
 }
 
 // WriteBotEventLog implements BotRepository interface.
-func (repo *Repository) WriteBotEventLog(log *model.BotEventLog) error {
+func (repo *Repository) WriteBotEventLog(ctx context.Context, log *model.BotEventLog) error {
 	if log == nil || log.RequestID == uuid.Nil {
 		return nil
 	}
-	return repo.db.Create(log).Error
+	return repo.db.WithContext(ctx).Create(log).Error
 }
 
 // GetBotEventLogs implements BotRepository interface.
-func (repo *Repository) GetBotEventLogs(botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error) {
+func (repo *Repository) GetBotEventLogs(ctx context.Context, botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error) {
 	logs := make([]*model.BotEventLog, 0)
 	if botID == uuid.Nil {
 		return logs, nil
 	}
-	return logs, repo.db.Where(&model.BotEventLog{BotID: botID}).
+	return logs, repo.db.WithContext(ctx).Where(&model.BotEventLog{BotID: botID}).
 		Order("date_time DESC").
 		Scopes(gormutil.LimitAndOffset(limit, offset)).
 		Find(&logs).
@@ -451,6 +452,6 @@ func (repo *Repository) GetBotEventLogs(botID uuid.UUID, limit, offset int) ([]*
 }
 
 // PurgeBotEventLogs implements BotRepository interface.
-func (repo *Repository) PurgeBotEventLogs(before time.Time) error {
-	return repo.db.Delete(&model.BotEventLog{}, "date_time < ?", before).Error
+func (repo *Repository) PurgeBotEventLogs(ctx context.Context, before time.Time) error {
+	return repo.db.WithContext(ctx).Delete(&model.BotEventLog{}, "date_time < ?", before).Error
 }

--- a/repository/gorm/channel.go
+++ b/repository/gorm/channel.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -18,7 +19,7 @@ import (
 var dmChannelRootUUID = uuid.Must(uuid.FromString(model.DirectMessageChannelRootID))
 
 // CreateChannel implements ChannelRepository interface.
-func (repo *Repository) CreateChannel(ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
+func (repo *Repository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
 	arr := []interface{}{&ch}
 
 	ch.ID = uuid.Must(uuid.NewV7())
@@ -67,7 +68,7 @@ func (repo *Repository) CreateChannel(ch model.Channel, privateMembers set.UUID,
 		arr = append(arr, m)
 	}
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, v := range arr {
 			if err := tx.Create(v).Error; err != nil {
 				return err
@@ -90,13 +91,13 @@ func (repo *Repository) CreateChannel(ch model.Channel, privateMembers set.UUID,
 }
 
 // UpdateChannel implements ChannelRepository interface.
-func (repo *Repository) UpdateChannel(channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
+func (repo *Repository) UpdateChannel(ctx context.Context, channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
 	if channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 
 	var ch model.Channel
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&ch, &model.Channel{ID: channelID}).Error; err != nil {
 			return convertError(err)
 		}
@@ -148,9 +149,9 @@ func (repo *Repository) UpdateChannel(channelID uuid.UUID, args repository.Updat
 }
 
 // ArchiveChannels implements ChannelRepository interface.
-func (repo *Repository) ArchiveChannels(ids []uuid.UUID) ([]*model.Channel, error) {
+func (repo *Repository) ArchiveChannels(ctx context.Context, ids []uuid.UUID) ([]*model.Channel, error) {
 	var changed []*model.Channel
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, id := range ids {
 			if id != uuid.Nil {
 				var ch model.Channel
@@ -187,28 +188,29 @@ func (repo *Repository) ArchiveChannels(ids []uuid.UUID) ([]*model.Channel, erro
 }
 
 // GetChannel implements ChannelRepository interface.
-func (repo *Repository) GetChannel(channelID uuid.UUID) (*model.Channel, error) {
+func (repo *Repository) GetChannel(ctx context.Context, channelID uuid.UUID) (*model.Channel, error) {
 	if channelID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	var ch model.Channel
-	if err := repo.db.First(&ch, &model.Channel{ID: channelID}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).First(&ch, &model.Channel{ID: channelID}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return &ch, nil
 }
 
 // GetPublicChannels implements ChannelRepository interface.
-func (repo *Repository) GetPublicChannels() (channels []*model.Channel, err error) {
+func (repo *Repository) GetPublicChannels(ctx context.Context) (channels []*model.Channel, err error) {
 	channels = make([]*model.Channel, 0)
 	return channels, repo.db.
+		WithContext(ctx).
 		Where(&model.Channel{IsPublic: true}).
 		Find(&channels).
 		Error
 }
 
 // GetDirectMessageChannel implements ChannelRepository interface.
-func (repo *Repository) GetDirectMessageChannel(user1, user2 uuid.UUID) (*model.Channel, error) {
+func (repo *Repository) GetDirectMessageChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error) {
 	// user1 <= user2 になるように入れかえ
 	if bytes.Compare(user1.Bytes(), user2.Bytes()) == 1 {
 		t := user1
@@ -219,6 +221,7 @@ func (repo *Repository) GetDirectMessageChannel(user1, user2 uuid.UUID) (*model.
 	// チャンネル存在確認
 	var ch model.Channel
 	err := repo.db.
+		WithContext(ctx).
 		Where("id = (SELECT channel_id FROM dm_channel_mappings WHERE user1 = ? AND user2 = ?)", user1, user2).
 		First(&ch).
 		Error
@@ -229,24 +232,26 @@ func (repo *Repository) GetDirectMessageChannel(user1, user2 uuid.UUID) (*model.
 }
 
 // GetDirectMessageChannelMapping implements ChannelRepository interface.
-func (repo *Repository) GetDirectMessageChannelMapping(userID uuid.UUID) (mappings []*model.DMChannelMapping, err error) {
+func (repo *Repository) GetDirectMessageChannelMapping(ctx context.Context, userID uuid.UUID) (mappings []*model.DMChannelMapping, err error) {
 	mappings = make([]*model.DMChannelMapping, 0)
 	if userID == uuid.Nil {
 		return
 	}
 	return mappings, repo.db.
+		WithContext(ctx).
 		Where("user1 = ? OR user2 = ?", userID, userID).
 		Find(&mappings).
 		Error
 }
 
 // GetPrivateChannelMemberIDs implements ChannelRepository interface.
-func (repo *Repository) GetPrivateChannelMemberIDs(channelID uuid.UUID) (users []uuid.UUID, err error) {
+func (repo *Repository) GetPrivateChannelMemberIDs(ctx context.Context, channelID uuid.UUID) (users []uuid.UUID, err error) {
 	users = make([]uuid.UUID, 0)
 	if channelID == uuid.Nil {
 		return users, nil
 	}
 	return users, repo.db.
+		WithContext(ctx).
 		Model(&model.UsersPrivateChannel{}).
 		Where(&model.UsersPrivateChannel{ChannelID: channelID}).
 		Pluck("user_id", &users).
@@ -254,7 +259,7 @@ func (repo *Repository) GetPrivateChannelMemberIDs(channelID uuid.UUID) (users [
 }
 
 // ChangeChannelSubscription implements ChannelRepository interface.
-func (repo *Repository) ChangeChannelSubscription(channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
+func (repo *Repository) ChangeChannelSubscription(ctx context.Context, channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
 	if channelID == uuid.Nil {
 		return nil, nil, repository.ErrNilID
 	}
@@ -267,7 +272,7 @@ func (repo *Repository) ChangeChannelSubscription(channelID uuid.UUID, args repo
 		uids = append(uids, uid)
 	}
 
-	err = repo.db.Transaction(func(tx *gorm.DB) error {
+	err = repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// 指定された各ユーザーの現在のチャンネルの購読設定を取得
 		var _current []*model.UserSubscribeChannel
 		if err := tx.
@@ -364,8 +369,8 @@ func (repo *Repository) ChangeChannelSubscription(channelID uuid.UUID, args repo
 }
 
 // GetChannelSubscriptions implements ChannelRepository interface.
-func (repo *Repository) GetChannelSubscriptions(query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
-	tx := repo.db
+func (repo *Repository) GetChannelSubscriptions(ctx context.Context, query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
+	tx := repo.db.WithContext(ctx)
 
 	if query.UserID.Valid {
 		tx = tx.Where("user_id = ?", query.UserID.V)
@@ -388,10 +393,10 @@ func (repo *Repository) GetChannelSubscriptions(query repository.ChannelSubscrip
 }
 
 // GetChannelEvents implements ChannelRepository interface.
-func (repo *Repository) GetChannelEvents(query repository.ChannelEventsQuery) (events []*model.ChannelEvent, more bool, err error) {
+func (repo *Repository) GetChannelEvents(ctx context.Context, query repository.ChannelEventsQuery) (events []*model.ChannelEvent, more bool, err error) {
 	events = make([]*model.ChannelEvent, 0)
 
-	tx := repo.db
+	tx := repo.db.WithContext(ctx)
 	if query.Asc {
 		tx = tx.Order("date_time")
 	} else {
@@ -434,8 +439,8 @@ func (repo *Repository) GetChannelEvents(query repository.ChannelEventsQuery) (e
 }
 
 // RecordChannelEvent implements ChannelRepository interface.
-func (repo *Repository) RecordChannelEvent(channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error {
-	return repo.db.Create(&model.ChannelEvent{
+func (repo *Repository) RecordChannelEvent(ctx context.Context, channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error {
+	return repo.db.WithContext(ctx).Create(&model.ChannelEvent{
 		EventID:   uuid.Must(uuid.NewV7()),
 		ChannelID: channelID,
 		EventType: eventType,
@@ -445,19 +450,19 @@ func (repo *Repository) RecordChannelEvent(channelID uuid.UUID, eventType model.
 }
 
 // GetChannelStats implements ChannelRepository interface.
-func (repo *Repository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessages bool) (*repository.ChannelStats, error) {
+func (repo *Repository) GetChannelStats(ctx context.Context, channelID uuid.UUID, excludeDeletedMessages bool) (*repository.ChannelStats, error) {
 	if channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 
-	if ok, err := gormutil.RecordExists(repo.db, &model.Channel{ID: channelID}); err != nil {
+	if ok, err := gormutil.RecordExists(repo.db.WithContext(ctx), &model.Channel{ID: channelID}); err != nil {
 		return nil, err
 	} else if !ok {
 		return nil, repository.ErrNotFound
 	}
 
 	var stats repository.ChannelStats
-	query := repo.db.Unscoped().
+	query := repo.db.WithContext(ctx).Unscoped().
 		Model(&model.Message{}).
 		Select("COUNT(channel_id) AS total_message_count").
 		Where(&model.Message{ChannelID: channelID})
@@ -470,7 +475,7 @@ func (repo *Repository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessa
 		return nil, err
 	}
 
-	query = repo.db.Unscoped().
+	query = repo.db.WithContext(ctx).Unscoped().
 		Model(&model.Message{}).
 		Select("stamp_id AS id", "COUNT(stamp_id) AS count", "SUM(count) As total").
 		Joins("JOIN messages_stamps ON id = messages_stamps.message_id").
@@ -488,7 +493,7 @@ func (repo *Repository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessa
 		return nil, err
 	}
 
-	query = repo.db.Unscoped().
+	query = repo.db.WithContext(ctx).Unscoped().
 		Model(&model.Message{}).
 		Select("user_id AS id", "COUNT(user_id) AS message_count").
 		Where(&model.Message{ChannelID: channelID})

--- a/repository/gorm/channel_test.go
+++ b/repository/gorm/channel_test.go
@@ -211,8 +211,8 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 		for i := range 14 {
 			u2Messages[i] = mustMakeMessage(t, repo, user2.GetID(), channel.ID)
 		}
-		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
-		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[12].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[13].ID))
 
 		for i := range 7 {
 			mustAddMessageStamp(t, repo, u1Messages[i].ID, stamp1.ID, user1.GetID())
@@ -267,8 +267,8 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 		for i := range 14 {
 			u2Messages[i] = mustMakeMessage(t, repo, user2.GetID(), channel.ID)
 		}
-		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
-		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[12].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[13].ID))
 
 		for i := range 7 {
 			mustAddMessageStamp(t, repo, u1Messages[i].ID, stamp1.ID, user1.GetID())
@@ -334,8 +334,8 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, u2Messages[i].ID, stamp2.ID, user1.GetID())
 		}
 
-		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
-		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[12].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[13].ID))
 
 		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, true)
 		if assert.NoError(t, err) {
@@ -391,8 +391,8 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, u2Messages[i].ID, stamp2.ID, user1.GetID())
 		}
 
-		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
-		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[12].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), u2Messages[13].ID))
 
 		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, true)
 		if assert.NoError(t, err) {

--- a/repository/gorm/channel_test.go
+++ b/repository/gorm/channel_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -54,9 +55,9 @@ func TestGormRepository_UpdateChannel(t *testing.T) {
 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
 			t.Parallel()
 			ch := mustMakeChannel(t, repo, rand)
-			changed, err := repo.UpdateChannel(ch.ID, v)
+			changed, err := repo.UpdateChannel(context.TODO(), ch.ID, v)
 			if assert.NoError(t, err) {
-				ch, err := repo.GetChannel(ch.ID)
+				ch, err := repo.GetChannel(context.TODO(), ch.ID)
 				require.NoError(t, err)
 				assert.EqualValues(t, ch, changed)
 			}
@@ -72,7 +73,7 @@ func TestRepositoryImpl_GetChannel(t *testing.T) {
 	t.Run("Exists", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		ch, err := repo.GetChannel(channel.ID)
+		ch, err := repo.GetChannel(context.TODO(), channel.ID)
 		if assert.NoError(err) {
 			assert.Equal(channel.ID, ch.ID)
 			assert.Equal(channel.Name, ch.Name)
@@ -80,7 +81,7 @@ func TestRepositoryImpl_GetChannel(t *testing.T) {
 	})
 
 	t.Run("NotExists", func(t *testing.T) {
-		_, err := repo.GetChannel(uuid.Nil)
+		_, err := repo.GetChannel(context.TODO(), uuid.Nil)
 		assert.Error(t, err)
 	})
 }
@@ -93,7 +94,7 @@ func TestGormRepository_ChangeChannelSubscription(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, _, err := repo.ChangeChannelSubscription(uuid.Nil, repository.ChangeChannelSubscriptionArgs{})
+		_, _, err := repo.ChangeChannelSubscription(context.TODO(), uuid.Nil, repository.ChangeChannelSubscriptionArgs{})
 		assert.EqualError(err, repository.ErrNilID.Error())
 	})
 
@@ -112,7 +113,7 @@ func TestGormRepository_ChangeChannelSubscription(t *testing.T) {
 				uuid.Must(uuid.NewV7()): model.ChannelSubscribeLevelMarkAndNotify,
 			},
 		}
-		_, _, err := repo.ChangeChannelSubscription(ch.ID, args)
+		_, _, err := repo.ChangeChannelSubscription(context.TODO(), ch.ID, args)
 		if assert.NoError(err) {
 			assert.Equal(2, count(t, getDB(repo).Model(model.UserSubscribeChannel{}).Where(&model.UserSubscribeChannel{ChannelID: ch.ID})))
 		}
@@ -125,7 +126,7 @@ func TestGormRepository_ChangeChannelSubscription(t *testing.T) {
 				uuid.Must(uuid.NewV7()): model.ChannelSubscribeLevelNone,
 			},
 		}
-		_, _, err = repo.ChangeChannelSubscription(ch.ID, args)
+		_, _, err = repo.ChangeChannelSubscription(context.TODO(), ch.ID, args)
 		if assert.NoError(err) {
 			assert.Equal(1, count(t, getDB(repo).Model(model.UserSubscribeChannel{}).Where(&model.UserSubscribeChannel{ChannelID: ch.ID})))
 		}
@@ -146,7 +147,7 @@ func TestGormRepository_ChangeChannelSubscription(t *testing.T) {
 				uuid.Must(uuid.NewV7()): model.ChannelSubscribeLevelMarkAndNotify,
 			},
 		}
-		_, _, err := repo.ChangeChannelSubscription(ch.ID, args)
+		_, _, err := repo.ChangeChannelSubscription(context.TODO(), ch.ID, args)
 		if assert.NoError(err) {
 			assert.Equal(2, count(t, getDB(repo).Model(model.UserSubscribeChannel{}).Where(&model.UserSubscribeChannel{ChannelID: ch.ID})))
 		}
@@ -159,7 +160,7 @@ func TestGormRepository_ChangeChannelSubscription(t *testing.T) {
 				uuid.Must(uuid.NewV7()): model.ChannelSubscribeLevelNone,
 			},
 		}
-		_, _, err = repo.ChangeChannelSubscription(ch.ID, args)
+		_, _, err = repo.ChangeChannelSubscription(context.TODO(), ch.ID, args)
 		if assert.NoError(err) {
 			assert.Equal(1, count(t, getDB(repo).Model(model.UserSubscribeChannel{}).Where(&model.UserSubscribeChannel{ChannelID: ch.ID})))
 		}
@@ -173,21 +174,21 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetChannelStats(uuid.Nil, false)
+		_, err := repo.GetChannelStats(context.TODO(), uuid.Nil, false)
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetChannelStats(uuid.Must(uuid.NewV4()), false)
+		_, err := repo.GetChannelStats(context.TODO(), uuid.Must(uuid.NewV4()), false)
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetChannelStats(uuid.Must(uuid.NewV7()), false)
+		_, err := repo.GetChannelStats(context.TODO(), uuid.Must(uuid.NewV7()), false)
 		assert.Error(t, err)
 	})
 
@@ -223,7 +224,7 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, u2Messages[i].ID, stamp2.ID, user1.GetID())
 		}
 
-		stats, err := repo.GetChannelStats(channel.ID, false)
+		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, false)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 
@@ -279,7 +280,7 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, u2Messages[i].ID, stamp2.ID, user1.GetID())
 		}
 
-		stats, err := repo.GetChannelStats(channel.ID, false)
+		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, false)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 
@@ -336,7 +337,7 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
 		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
 
-		stats, err := repo.GetChannelStats(channel.ID, true)
+		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, true)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 
@@ -393,7 +394,7 @@ func TestGormRepository_GetChannelStats(t *testing.T) {
 		require.NoError(t, repo.DeleteMessage(u2Messages[12].ID))
 		require.NoError(t, repo.DeleteMessage(u2Messages[13].ID))
 
-		stats, err := repo.GetChannelStats(channel.ID, true)
+		stats, err := repo.GetChannelStats(context.TODO(), channel.ID, true)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 

--- a/repository/gorm/clip.go
+++ b/repository/gorm/clip.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/traPtitech/traQ/repository"
 	"github.com/traPtitech/traQ/utils/gormutil"
 	"github.com/traPtitech/traQ/utils/optional"
@@ -14,7 +16,7 @@ import (
 )
 
 // CreateClipFolder implements ClipRepository interface.
-func (repo *Repository) CreateClipFolder(userID uuid.UUID, name string, description string) (*model.ClipFolder, error) {
+func (repo *Repository) CreateClipFolder(ctx context.Context, userID uuid.UUID, name string, description string) (*model.ClipFolder, error) {
 	if userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -26,7 +28,7 @@ func (repo *Repository) CreateClipFolder(userID uuid.UUID, name string, descript
 		Name:        name,
 		OwnerID:     userID,
 	}
-	if err := repo.db.Create(clipFolder).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Create(clipFolder).Error; err != nil {
 		return nil, err
 	}
 	repo.hub.Publish(hub.Message{
@@ -42,7 +44,7 @@ func (repo *Repository) CreateClipFolder(userID uuid.UUID, name string, descript
 }
 
 // UpdateClipFolder implements ClipRepository interface.
-func (repo *Repository) UpdateClipFolder(folderID uuid.UUID, name optional.Of[string], description optional.Of[string]) error {
+func (repo *Repository) UpdateClipFolder(ctx context.Context, folderID uuid.UUID, name optional.Of[string], description optional.Of[string]) error {
 	if folderID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -63,7 +65,7 @@ func (repo *Repository) UpdateClipFolder(folderID uuid.UUID, name optional.Of[st
 		ok        bool
 	)
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&oldFolder, &model.ClipFolder{ID: folderID}).Error; err != nil {
 			return convertError(err)
 		}
@@ -95,12 +97,12 @@ func (repo *Repository) UpdateClipFolder(folderID uuid.UUID, name optional.Of[st
 }
 
 // DeleteClipFolder implements ClipRepository interface.
-func (repo *Repository) DeleteClipFolder(folderID uuid.UUID) error {
+func (repo *Repository) DeleteClipFolder(ctx context.Context, folderID uuid.UUID) error {
 	if folderID == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var cf model.ClipFolder
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&cf, &model.ClipFolder{ID: folderID}).Error; err != nil {
 			return convertError(err)
 		}
@@ -125,7 +127,7 @@ func (repo *Repository) DeleteClipFolder(folderID uuid.UUID) error {
 }
 
 // DeleteClipFolderMessage implements ClipRepository interface.
-func (repo *Repository) DeleteClipFolderMessage(folderID, messageID uuid.UUID) error {
+func (repo *Repository) DeleteClipFolderMessage(ctx context.Context, folderID, messageID uuid.UUID) error {
 	if folderID == uuid.Nil || messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -133,7 +135,7 @@ func (repo *Repository) DeleteClipFolderMessage(folderID, messageID uuid.UUID) e
 		cf  model.ClipFolder
 		cfm model.ClipFolderMessage
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// フォルダ存在チェック
 		if err := tx.First(&cf, &model.ClipFolder{ID: folderID}).Error; err != nil {
 			return convertError(err)
@@ -161,7 +163,7 @@ func (repo *Repository) DeleteClipFolderMessage(folderID, messageID uuid.UUID) e
 }
 
 // AddClipFolderMessage implements ClipRepository interface.
-func (repo *Repository) AddClipFolderMessage(folderID, messageID uuid.UUID) (*model.ClipFolderMessage, error) {
+func (repo *Repository) AddClipFolderMessage(ctx context.Context, folderID, messageID uuid.UUID) (*model.ClipFolderMessage, error) {
 	if folderID == uuid.Nil || messageID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -172,7 +174,7 @@ func (repo *Repository) AddClipFolderMessage(folderID, messageID uuid.UUID) (*mo
 	}
 	var cf model.ClipFolder
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// フォルダ存在チェック
 		if err := tx.First(&cf, &model.ClipFolder{ID: folderID}).Error; err != nil {
 			return convertError(err)
@@ -209,14 +211,14 @@ func (repo *Repository) AddClipFolderMessage(folderID, messageID uuid.UUID) (*mo
 }
 
 // GetClipFoldersByUserID implements ClipRepository interface.
-func (repo *Repository) GetClipFoldersByUserID(userID uuid.UUID) ([]*model.ClipFolder, error) {
+func (repo *Repository) GetClipFoldersByUserID(ctx context.Context, userID uuid.UUID) ([]*model.ClipFolder, error) {
 	if userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 
 	clipFolders := make([]*model.ClipFolder, 0)
 
-	if err := repo.db.Find(&clipFolders, "owner_id=?", userID).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Find(&clipFolders, "owner_id=?", userID).Error; err != nil {
 		return nil, convertError(err)
 	}
 
@@ -224,13 +226,13 @@ func (repo *Repository) GetClipFoldersByUserID(userID uuid.UUID) ([]*model.ClipF
 }
 
 // GetClipFolder implements ClipRepository interface.
-func (repo *Repository) GetClipFolder(folderID uuid.UUID) (*model.ClipFolder, error) {
+func (repo *Repository) GetClipFolder(ctx context.Context, folderID uuid.UUID) (*model.ClipFolder, error) {
 	if folderID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 	clipFolder := &model.ClipFolder{}
 
-	if err := repo.db.First(clipFolder, &model.ClipFolder{ID: folderID}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).First(clipFolder, &model.ClipFolder{ID: folderID}).Error; err != nil {
 		return nil, convertError(err)
 	}
 
@@ -238,20 +240,20 @@ func (repo *Repository) GetClipFolder(folderID uuid.UUID) (*model.ClipFolder, er
 }
 
 // GetClipFolderMessages implements ClipRepository interface.
-func (repo *Repository) GetClipFolderMessages(folderID uuid.UUID, query repository.ClipFolderMessageQuery) (messages []*model.ClipFolderMessage, more bool, err error) {
+func (repo *Repository) GetClipFolderMessages(ctx context.Context, folderID uuid.UUID, query repository.ClipFolderMessageQuery) (messages []*model.ClipFolderMessage, more bool, err error) {
 	if folderID == uuid.Nil {
 		return nil, false, repository.ErrNilID
 	}
 	messages = make([]*model.ClipFolderMessage, 0)
 
 	// フォルダ存在チェック
-	if exists, err := gormutil.RecordExists(repo.db, &model.ClipFolder{ID: folderID}); err != nil {
+	if exists, err := gormutil.RecordExists(repo.db.WithContext(ctx), &model.ClipFolder{ID: folderID}); err != nil {
 		return nil, false, err
 	} else if !exists {
 		return nil, false, repository.ErrNotFound
 	}
 
-	tx := repo.db
+	tx := repo.db.WithContext(ctx)
 	tx = tx.Where("folder_id=?", folderID).Scopes(clipPreloads)
 
 	if query.Asc {
@@ -276,13 +278,13 @@ func (repo *Repository) GetClipFolderMessages(folderID uuid.UUID, query reposito
 }
 
 // GetMessageClips implements ClipRepository interface.
-func (repo *Repository) GetMessageClips(userID, messageID uuid.UUID) ([]*model.ClipFolderMessage, error) {
+func (repo *Repository) GetMessageClips(ctx context.Context, userID, messageID uuid.UUID) ([]*model.ClipFolderMessage, error) {
 	clips := make([]*model.ClipFolderMessage, 0)
 	if userID == uuid.Nil || messageID == uuid.Nil {
 		return clips, nil
 	}
 
-	err := repo.db.
+	err := repo.db.WithContext(ctx).
 		Joins("INNER JOIN clip_folders ON clip_folders.id = clip_folder_messages.folder_id").
 		Where("clip_folders.owner_id = ? AND clip_folder_messages.message_id = ?", userID, messageID).
 		Find(&clips).

--- a/repository/gorm/clip_test.go
+++ b/repository/gorm/clip_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestRepositoryImpl_CreateClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.CreateClipFolder(uuid.Nil, random2.AlphaNumeric(20), random2.AlphaNumeric(100))
+		_, err := repo.CreateClipFolder(context.TODO(), uuid.Nil, random2.AlphaNumeric(20), random2.AlphaNumeric(100))
 
 		assert.Error(err)
 	})
@@ -33,7 +34,7 @@ func TestRepositoryImpl_CreateClipFolder(t *testing.T) {
 
 		name := random2.AlphaNumeric(20)
 		description := random2.AlphaNumeric(100)
-		cf, err := repo.CreateClipFolder(user.GetID(), name, description)
+		cf, err := repo.CreateClipFolder(context.TODO(), user.GetID(), name, description)
 
 		if assert.NoError(err) {
 			assert.NotEmpty(cf.ID)
@@ -56,28 +57,28 @@ func TestRepositoryImpl_UpdateClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateClipFolder(uuid.Nil, optional.Of[string]{}, optional.Of[string]{}), repository.ErrNilID.Error())
+		assert.EqualError(repo.UpdateClipFolder(context.TODO(), uuid.Nil, optional.Of[string]{}, optional.Of[string]{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateClipFolder(uuid.Must(uuid.NewV4()), optional.Of[string]{}, optional.Of[string]{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateClipFolder(context.TODO(), uuid.Must(uuid.NewV4()), optional.Of[string]{}, optional.Of[string]{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateClipFolder(uuid.Must(uuid.NewV7()), optional.Of[string]{}, optional.Of[string]{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateClipFolder(context.TODO(), uuid.Must(uuid.NewV7()), optional.Of[string]{}, optional.Of[string]{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("no change", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.NoError(repo.UpdateClipFolder(clipFolder.ID, optional.Of[string]{}, optional.Of[string]{}))
+		assert.NoError(repo.UpdateClipFolder(context.TODO(), clipFolder.ID, optional.Of[string]{}, optional.Of[string]{}))
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -87,8 +88,8 @@ func TestRepositoryImpl_UpdateClipFolder(t *testing.T) {
 		newName := random2.AlphaNumeric(20)
 		newDescription := random2.AlphaNumeric(100)
 
-		if assert.NoError(repo.UpdateClipFolder(clipFolder.ID, optional.From(newName), optional.From(newDescription))) {
-			newClipFolder, err := repo.GetClipFolder(clipFolder.ID)
+		if assert.NoError(repo.UpdateClipFolder(context.TODO(), clipFolder.ID, optional.From(newName), optional.From(newDescription))) {
+			newClipFolder, err := repo.GetClipFolder(context.TODO(), clipFolder.ID)
 			require.NoError(err)
 			assert.Equal(newDescription, newClipFolder.Description)
 			assert.Equal(newName, newClipFolder.Name)
@@ -104,20 +105,20 @@ func TestRepositoryImpl_DeleteClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolder(uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(repo.DeleteClipFolder(context.TODO(), uuid.Nil), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolder(uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteClipFolder(context.TODO(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolder(uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteClipFolder(context.TODO(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -126,8 +127,8 @@ func TestRepositoryImpl_DeleteClipFolder(t *testing.T) {
 
 		clipFolder := mustMakeClipFolder(t, repo, user.GetID(), rand, rand)
 
-		if assert.NoError(repo.DeleteClipFolder(clipFolder.ID)) {
-			_, err := repo.GetClipFolder(clipFolder.ID)
+		if assert.NoError(repo.DeleteClipFolder(context.TODO(), clipFolder.ID)) {
+			_, err := repo.GetClipFolder(context.TODO(), clipFolder.ID)
 			assert.EqualError(err, repository.ErrNotFound.Error())
 		}
 	})
@@ -142,20 +143,20 @@ func TestRepositoryImpl_DeleteClipFolderMessage(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolderMessage(uuid.Nil, uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(repo.DeleteClipFolderMessage(context.TODO(), uuid.Nil, uuid.Nil), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolderMessage(uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteClipFolderMessage(context.TODO(), uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteClipFolderMessage(uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteClipFolderMessage(context.TODO(), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -166,8 +167,8 @@ func TestRepositoryImpl_DeleteClipFolderMessage(t *testing.T) {
 		message := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		clipFolderMessage := mustMakeClipFolderMessage(t, repo, clipFolder.ID, message.ID)
 
-		if assert.NoError(repo.DeleteClipFolderMessage(clipFolderMessage.FolderID, clipFolderMessage.MessageID)) {
-			messages, _, err := repo.GetClipFolderMessages(clipFolderMessage.FolderID, repository.ClipFolderMessageQuery{})
+		if assert.NoError(repo.DeleteClipFolderMessage(context.TODO(), clipFolderMessage.FolderID, clipFolderMessage.MessageID)) {
+			messages, _, err := repo.GetClipFolderMessages(context.TODO(), clipFolderMessage.FolderID, repository.ClipFolderMessageQuery{})
 			assert.Equal([]*model.ClipFolderMessage{}, messages)
 			assert.NoError(err)
 		}
@@ -181,20 +182,20 @@ func TestRepositoryImpl_AddClipFolderMessage(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, err := repo.AddClipFolderMessage(uuid.Nil, uuid.Nil)
+		_, err := repo.AddClipFolderMessage(context.TODO(), uuid.Nil, uuid.Nil)
 		assert.EqualError(err, repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, err := repo.AddClipFolderMessage(uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()))
+		_, err := repo.AddClipFolderMessage(context.TODO(), uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, err := repo.AddClipFolderMessage(uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()))
+		_, err := repo.AddClipFolderMessage(context.TODO(), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -205,7 +206,7 @@ func TestRepositoryImpl_AddClipFolderMessage(t *testing.T) {
 		message := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		clipFolderMessage := mustMakeClipFolderMessage(t, repo, clipFolder.ID, message.ID)
 
-		_, err := repo.AddClipFolderMessage(clipFolderMessage.FolderID, clipFolderMessage.MessageID)
+		_, err := repo.AddClipFolderMessage(context.TODO(), clipFolderMessage.FolderID, clipFolderMessage.MessageID)
 		assert.EqualError(err, repository.ErrAlreadyExists.Error())
 	})
 
@@ -216,7 +217,7 @@ func TestRepositoryImpl_AddClipFolderMessage(t *testing.T) {
 		clipFolder := mustMakeClipFolder(t, repo, user.GetID(), rand, rand)
 		message := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 
-		cfm, err := repo.AddClipFolderMessage(clipFolder.ID, message.ID)
+		cfm, err := repo.AddClipFolderMessage(context.TODO(), clipFolder.ID, message.ID)
 
 		if assert.NoError(err) {
 			assert.Equal(message.ID, cfm.MessageID)
@@ -233,7 +234,7 @@ func TestRepositoryImpl_GetClipFoldersByUserID(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, err := repo.GetClipFoldersByUserID(uuid.Nil)
+		_, err := repo.GetClipFoldersByUserID(context.TODO(), uuid.Nil)
 		assert.EqualError(err, repository.ErrNilID.Error())
 	})
 	t.Run("success", func(t *testing.T) {
@@ -245,7 +246,7 @@ func TestRepositoryImpl_GetClipFoldersByUserID(t *testing.T) {
 			mustMakeClipFolder(t, repo, user.GetID(), rand, rand)
 		}
 		mustMakeClipFolder(t, repo, otherUser.GetID(), rand, rand)
-		clipFolders, err := repo.GetClipFoldersByUserID(user.GetID())
+		clipFolders, err := repo.GetClipFoldersByUserID(context.TODO(), user.GetID())
 		if assert.NoError(err) {
 			assert.Len(clipFolders, n)
 			for _, clipFolder := range clipFolders {
@@ -262,7 +263,7 @@ func TestRepositoryImpl_GetClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetClipFolder(uuid.Nil)
+		_, err := repo.GetClipFolder(context.TODO(), uuid.Nil)
 		assert.EqualError(err, repository.ErrNilID.Error())
 	})
 
@@ -270,7 +271,7 @@ func TestRepositoryImpl_GetClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetClipFolder(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetClipFolder(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -278,7 +279,7 @@ func TestRepositoryImpl_GetClipFolder(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetClipFolder(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetClipFolder(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -287,7 +288,7 @@ func TestRepositoryImpl_GetClipFolder(t *testing.T) {
 		assert := assert.New(t)
 
 		createdClipFolder := mustMakeClipFolder(t, repo, user.GetID(), rand, rand)
-		clipFolder, err := repo.GetClipFolder(createdClipFolder.ID)
+		clipFolder, err := repo.GetClipFolder(context.TODO(), createdClipFolder.ID)
 
 		if assert.NoError(err) {
 			assert.Equal(createdClipFolder.Description, clipFolder.Description)
@@ -305,21 +306,21 @@ func TestRepositoryImpl_GetClipFolderMessages(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, _, err := repo.GetClipFolderMessages(uuid.Nil, repository.ClipFolderMessageQuery{})
+		_, _, err := repo.GetClipFolderMessages(context.TODO(), uuid.Nil, repository.ClipFolderMessageQuery{})
 		assert.EqualError(err, repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, _, err := repo.GetClipFolderMessages(uuid.Must(uuid.NewV4()), repository.ClipFolderMessageQuery{})
+		_, _, err := repo.GetClipFolderMessages(context.TODO(), uuid.Must(uuid.NewV4()), repository.ClipFolderMessageQuery{})
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		_, _, err := repo.GetClipFolderMessages(uuid.Must(uuid.NewV7()), repository.ClipFolderMessageQuery{})
+		_, _, err := repo.GetClipFolderMessages(context.TODO(), uuid.Must(uuid.NewV7()), repository.ClipFolderMessageQuery{})
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -341,7 +342,7 @@ func TestRepositoryImpl_GetClipFolderMessages(t *testing.T) {
 		otherCreatedMessage := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		mustMakeClipFolderMessage(t, repo, otherCreatedClipFolder.ID, otherCreatedMessage.ID)
 
-		clipFolderMessages, more, err := repo.GetClipFolderMessages(createdClipFolder.ID, repository.ClipFolderMessageQuery{})
+		clipFolderMessages, more, err := repo.GetClipFolderMessages(context.TODO(), createdClipFolder.ID, repository.ClipFolderMessageQuery{})
 
 		if assert.NoError(err) {
 			assert.EqualValues(false, more)

--- a/repository/gorm/device.go
+++ b/repository/gorm/device.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 
@@ -10,7 +12,7 @@ import (
 )
 
 // RegisterDevice implements DeviceRepository interface.
-func (repo *Repository) RegisterDevice(userID uuid.UUID, token string) error {
+func (repo *Repository) RegisterDevice(ctx context.Context, userID uuid.UUID, token string) error {
 	if userID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -18,7 +20,7 @@ func (repo *Repository) RegisterDevice(userID uuid.UUID, token string) error {
 		return repository.ArgError("Token", "token is empty")
 	}
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var d model.Device
 		if err := tx.First(&d, &model.Device{Token: token}).Error; err == nil {
 			if d.UserID != userID {
@@ -38,9 +40,9 @@ func (repo *Repository) RegisterDevice(userID uuid.UUID, token string) error {
 }
 
 // GetDeviceTokens implements DeviceRepository interface.
-func (repo *Repository) GetDeviceTokens(userIDs set.UUID) (tokens map[uuid.UUID][]string, err error) {
+func (repo *Repository) GetDeviceTokens(ctx context.Context, userIDs set.UUID) (tokens map[uuid.UUID][]string, err error) {
 	var tmp []*model.Device
-	if err := repo.db.Where("user_id IN (?)", userIDs.StringArray()).Find(&tmp).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Where("user_id IN (?)", userIDs.StringArray()).Find(&tmp).Error; err != nil {
 		return nil, err
 	}
 
@@ -52,6 +54,6 @@ func (repo *Repository) GetDeviceTokens(userIDs set.UUID) (tokens map[uuid.UUID]
 }
 
 // DeleteDeviceTokens implements DeviceRepository interface.
-func (repo *Repository) DeleteDeviceTokens(tokens []string) error {
-	return repo.db.Where("token IN (?)", tokens).Delete(&model.Device{}).Error
+func (repo *Repository) DeleteDeviceTokens(ctx context.Context, tokens []string) error {
+	return repo.db.WithContext(ctx).Where("token IN (?)", tokens).Delete(&model.Device{}).Error
 }

--- a/repository/gorm/device_test.go
+++ b/repository/gorm/device_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -41,7 +42,7 @@ func TestRepositoryImpl_RegisterDevice(t *testing.T) {
 	}
 
 	for _, v := range cases {
-		err := repo.RegisterDevice(v.user, v.token)
+		err := repo.RegisterDevice(context.TODO(), v.user, v.token)
 		if v.error {
 			assert.Error(err)
 		} else {
@@ -69,19 +70,19 @@ func TestRepositoryImpl_DeleteDeviceTokens(t *testing.T) {
 	token6 := random2.AlphaNumeric(20)
 	token7 := random2.AlphaNumeric(20)
 
-	err := repo.RegisterDevice(id1, token1)
+	err := repo.RegisterDevice(context.TODO(), id1, token1)
 	require.NoError(err)
-	err = repo.RegisterDevice(id2, token2)
+	err = repo.RegisterDevice(context.TODO(), id2, token2)
 	require.NoError(err)
-	err = repo.RegisterDevice(id1, token3)
+	err = repo.RegisterDevice(context.TODO(), id1, token3)
 	require.NoError(err)
-	err = repo.RegisterDevice(id1, token4)
+	err = repo.RegisterDevice(context.TODO(), id1, token4)
 	require.NoError(err)
-	err = repo.RegisterDevice(id3, token5)
+	err = repo.RegisterDevice(context.TODO(), id3, token5)
 	require.NoError(err)
-	err = repo.RegisterDevice(id4, token6)
+	err = repo.RegisterDevice(context.TODO(), id4, token6)
 	require.NoError(err)
-	err = repo.RegisterDevice(id4, token7)
+	err = repo.RegisterDevice(context.TODO(), id4, token7)
 	require.NoError(err)
 
 	cases := []struct {
@@ -96,7 +97,7 @@ func TestRepositoryImpl_DeleteDeviceTokens(t *testing.T) {
 		{[]string{token3, token2, token6}, 0},
 	}
 	for _, v := range cases {
-		assert.NoError(repo.DeleteDeviceTokens(v.tokens))
+		assert.NoError(repo.DeleteDeviceTokens(context.TODO(), v.tokens))
 		assert.EqualValues(v.expect, count(t, getDB(repo).Model(model.Device{}).Where("user_id IN (?, ?, ?, ?)", id1, id2, id3, id4)))
 	}
 }
@@ -114,13 +115,13 @@ func TestRepositoryImpl_GetDeviceTokens(t *testing.T) {
 	token3 := random2.AlphaNumeric(20)
 	token4 := random2.AlphaNumeric(20)
 
-	err := repo.RegisterDevice(id1, token1)
+	err := repo.RegisterDevice(context.TODO(), id1, token1)
 	require.NoError(err)
-	err = repo.RegisterDevice(id2, token2)
+	err = repo.RegisterDevice(context.TODO(), id2, token2)
 	require.NoError(err)
-	err = repo.RegisterDevice(id1, token3)
+	err = repo.RegisterDevice(context.TODO(), id1, token3)
 	require.NoError(err)
-	err = repo.RegisterDevice(id3, token4)
+	err = repo.RegisterDevice(context.TODO(), id3, token4)
 	require.NoError(err)
 
 	cases := []struct {
@@ -141,7 +142,7 @@ func TestRepositoryImpl_GetDeviceTokens(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			t.Parallel()
 			assert := assert.New(t)
-			devs, err := repo.GetDeviceTokens(set.UUIDSetFromArray(v.users))
+			devs, err := repo.GetDeviceTokens(context.TODO(), set.UUIDSetFromArray(v.users))
 			if assert.NoError(err) {
 				n := 0
 				for _, arr := range devs {

--- a/repository/gorm/file.go
+++ b/repository/gorm/file.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 
@@ -9,9 +11,9 @@ import (
 )
 
 // GetFileMetas implements FileRepository interface.
-func (repo *Repository) GetFileMetas(q repository.FilesQuery) (result []*model.FileMeta, more bool, err error) {
+func (repo *Repository) GetFileMetas(ctx context.Context, q repository.FilesQuery) (result []*model.FileMeta, more bool, err error) {
 	files := make([]*model.FileMeta, 0)
-	tx := repo.db.
+	tx := repo.db.WithContext(ctx).
 		Where("files.type = ?", q.Type.String()).
 		Scopes(filePreloads)
 
@@ -67,11 +69,11 @@ func (repo *Repository) GetFileMetas(q repository.FilesQuery) (result []*model.F
 	return files, false, err
 }
 
-func (repo *Repository) SaveFileMeta(meta *model.FileMeta, acl []*model.FileACLEntry) error {
+func (repo *Repository) SaveFileMeta(ctx context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error {
 	if meta == nil || meta.ID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Create files, files_thumbnails
 		if err := tx.Create(meta).Error; err != nil {
 			return err
@@ -84,12 +86,12 @@ func (repo *Repository) SaveFileMeta(meta *model.FileMeta, acl []*model.FileACLE
 }
 
 // GetFileMeta implements FileRepository interface.
-func (repo *Repository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error) {
+func (repo *Repository) GetFileMeta(ctx context.Context, fileID uuid.UUID) (*model.FileMeta, error) {
 	if fileID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	f := &model.FileMeta{}
-	if err := repo.db.
+	if err := repo.db.WithContext(ctx).
 		Scopes(filePreloads).
 		First(f, &model.FileMeta{ID: fileID}).
 		Error; err != nil {
@@ -99,24 +101,24 @@ func (repo *Repository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error) {
 }
 
 // DeleteFileMeta implements FileRepository interface.
-func (repo *Repository) DeleteFileMeta(fileID uuid.UUID) error {
+func (repo *Repository) DeleteFileMeta(ctx context.Context, fileID uuid.UUID) error {
 	if fileID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
-	if err := repo.db.Delete(&model.FileMeta{ID: fileID}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Delete(&model.FileMeta{ID: fileID}).Error; err != nil {
 		return err
 	}
-	return repo.db.Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID}).Error
+	return repo.db.WithContext(ctx).Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID}).Error
 }
 
 // IsFileAccessible implements FileRepository interface.
-func (repo *Repository) IsFileAccessible(fileID, userID uuid.UUID) (bool, error) {
+func (repo *Repository) IsFileAccessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error) {
 	var result struct {
 		Allow int
 		Deny  int
 	}
-	err := repo.db.
+	err := repo.db.WithContext(ctx).
 		Model(&model.FileACLEntry{}).
 		Select("COUNT(allow = TRUE OR NULL) AS allow, COUNT(allow = FALSE OR NULL) AS deny").
 		Where("file_id = ? AND user_id IN (?)", fileID, []uuid.UUID{userID, uuid.Nil}).
@@ -133,11 +135,11 @@ func filePreloads(db *gorm.DB) *gorm.DB {
 }
 
 // DeleteFileThumbnail implements FileRepository interface.
-func (repo *Repository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
+func (repo *Repository) DeleteFileThumbnail(ctx context.Context, fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
 	if fileID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	if err := repo.db.Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID, Type: thumbnailType}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Delete(&model.FileThumbnail{}, &model.FileThumbnail{FileID: fileID, Type: thumbnailType}).Error; err != nil {
 		return err
 	}
 	return nil

--- a/repository/gorm/file_test.go
+++ b/repository/gorm/file_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestGormRepository_SaveFileMeta(t *testing.T) {
 	t.Run("nil file", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.SaveFileMeta(nil, nil))
+		assert.Error(t, repo.SaveFileMeta(context.TODO(), nil, nil))
 	})
 
 	t.Run("success with UUIDv4", func(t *testing.T) {
@@ -36,7 +37,7 @@ func TestGormRepository_SaveFileMeta(t *testing.T) {
 			{UserID: uuid.Nil, Allow: true},
 		}
 
-		err := repo.SaveFileMeta(meta, acl)
+		err := repo.SaveFileMeta(context.TODO(), meta, acl)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, meta.CreatedAt)
 			assert.False(t, meta.DeletedAt.Valid)
@@ -56,7 +57,7 @@ func TestGormRepository_SaveFileMeta(t *testing.T) {
 			{UserID: uuid.Nil, Allow: true},
 		}
 
-		err := repo.SaveFileMeta(meta, acl)
+		err := repo.SaveFileMeta(context.TODO(), meta, acl)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, meta.CreatedAt)
 			assert.False(t, meta.DeletedAt.Valid)
@@ -73,21 +74,21 @@ func TestGormRepository_GetFileMeta(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetFileMeta(uuid.Nil)
+		_, err := repo.GetFileMeta(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetFileMeta(uuid.NewV3(uuid.Nil, "not found"))
+		_, err := repo.GetFileMeta(context.TODO(), uuid.NewV3(uuid.Nil, "not found"))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("found", func(t *testing.T) {
 		t.Parallel()
 
-		meta, err := repo.GetFileMeta(f.ID)
+		meta, err := repo.GetFileMeta(context.TODO(), f.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, f.ID, meta.ID)
 			assert.EqualValues(t, 1, len(meta.Thumbnails))
@@ -103,7 +104,7 @@ func TestGormRepository_DeleteFileMeta(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		err := repo.DeleteFileMeta(uuid.Nil)
+		err := repo.DeleteFileMeta(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNilID.Error())
 	})
 
@@ -111,7 +112,7 @@ func TestGormRepository_DeleteFileMeta(t *testing.T) {
 		t.Parallel()
 		f := mustMakeDummyFile(t, repo, false)
 
-		err := repo.DeleteFileMeta(f.ID)
+		err := repo.DeleteFileMeta(context.TODO(), f.ID)
 		if assert.NoError(t, err) {
 			assert.Equal(t, 0, count(t, getDB(repo).Model(&model.FileMeta{}).Where(&model.FileMeta{ID: f.ID})))
 		}
@@ -120,7 +121,7 @@ func TestGormRepository_DeleteFileMeta(t *testing.T) {
 	t.Run("success (noop)", func(t *testing.T) {
 		t.Parallel()
 
-		err := repo.DeleteFileMeta(uuid.NewV3(uuid.Nil, "not exists"))
+		err := repo.DeleteFileMeta(context.TODO(), uuid.NewV3(uuid.Nil, "not exists"))
 		assert.NoError(t, err)
 	})
 }
@@ -132,7 +133,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 	t.Run("file which doesn't exist", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.IsFileAccessible(uuid.NewV3(uuid.Nil, "not exists"), uuid.Nil)
+		ok, err := repo.IsFileAccessible(context.TODO(), uuid.NewV3(uuid.Nil, "not exists"), uuid.Nil)
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}
@@ -141,7 +142,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.IsFileAccessible(uuid.Nil, uuid.Nil)
+		ok, err := repo.IsFileAccessible(context.TODO(), uuid.Nil, uuid.Nil)
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}
@@ -154,7 +155,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any users", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(f.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), f.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -163,7 +164,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("a certain user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(f.ID, uuid.NewV3(uuid.Nil, "u1"))
+			ok, err := repo.IsFileAccessible(context.TODO(), f.ID, uuid.NewV3(uuid.Nil, "u1"))
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -181,7 +182,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: user.GetID(), Allow: true},
 		})
 		require.NoError(t, err)
@@ -189,7 +190,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any users", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -198,7 +199,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -208,7 +209,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			t.Parallel()
 
 			user := mustMakeUser(t, repo, rand, false)
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -226,7 +227,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: user.GetID(), Allow: true},
 		})
 		require.NoError(t, err)
@@ -234,7 +235,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any users", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -243,7 +244,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -253,7 +254,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			t.Parallel()
 
 			user := mustMakeUser(t, repo, rand, false)
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -272,7 +273,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: user.GetID(), Allow: true},
 			{UserID: user2.GetID(), Allow: true},
 		})
@@ -281,7 +282,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any users", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -290,7 +291,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -299,7 +300,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user2", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user2.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user2.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -309,7 +310,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			t.Parallel()
 
 			user := mustMakeUser(t, repo, rand, false)
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -327,7 +328,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: user.GetID(), Allow: true},
 			{UserID: user2.GetID(), Allow: true},
 		})
@@ -336,7 +337,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any users", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -345,7 +346,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -354,7 +355,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user2", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user2.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user2.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -364,7 +365,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			t.Parallel()
 
 			user := mustMakeUser(t, repo, rand, false)
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -383,7 +384,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: uuid.Nil, Allow: true},
 			{UserID: deniedUser.GetID(), Allow: false},
 		})
@@ -392,7 +393,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -401,7 +402,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -410,7 +411,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("denied user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, deniedUser.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, deniedUser.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -429,7 +430,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 			Hash: "d41d8cd98f00b204e9800998ecf8427e",
 			Type: model.FileTypeUserFile,
 		}
-		err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+		err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 			{UserID: uuid.Nil, Allow: true},
 			{UserID: deniedUser.GetID(), Allow: false},
 		})
@@ -438,7 +439,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("any user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, uuid.Nil)
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, uuid.Nil)
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -447,7 +448,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("allowed user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, user.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, user.GetID())
 			if assert.NoError(t, err) {
 				assert.True(t, ok)
 			}
@@ -456,7 +457,7 @@ func TestGormRepository_IsFileAccessible(t *testing.T) {
 		t.Run("denied user", func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := repo.IsFileAccessible(meta.ID, deniedUser.GetID())
+			ok, err := repo.IsFileAccessible(context.TODO(), meta.ID, deniedUser.GetID())
 			if assert.NoError(t, err) {
 				assert.False(t, ok)
 			}
@@ -528,7 +529,7 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			if !tt.createsFile {
-				err := repo.DeleteFileThumbnail(uuid.Nil, tt.thumbnailTypeToDelete)
+				err := repo.DeleteFileThumbnail(context.TODO(), uuid.Nil, tt.thumbnailTypeToDelete)
 				assert.EqualError(t, err, repository.ErrNilID.Error())
 				return
 			}
@@ -542,23 +543,23 @@ func TestGormRepository_DeleteFileThumbnail(t *testing.T) {
 				} else {
 					nonExistentID = uuid.Must(uuid.NewV7())
 				}
-				err := repo.DeleteFileThumbnail(nonExistentID, tt.thumbnailTypeToDelete)
+				err := repo.DeleteFileThumbnail(context.TODO(), nonExistentID, tt.thumbnailTypeToDelete)
 				assert.NoError(t, err)
-				ff, err := repo.GetFileMeta(f.ID)
+				ff, err := repo.GetFileMeta(context.TODO(), f.ID)
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
 				return
 			}
 
-			err := repo.DeleteFileThumbnail(f.ID, tt.thumbnailTypeToDelete)
+			err := repo.DeleteFileThumbnail(context.TODO(), f.ID, tt.thumbnailTypeToDelete)
 			assert.NoError(t, err)
 			if !slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete)) { // f.Thumbnails が tt.thumbnailTypeToDelete を含まない場合, 変更なしを検証
-				ff, err := repo.GetFileMeta(f.ID)
+				ff, err := repo.GetFileMeta(context.TODO(), f.ID)
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, f.Thumbnails, ff.Thumbnails)
 				return
 			}
-			f, err = repo.GetFileMeta(f.ID)
+			f, err = repo.GetFileMeta(context.TODO(), f.ID)
 			assert.NoError(t, err)
 			assert.False(t, slices.ContainsFunc(f.Thumbnails, getThumbnailEqualityComparerByType(tt.thumbnailTypeToDelete))) // f.Thumbnails が tt.thumbnailTypeToDelete を含まない
 		})

--- a/repository/gorm/message.go
+++ b/repository/gorm/message.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -17,7 +18,7 @@ import (
 )
 
 // CreateMessage implements MessageRepository interface.
-func (repo *Repository) CreateMessage(userID, channelID uuid.UUID, text string) (*model.Message, error) {
+func (repo *Repository) CreateMessage(ctx context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error) {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -29,7 +30,7 @@ func (repo *Repository) CreateMessage(userID, channelID uuid.UUID, text string) 
 		Text:      text,
 		Stamps:    []model.MessageStamp{},
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(m).Error; err != nil {
 			return err
 		}
@@ -72,7 +73,7 @@ func (repo *Repository) CreateMessage(userID, channelID uuid.UUID, text string) 
 }
 
 // UpdateMessage implements MessageRepository interface.
-func (repo *Repository) UpdateMessage(messageID uuid.UUID, text string) error {
+func (repo *Repository) UpdateMessage(ctx context.Context, messageID uuid.UUID, text string) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -81,7 +82,7 @@ func (repo *Repository) UpdateMessage(messageID uuid.UUID, text string) error {
 		oldMes model.Message
 		newMes model.Message
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&oldMes, &model.Message{ID: messageID}).Error; err != nil {
 			return convertError(err)
 		}
@@ -119,7 +120,7 @@ func (repo *Repository) UpdateMessage(messageID uuid.UUID, text string) error {
 }
 
 // DeleteMessage implements MessageRepository interface.
-func (repo *Repository) DeleteMessage(messageID uuid.UUID) error {
+func (repo *Repository) DeleteMessage(ctx context.Context, messageID uuid.UUID) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -128,7 +129,7 @@ func (repo *Repository) DeleteMessage(messageID uuid.UUID) error {
 		m       model.Message
 		unreads []*model.Unread
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where(&model.Message{ID: messageID}).First(&m).Error; err != nil {
 			return convertError(err)
 		}
@@ -182,22 +183,22 @@ func (repo *Repository) DeleteMessage(messageID uuid.UUID) error {
 }
 
 // GetMessageByID implements MessageRepository interface.
-func (repo *Repository) GetMessageByID(messageID uuid.UUID) (*model.Message, error) {
+func (repo *Repository) GetMessageByID(ctx context.Context, messageID uuid.UUID) (*model.Message, error) {
 	if messageID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	message := &model.Message{}
-	if err := repo.db.Scopes(messagePreloads).Where(&model.Message{ID: messageID}).Take(message).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Scopes(messagePreloads).Where(&model.Message{ID: messageID}).Take(message).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return message, nil
 }
 
 // GetMessages implements MessageRepository interface.
-func (repo *Repository) GetMessages(query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
+func (repo *Repository) GetMessages(ctx context.Context, query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
 	messages = make([]*model.Message, 0)
 
-	tx := repo.db
+	tx := repo.db.WithContext(ctx)
 	if !query.DisablePreload {
 		tx = tx.Scopes(messagePreloads)
 	}
@@ -263,8 +264,9 @@ func (repo *Repository) GetMessages(query repository.MessagesQuery) (messages []
 }
 
 // GetUpdatedMessagesAfter implements MessageRepository interface.
-func (repo *Repository) GetUpdatedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *Repository) GetUpdatedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	err = repo.db.
+		WithContext(ctx).
 		Raw("SELECT * FROM `messages` USE INDEX (idx_messages_deleted_at_updated_at) WHERE `messages`.`deleted_at` IS NULL AND `messages`.`updated_at` > ? ORDER BY `messages`.`updated_at` LIMIT ?", after, limit+1).
 		Scan(&messages).
 		Error
@@ -277,8 +279,9 @@ func (repo *Repository) GetUpdatedMessagesAfter(after time.Time, limit int) (mes
 }
 
 // GetDeletedMessagesAfter implements MessageRepository interface.
-func (repo *Repository) GetDeletedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *Repository) GetDeletedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	err = repo.db.
+		WithContext(ctx).
 		Raw("SELECT * FROM `messages` USE INDEX (idx_messages_deleted_at_updated_at) WHERE `messages`.`deleted_at` > ? ORDER BY `messages`.`deleted_at` LIMIT ?", after, limit+1).
 		Scan(&messages).
 		Error
@@ -291,7 +294,7 @@ func (repo *Repository) GetDeletedMessagesAfter(after time.Time, limit int) (mes
 }
 
 // SetMessageUnreads implements MessageRepository interface.
-func (repo *Repository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
+func (repo *Repository) SetMessageUnreads(ctx context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -308,7 +311,7 @@ func (repo *Repository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, 
 	}
 
 	unreadListToInsert := make([]*model.Unread, 0, len(userNoticeableMap))
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var msg model.Message
 		err := tx.First(&msg, &model.Message{ID: messageID}).Error
 		if err != nil {
@@ -390,12 +393,13 @@ func (repo *Repository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, 
 }
 
 // GetUnreadMessagesByUserID implements MessageRepository interface.
-func (repo *Repository) GetUnreadMessagesByUserID(userID uuid.UUID) (unreads []*model.Message, err error) {
+func (repo *Repository) GetUnreadMessagesByUserID(ctx context.Context, userID uuid.UUID) (unreads []*model.Message, err error) {
 	unreads = make([]*model.Message, 0)
 	if userID == uuid.Nil {
 		return unreads, nil
 	}
 	err = repo.db.
+		WithContext(ctx).
 		Joins("INNER JOIN unreads ON unreads.message_id = messages.id AND unreads.user_id = ?", userID.String()).
 		Order("messages.created_at").
 		Find(&unreads).
@@ -404,12 +408,12 @@ func (repo *Repository) GetUnreadMessagesByUserID(userID uuid.UUID) (unreads []*
 }
 
 // GetUserUnreadChannels implements MessageRepository interface.
-func (repo *Repository) GetUserUnreadChannels(userID uuid.UUID) ([]*repository.UserUnreadChannel, error) {
+func (repo *Repository) GetUserUnreadChannels(ctx context.Context, userID uuid.UUID) ([]*repository.UserUnreadChannel, error) {
 	res := make([]*repository.UserUnreadChannel, 0)
 	if userID == uuid.Nil {
 		return res, nil
 	}
-	return res, repo.db.Raw(`
+	return res, repo.db.WithContext(ctx).Raw(`
 		SELECT
 			channel_id,
 			COUNT(message_id) AS count,
@@ -437,11 +441,11 @@ func (repo *Repository) GetUserUnreadChannels(userID uuid.UUID) ([]*repository.U
 }
 
 // DeleteUnreadsByChannelID implements MessageRepository interface.
-func (repo *Repository) DeleteUnreadsByChannelID(channelID, userID uuid.UUID) error {
+func (repo *Repository) DeleteUnreadsByChannelID(ctx context.Context, channelID, userID uuid.UUID) error {
 	if channelID == uuid.Nil || userID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	result := repo.db.Where("user_id = ?", userID).Where("channel_id = ?", channelID).Delete(&model.Unread{})
+	result := repo.db.WithContext(ctx).Where("user_id = ?", userID).Where("channel_id = ?", channelID).Delete(&model.Unread{})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -459,10 +463,11 @@ func (repo *Repository) DeleteUnreadsByChannelID(channelID, userID uuid.UUID) er
 }
 
 // GetChannelLatestMessages implements MessageRepository interface.
-func (repo *Repository) GetChannelLatestMessages(query repository.ChannelLatestMessagesQuery) ([]*model.Message, error) {
+func (repo *Repository) GetChannelLatestMessages(ctx context.Context, query repository.ChannelLatestMessagesQuery) ([]*model.Message, error) {
 	var messages []*model.Message
 
 	tx := repo.db.
+		WithContext(ctx).
 		Unscoped().
 		Select("m.id, m.user_id, m.channel_id, m.text, m.created_at, m.updated_at, m.deleted_at").
 		Table("channel_latest_messages clm").
@@ -472,7 +477,7 @@ func (repo *Repository) GetChannelLatestMessages(query repository.ChannelLatestM
 		Order("clm.date_time DESC")
 
 	if query.SubscribedByUser.Valid {
-		tx = tx.Where("c.is_forced = TRUE OR c.id IN (?)", repo.db.Table("users_subscribe_channels").Select("channel_id").Where("user_id", query.SubscribedByUser.V))
+		tx = tx.Where("c.is_forced = TRUE OR c.id IN (?)", repo.db.WithContext(ctx).Table("users_subscribe_channels").Select("channel_id").Where("user_id", query.SubscribedByUser.V))
 	}
 
 	if query.Limit > 0 {
@@ -487,12 +492,13 @@ func (repo *Repository) GetChannelLatestMessages(query repository.ChannelLatestM
 }
 
 // AddStampToMessage implements MessageRepository interface.
-func (repo *Repository) AddStampToMessage(messageID, stampID, userID uuid.UUID, count int) (ms *model.MessageStamp, err error) {
+func (repo *Repository) AddStampToMessage(ctx context.Context, messageID, stampID, userID uuid.UUID, count int) (ms *model.MessageStamp, err error) {
 	if messageID == uuid.Nil || stampID == uuid.Nil || userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 
 	err = repo.db.
+		WithContext(ctx).
 		Clauses(clause.OnConflict{
 			DoUpdates: clause.Assignments(map[string]interface{}{
 				"count":      gorm.Expr(fmt.Sprintf("count + %d", count)),
@@ -507,7 +513,7 @@ func (repo *Repository) AddStampToMessage(messageID, stampID, userID uuid.UUID, 
 
 	// 楽観的に取得し直す。
 	ms = &model.MessageStamp{}
-	if err := repo.db.Take(ms, &model.MessageStamp{MessageID: messageID, StampID: stampID, UserID: userID}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(ms, &model.MessageStamp{MessageID: messageID, StampID: stampID, UserID: userID}).Error; err != nil {
 		return nil, err
 	}
 	repo.hub.Publish(hub.Message{
@@ -524,11 +530,11 @@ func (repo *Repository) AddStampToMessage(messageID, stampID, userID uuid.UUID, 
 }
 
 // RemoveStampFromMessage implements MessageRepository interface.
-func (repo *Repository) RemoveStampFromMessage(messageID, stampID, userID uuid.UUID) (err error) {
+func (repo *Repository) RemoveStampFromMessage(ctx context.Context, messageID, stampID, userID uuid.UUID) (err error) {
 	if messageID == uuid.Nil || stampID == uuid.Nil || userID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	result := repo.db.Delete(&model.MessageStamp{}, &model.MessageStamp{MessageID: messageID, StampID: stampID, UserID: userID})
+	result := repo.db.WithContext(ctx).Delete(&model.MessageStamp{}, &model.MessageStamp{MessageID: messageID, StampID: stampID, UserID: userID})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/repository/gorm/message_report.go
+++ b/repository/gorm/message_report.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -9,7 +11,7 @@ import (
 )
 
 // CreateMessageReport implements MessageReportRepository interface.
-func (repo *Repository) CreateMessageReport(messageID, reporterID uuid.UUID, reason string) error {
+func (repo *Repository) CreateMessageReport(ctx context.Context, messageID, reporterID uuid.UUID, reason string) error {
 	// nil check
 	if messageID == uuid.Nil || reporterID == uuid.Nil {
 		return repository.ErrNilID
@@ -22,7 +24,7 @@ func (repo *Repository) CreateMessageReport(messageID, reporterID uuid.UUID, rea
 		Reporter:  reporterID,
 		Reason:    reason,
 	}
-	if err := repo.db.Create(r).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Create(r).Error; err != nil {
 		if gormutil.IsMySQLDuplicatedRecordErr(err) {
 			return repository.ErrAlreadyExists
 		}
@@ -32,28 +34,28 @@ func (repo *Repository) CreateMessageReport(messageID, reporterID uuid.UUID, rea
 }
 
 // GetMessageReports implements MessageReportRepository interface.
-func (repo *Repository) GetMessageReports(offset, limit int) (arr []*model.MessageReport, err error) {
+func (repo *Repository) GetMessageReports(ctx context.Context, offset, limit int) (arr []*model.MessageReport, err error) {
 	arr = make([]*model.MessageReport, 0)
-	err = repo.db.Scopes(gormutil.LimitAndOffset(limit, offset)).Order("created_at").Find(&arr).Error
+	err = repo.db.WithContext(ctx).Scopes(gormutil.LimitAndOffset(limit, offset)).Order("created_at").Find(&arr).Error
 	return arr, err
 }
 
 // GetMessageReportsByMessageID implements MessageReportRepository interface.
-func (repo *Repository) GetMessageReportsByMessageID(messageID uuid.UUID) (arr []*model.MessageReport, err error) {
+func (repo *Repository) GetMessageReportsByMessageID(ctx context.Context, messageID uuid.UUID) (arr []*model.MessageReport, err error) {
 	arr = make([]*model.MessageReport, 0)
 	if messageID == uuid.Nil {
 		return arr, nil
 	}
-	err = repo.db.Where(&model.MessageReport{MessageID: messageID}).Order("created_at").Find(&arr).Error
+	err = repo.db.WithContext(ctx).Where(&model.MessageReport{MessageID: messageID}).Order("created_at").Find(&arr).Error
 	return arr, err
 }
 
 // GetMessageReportsByReporterID implements MessageReportRepository interface.
-func (repo *Repository) GetMessageReportsByReporterID(reporterID uuid.UUID) (arr []*model.MessageReport, err error) {
+func (repo *Repository) GetMessageReportsByReporterID(ctx context.Context, reporterID uuid.UUID) (arr []*model.MessageReport, err error) {
 	arr = make([]*model.MessageReport, 0)
 	if reporterID == uuid.Nil {
 		return arr, nil
 	}
-	err = repo.db.Where(&model.MessageReport{Reporter: reporterID}).Order("created_at").Find(&arr).Error
+	err = repo.db.WithContext(ctx).Where(&model.MessageReport{Reporter: reporterID}).Order("created_at").Find(&arr).Error
 	return arr, err
 }

--- a/repository/gorm/message_test.go
+++ b/repository/gorm/message_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -135,7 +136,7 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	ch1 := mustMakeChannel(t, repo, rand)
 	ch2 := mustMakeChannel(t, repo, rand)
 
-	_, _, err := repo.ChangeChannelSubscription(ch1.ID, repository.ChangeChannelSubscriptionArgs{
+	_, _, err := repo.ChangeChannelSubscription(context.TODO(), ch1.ID, repository.ChangeChannelSubscriptionArgs{
 		Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{
 			user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 		},

--- a/repository/gorm/message_test.go
+++ b/repository/gorm/message_test.go
@@ -20,14 +20,14 @@ func TestRepositoryImpl_CreateMessage(t *testing.T) {
 	t.Run("failures 1", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateMessage(user.GetID(), uuid.Nil, "a")
+		_, err := repo.CreateMessage(context.TODO(), user.GetID(), uuid.Nil, "a")
 		assert.Error(t, err)
 	})
 
 	t.Run("failures 2", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateMessage(uuid.Nil, channel.ID, "a")
+		_, err := repo.CreateMessage(context.TODO(), uuid.Nil, channel.ID, "a")
 		assert.Error(t, err)
 	})
 
@@ -35,7 +35,7 @@ func TestRepositoryImpl_CreateMessage(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		m, err := repo.CreateMessage(user.GetID(), channel.ID, "test")
+		m, err := repo.CreateMessage(context.TODO(), user.GetID(), channel.ID, "test")
 		if assert.NoError(err) {
 			assert.NotZero(m.ID)
 			assert.Equal(user.GetID(), m.UserID)
@@ -46,7 +46,7 @@ func TestRepositoryImpl_CreateMessage(t *testing.T) {
 			assert.False(m.DeletedAt.Valid)
 		}
 
-		m, err = repo.CreateMessage(user.GetID(), channel.ID, "")
+		m, err = repo.CreateMessage(context.TODO(), user.GetID(), channel.ID, "")
 		if assert.NoError(err) {
 			assert.NotZero(m.ID)
 			assert.Equal(user.GetID(), m.UserID)
@@ -62,7 +62,7 @@ func TestRepositoryImpl_CreateMessage(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		m, err := repo.CreateMessage(user.GetID(), channel.ID, "")
+		m, err := repo.CreateMessage(context.TODO(), user.GetID(), channel.ID, "")
 		if assert.NoError(err) {
 			assert.NotZero(m.ID)
 			assert.Equal(user.GetID(), m.UserID)
@@ -82,12 +82,12 @@ func TestRepositoryImpl_UpdateMessage(t *testing.T) {
 	m := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 	originalText := m.Text
 
-	assert.EqualError(repo.UpdateMessage(uuid.Must(uuid.NewV4()), "new message"), repository.ErrNotFound.Error())
-	assert.EqualError(repo.UpdateMessage(uuid.Must(uuid.NewV7()), "new message"), repository.ErrNotFound.Error())
-	assert.EqualError(repo.UpdateMessage(uuid.Nil, "new message"), repository.ErrNilID.Error())
-	assert.NoError(repo.UpdateMessage(m.ID, "new message"))
+	assert.EqualError(repo.UpdateMessage(context.TODO(), uuid.Must(uuid.NewV4()), "new message"), repository.ErrNotFound.Error())
+	assert.EqualError(repo.UpdateMessage(context.TODO(), uuid.Must(uuid.NewV7()), "new message"), repository.ErrNotFound.Error())
+	assert.EqualError(repo.UpdateMessage(context.TODO(), uuid.Nil, "new message"), repository.ErrNilID.Error())
+	assert.NoError(repo.UpdateMessage(context.TODO(), m.ID, "new message"))
 
-	m, err := repo.GetMessageByID(m.ID)
+	m, err := repo.GetMessageByID(context.TODO(), m.ID)
 	if assert.NoError(err) {
 		assert.Equal("new message", m.Text)
 		assert.Equal(1, count(t, getDB(repo).Model(&model.ArchivedMessage{}).Where(&model.ArchivedMessage{MessageID: m.ID, Text: originalText})))
@@ -100,13 +100,13 @@ func TestRepositoryImpl_DeleteMessage(t *testing.T) {
 
 	m := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 
-	assert.EqualError(repo.DeleteMessage(uuid.Nil), repository.ErrNilID.Error())
+	assert.EqualError(repo.DeleteMessage(context.TODO(), uuid.Nil), repository.ErrNilID.Error())
 
-	if assert.NoError(repo.DeleteMessage(m.ID)) {
-		_, err := repo.GetMessageByID(m.ID)
+	if assert.NoError(repo.DeleteMessage(context.TODO(), m.ID)) {
+		_, err := repo.GetMessageByID(context.TODO(), m.ID)
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	}
-	assert.EqualError(repo.DeleteMessage(m.ID), repository.ErrNotFound.Error())
+	assert.EqualError(repo.DeleteMessage(context.TODO(), m.ID), repository.ErrNotFound.Error())
 }
 
 func TestRepositoryImpl_GetMessageByID(t *testing.T) {
@@ -115,18 +115,18 @@ func TestRepositoryImpl_GetMessageByID(t *testing.T) {
 
 	m := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 
-	r, err := repo.GetMessageByID(m.ID)
+	r, err := repo.GetMessageByID(context.TODO(), m.ID)
 	if assert.NoError(err) {
 		assert.Equal(m.Text, r.Text)
 	}
 
-	_, err = repo.GetMessageByID(uuid.Nil)
+	_, err = repo.GetMessageByID(context.TODO(), uuid.Nil)
 	assert.Error(err)
 
-	_, err = repo.GetMessageByID(uuid.Must(uuid.NewV4()))
+	_, err = repo.GetMessageByID(context.TODO(), uuid.Must(uuid.NewV4()))
 	assert.Error(err)
 
-	_, err = repo.GetMessageByID(uuid.Must(uuid.NewV7()))
+	_, err = repo.GetMessageByID(context.TODO(), uuid.Must(uuid.NewV7()))
 	assert.Error(err)
 }
 
@@ -164,7 +164,7 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	t.Run("id in", func(t *testing.T) {
 		t.Parallel()
 
-		messages, more, err := repo.GetMessages(repository.MessagesQuery{
+		messages, more, err := repo.GetMessages(context.TODO(), repository.MessagesQuery{
 			IDIn: optional.From([]uuid.UUID{m6.ID, latestCh1Msg.ID}),
 		})
 
@@ -178,7 +178,7 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	t.Run("activity all", func(t *testing.T) {
 		t.Parallel()
 
-		messages, more, err := repo.GetMessages(repository.MessagesQuery{
+		messages, more, err := repo.GetMessages(context.TODO(), repository.MessagesQuery{
 			Since:          optional.From(time.Now().Add(-7 * 24 * time.Hour)),
 			Limit:          50,
 			ExcludeDMs:     true,
@@ -196,7 +196,7 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	t.Run("activity all with limit", func(t *testing.T) {
 		t.Parallel()
 
-		messages, more, err := repo.GetMessages(repository.MessagesQuery{
+		messages, more, err := repo.GetMessages(context.TODO(), repository.MessagesQuery{
 			Since:          optional.From(time.Now().Add(-7 * 24 * time.Hour)),
 			Limit:          5,
 			ExcludeDMs:     true,
@@ -214,7 +214,7 @@ func TestRepositoryImpl_GetMessages(t *testing.T) {
 	t.Run("activity subscription", func(t *testing.T) {
 		t.Parallel()
 
-		messages, more, err := repo.GetMessages(repository.MessagesQuery{
+		messages, more, err := repo.GetMessages(context.TODO(), repository.MessagesQuery{
 			Since:                    optional.From(time.Now().Add(-7 * 24 * time.Hour)),
 			Limit:                    50,
 			ExcludeDMs:               true,
@@ -238,9 +238,9 @@ func TestRepositoryImpl_SetMessageUnreads(t *testing.T) {
 
 	m := mustMakeMessage(t, repo, user1.GetID(), channel.ID)
 
-	assert.NoError(repo.SetMessageUnreads(nil, m.ID))
-	assert.Error(repo.SetMessageUnreads(map[uuid.UUID]bool{uuid.Nil: true}, uuid.Nil))
-	if assert.NoError(repo.SetMessageUnreads(map[uuid.UUID]bool{user1.GetID(): true, user2.GetID(): false}, m.ID)) {
+	assert.NoError(repo.SetMessageUnreads(context.TODO(), nil, m.ID))
+	assert.Error(repo.SetMessageUnreads(context.TODO(), map[uuid.UUID]bool{uuid.Nil: true}, uuid.Nil))
+	if assert.NoError(repo.SetMessageUnreads(context.TODO(), map[uuid.UUID]bool{user1.GetID(): true, user2.GetID(): false}, m.ID)) {
 		assert.Equal(1, count(t, getDB(repo).Model(model.Unread{}).Where(model.Unread{UserID: user1.GetID()})))
 		assert.Equal(1, count(t, getDB(repo).Model(model.Unread{}).Where(model.Unread{UserID: user2.GetID()})))
 		var messageCreatedAt time.Time
@@ -255,7 +255,7 @@ func TestRepositoryImpl_SetMessageUnreads(t *testing.T) {
 		assert.Equal(false, noticeable)
 
 	}
-	if assert.NoError(repo.SetMessageUnreads(map[uuid.UUID]bool{user1.GetID(): false, user2.GetID(): true, user3.GetID(): false}, m.ID)) {
+	if assert.NoError(repo.SetMessageUnreads(context.TODO(), map[uuid.UUID]bool{user1.GetID(): false, user2.GetID(): true, user3.GetID(): false}, m.ID)) {
 		var noticeable bool
 		assert.NoError(getDB(repo).Model(model.Unread{}).Where(model.Unread{UserID: user1.GetID()}).Select("noticeable").Row().Scan(&noticeable))
 		assert.Equal(false, noticeable)
@@ -274,10 +274,10 @@ func TestRepositoryImpl_GetUnreadMessagesByUserID(t *testing.T) {
 		mustMakeMessageUnread(t, repo, user.GetID(), mustMakeMessage(t, repo, user.GetID(), channel.ID).ID)
 	}
 
-	if unreads, err := repo.GetUnreadMessagesByUserID(user.GetID()); assert.NoError(err) {
+	if unreads, err := repo.GetUnreadMessagesByUserID(context.TODO(), user.GetID()); assert.NoError(err) {
 		assert.Len(unreads, 10)
 	}
-	if unreads, err := repo.GetUnreadMessagesByUserID(uuid.Nil); assert.NoError(err) {
+	if unreads, err := repo.GetUnreadMessagesByUserID(context.TODO(), uuid.Nil); assert.NoError(err) {
 		assert.Len(unreads, 0)
 	}
 }
@@ -296,7 +296,7 @@ func TestRepositoryImpl_GetUserUnreadChannels(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		unreads, err := repo.GetUserUnreadChannels(uuid.Nil)
+		unreads, err := repo.GetUserUnreadChannels(context.TODO(), uuid.Nil)
 		assert.NoError(err)
 		assert.Len(unreads, 0)
 	})
@@ -304,7 +304,7 @@ func TestRepositoryImpl_GetUserUnreadChannels(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		unreads, err := repo.GetUserUnreadChannels(user.GetID())
+		unreads, err := repo.GetUserUnreadChannels(context.TODO(), user.GetID())
 		assert.NoError(err)
 		assert.Len(unreads, 1)
 
@@ -331,14 +331,14 @@ func TestRepositoryImpl_DeleteUnreadsByChannelID(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteUnreadsByChannelID(channel.ID, uuid.Nil), repository.ErrNilID.Error())
-		assert.EqualError(t, repo.DeleteUnreadsByChannelID(uuid.Nil, user.GetID()), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.DeleteUnreadsByChannelID(context.TODO(), channel.ID, uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.DeleteUnreadsByChannelID(context.TODO(), uuid.Nil, user.GetID()), repository.ErrNilID.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		if assert.NoError(repo.DeleteUnreadsByChannelID(channel.ID, user.GetID())) {
+		if assert.NoError(repo.DeleteUnreadsByChannelID(context.TODO(), channel.ID, user.GetID())) {
 			assert.Equal(1, count(t, getDB(repo).Model(model.Unread{}).Where(&model.Unread{UserID: user.GetID()})))
 		}
 	})
@@ -364,7 +364,7 @@ func TestRepositoryImpl_GetChannelLatestMessages(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		arr, err := repo.GetChannelLatestMessages(repository.ChannelLatestMessagesQuery{})
+		arr, err := repo.GetChannelLatestMessages(context.TODO(), repository.ChannelLatestMessagesQuery{})
 		derefs := make([]uuid.UUID, len(arr))
 		for i := range arr {
 			derefs[i] = arr[i].ID
@@ -378,7 +378,7 @@ func TestRepositoryImpl_GetChannelLatestMessages(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		arr, err := repo.GetChannelLatestMessages(repository.ChannelLatestMessagesQuery{SubscribedByUser: optional.From(user.GetID())})
+		arr, err := repo.GetChannelLatestMessages(context.TODO(), repository.ChannelLatestMessagesQuery{SubscribedByUser: optional.From(user.GetID())})
 		derefs := make([]uuid.UUID, len(arr))
 		for i := range arr {
 			derefs[i] = arr[i].ID
@@ -392,7 +392,7 @@ func TestRepositoryImpl_GetChannelLatestMessages(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		arr, err := repo.GetChannelLatestMessages(repository.ChannelLatestMessagesQuery{Limit: 5})
+		arr, err := repo.GetChannelLatestMessages(context.TODO(), repository.ChannelLatestMessagesQuery{Limit: 5})
 		derefs := make([]uuid.UUID, len(arr))
 		for i := range arr {
 			derefs[i] = arr[i].ID
@@ -413,7 +413,7 @@ func TestRepositoryImpl_AddStampToMessage(t *testing.T) {
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.AddStampToMessage(uuid.Nil, uuid.Nil, uuid.Nil, 1)
+		_, err := repo.AddStampToMessage(context.TODO(), uuid.Nil, uuid.Nil, uuid.Nil, 1)
 		assert.EqualError(t, err, repository.ErrNilID.Error())
 	})
 
@@ -421,7 +421,7 @@ func TestRepositoryImpl_AddStampToMessage(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 		{
-			ms, err := repo.AddStampToMessage(message.ID, stamp.ID, user.GetID(), 1)
+			ms, err := repo.AddStampToMessage(context.TODO(), message.ID, stamp.ID, user.GetID(), 1)
 			if assert.NoError(err) {
 				assert.Equal(message.ID, ms.MessageID)
 				assert.Equal(stamp.ID, ms.StampID)
@@ -432,7 +432,7 @@ func TestRepositoryImpl_AddStampToMessage(t *testing.T) {
 			}
 		}
 		{
-			ms, err := repo.AddStampToMessage(message.ID, stamp.ID, user.GetID(), 1)
+			ms, err := repo.AddStampToMessage(context.TODO(), message.ID, stamp.ID, user.GetID(), 1)
 			if assert.NoError(err) {
 				assert.Equal(message.ID, ms.MessageID)
 				assert.Equal(stamp.ID, ms.StampID)
@@ -443,7 +443,7 @@ func TestRepositoryImpl_AddStampToMessage(t *testing.T) {
 			}
 		}
 		{
-			ms, err := repo.AddStampToMessage(message.ID, stamp.ID, user.GetID(), 3)
+			ms, err := repo.AddStampToMessage(context.TODO(), message.ID, stamp.ID, user.GetID(), 3)
 			if assert.NoError(err) {
 				assert.Equal(message.ID, ms.MessageID)
 				assert.Equal(stamp.ID, ms.StampID)
@@ -465,9 +465,9 @@ func TestRepositoryImpl_RemoveStampFromMessage(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.RemoveStampFromMessage(message.ID, stamp.ID, uuid.Nil), repository.ErrNilID.Error())
-		assert.EqualError(t, repo.RemoveStampFromMessage(message.ID, uuid.Nil, user.GetID()), repository.ErrNilID.Error())
-		assert.EqualError(t, repo.RemoveStampFromMessage(uuid.Nil, stamp.ID, user.GetID()), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.RemoveStampFromMessage(context.TODO(), message.ID, stamp.ID, uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.RemoveStampFromMessage(context.TODO(), message.ID, uuid.Nil, user.GetID()), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.RemoveStampFromMessage(context.TODO(), uuid.Nil, stamp.ID, user.GetID()), repository.ErrNilID.Error())
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -475,7 +475,7 @@ func TestRepositoryImpl_RemoveStampFromMessage(t *testing.T) {
 		mustAddMessageStamp(t, repo, message.ID, stamp.ID, user.GetID())
 		mustAddMessageStamp(t, repo, message.ID, stamp.ID, user.GetID())
 
-		if assert.NoError(t, repo.RemoveStampFromMessage(message.ID, stamp.ID, user.GetID())) {
+		if assert.NoError(t, repo.RemoveStampFromMessage(context.TODO(), message.ID, stamp.ID, user.GetID())) {
 			assert.Equal(t, 0, count(t, getDB(repo).Model(&model.MessageStamp{}).Where(&model.MessageStamp{MessageID: message.ID, StampID: stamp.ID, UserID: user.GetID()})))
 		}
 	})

--- a/repository/gorm/oauth2.go
+++ b/repository/gorm/oauth2.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -70,7 +71,7 @@ func (repo *Repository) UpdateClient(clientID string, args repository.UpdateClie
 		}
 		if args.DeveloperID.Valid {
 			// 作成者検証
-			user, err := repo.GetUser(args.DeveloperID.V, false)
+			user, err := repo.GetUser(context.TODO(), args.DeveloperID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.DeveloperID", "the Developer is not found")

--- a/repository/gorm/oauth2.go
+++ b/repository/gorm/oauth2.go
@@ -13,21 +13,21 @@ import (
 )
 
 // GetClient implements OAuth2Repository interface.
-func (repo *Repository) GetClient(id string) (*model.OAuth2Client, error) {
+func (repo *Repository) GetClient(ctx context.Context, id string) (*model.OAuth2Client, error) {
 	if len(id) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	oc := &model.OAuth2Client{}
-	if err := repo.db.Take(oc, &model.OAuth2Client{ID: id}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(oc, &model.OAuth2Client{ID: id}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return oc, nil
 }
 
 // GetClients implements OAuth2Repository interface.
-func (repo *Repository) GetClients(query repository.GetClientsQuery) ([]*model.OAuth2Client, error) {
+func (repo *Repository) GetClients(ctx context.Context, query repository.GetClientsQuery) ([]*model.OAuth2Client, error) {
 	cs := make([]*model.OAuth2Client, 0)
-	tx := repo.db
+	tx := repo.db.WithContext(ctx)
 	if query.DeveloperID.Valid {
 		tx = tx.Where("creator_id = ?", query.DeveloperID.V)
 	}
@@ -35,16 +35,16 @@ func (repo *Repository) GetClients(query repository.GetClientsQuery) ([]*model.O
 }
 
 // SaveClient implements OAuth2Repository interface.
-func (repo *Repository) SaveClient(client *model.OAuth2Client) error {
-	return repo.db.Create(client).Error
+func (repo *Repository) SaveClient(ctx context.Context, client *model.OAuth2Client) error {
+	return repo.db.WithContext(ctx).Create(client).Error
 }
 
 // UpdateClient implements OAuth2Repository interface.
-func (repo *Repository) UpdateClient(clientID string, args repository.UpdateClientArgs) error {
+func (repo *Repository) UpdateClient(ctx context.Context, clientID string, args repository.UpdateClientArgs) error {
 	if len(clientID) == 0 {
 		return repository.ErrNilID
 	}
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var oc model.OAuth2Client
 		if err := repo.db.Where(&model.OAuth2Client{ID: clientID}).First(&oc).Error; err != nil {
 			return convertError(err)
@@ -95,11 +95,11 @@ func (repo *Repository) UpdateClient(clientID string, args repository.UpdateClie
 }
 
 // DeleteClient implements OAuth2Repository interface.
-func (repo *Repository) DeleteClient(id string) error {
+func (repo *Repository) DeleteClient(ctx context.Context, id string) error {
 	if len(id) == 0 {
 		return nil
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Delete(&model.OAuth2Client{ID: id}).Error; err != nil {
 			return err
 		}
@@ -112,32 +112,32 @@ func (repo *Repository) DeleteClient(id string) error {
 }
 
 // SaveAuthorize implements OAuth2Repository interface.
-func (repo *Repository) SaveAuthorize(data *model.OAuth2Authorize) error {
-	return repo.db.Create(data).Error
+func (repo *Repository) SaveAuthorize(ctx context.Context, data *model.OAuth2Authorize) error {
+	return repo.db.WithContext(ctx).Create(data).Error
 }
 
 // GetAuthorize implements OAuth2Repository interface.
-func (repo *Repository) GetAuthorize(code string) (*model.OAuth2Authorize, error) {
+func (repo *Repository) GetAuthorize(ctx context.Context, code string) (*model.OAuth2Authorize, error) {
 	if len(code) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	oa := &model.OAuth2Authorize{}
-	if err := repo.db.Take(oa, &model.OAuth2Authorize{Code: code}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(oa, &model.OAuth2Authorize{Code: code}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return oa, nil
 }
 
 // DeleteAuthorize implements OAuth2Repository interface.
-func (repo *Repository) DeleteAuthorize(code string) error {
+func (repo *Repository) DeleteAuthorize(ctx context.Context, code string) error {
 	if len(code) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Authorize{Code: code}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Authorize{Code: code}).Error
 }
 
 // IssueToken implements OAuth2Repository interface.
-func (repo *Repository) IssueToken(client *model.OAuth2Client, userID uuid.UUID, redirectURI string, scope model.AccessScopes, expire int, refresh bool) (*model.OAuth2Token, error) {
+func (repo *Repository) IssueToken(ctx context.Context, client *model.OAuth2Client, userID uuid.UUID, redirectURI string, scope model.AccessScopes, expire int, refresh bool) (*model.OAuth2Token, error) {
 	newToken := &model.OAuth2Token{
 		ID:             uuid.Must(uuid.NewV7()),
 		UserID:         userID,
@@ -154,97 +154,97 @@ func (repo *Repository) IssueToken(client *model.OAuth2Client, userID uuid.UUID,
 		newToken.ClientID = client.ID
 	}
 
-	return newToken, repo.db.Create(newToken).Error
+	return newToken, repo.db.WithContext(ctx).Create(newToken).Error
 }
 
 // GetTokenByID implements OAuth2Repository interface.
-func (repo *Repository) GetTokenByID(id uuid.UUID) (*model.OAuth2Token, error) {
+func (repo *Repository) GetTokenByID(ctx context.Context, id uuid.UUID) (*model.OAuth2Token, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	ot := &model.OAuth2Token{}
-	if err := repo.db.Take(ot, &model.OAuth2Token{ID: id}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(ot, &model.OAuth2Token{ID: id}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return ot, nil
 }
 
 // DeleteTokenByID implements OAuth2Repository interface.
-func (repo *Repository) DeleteTokenByID(id uuid.UUID) error {
+func (repo *Repository) DeleteTokenByID(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{ID: id}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{ID: id}).Error
 }
 
 // GetTokenByAccess implements OAuth2Repository interface.
-func (repo *Repository) GetTokenByAccess(access string) (*model.OAuth2Token, error) {
+func (repo *Repository) GetTokenByAccess(ctx context.Context, access string) (*model.OAuth2Token, error) {
 	if len(access) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	ot := &model.OAuth2Token{}
-	if err := repo.db.Take(ot, &model.OAuth2Token{AccessToken: access}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(ot, &model.OAuth2Token{AccessToken: access}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return ot, nil
 }
 
 // DeleteTokenByAccess implements OAuth2Repository interface.
-func (repo *Repository) DeleteTokenByAccess(access string) error {
+func (repo *Repository) DeleteTokenByAccess(ctx context.Context, access string) error {
 	if len(access) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{AccessToken: access}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{AccessToken: access}).Error
 }
 
 // GetTokenByRefresh implements OAuth2Repository interface.
-func (repo *Repository) GetTokenByRefresh(refresh string) (*model.OAuth2Token, error) {
+func (repo *Repository) GetTokenByRefresh(ctx context.Context, refresh string) (*model.OAuth2Token, error) {
 	if len(refresh) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	ot := &model.OAuth2Token{}
-	if err := repo.db.Take(ot, &model.OAuth2Token{RefreshToken: refresh, RefreshEnabled: true}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(ot, &model.OAuth2Token{RefreshToken: refresh, RefreshEnabled: true}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return ot, nil
 }
 
 // DeleteTokenByRefresh implements OAuth2Repository interface.
-func (repo *Repository) DeleteTokenByRefresh(refresh string) error {
+func (repo *Repository) DeleteTokenByRefresh(ctx context.Context, refresh string) error {
 	if len(refresh) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{RefreshToken: refresh, RefreshEnabled: true}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{RefreshToken: refresh, RefreshEnabled: true}).Error
 }
 
 // GetTokensByUser implements OAuth2Repository interface.
-func (repo *Repository) GetTokensByUser(userID uuid.UUID) ([]*model.OAuth2Token, error) {
+func (repo *Repository) GetTokensByUser(ctx context.Context, userID uuid.UUID) ([]*model.OAuth2Token, error) {
 	ts := make([]*model.OAuth2Token, 0)
 	if userID == uuid.Nil {
 		return ts, nil
 	}
-	return ts, repo.db.Where(&model.OAuth2Token{UserID: userID}).Find(&ts).Error
+	return ts, repo.db.WithContext(ctx).Where(&model.OAuth2Token{UserID: userID}).Find(&ts).Error
 }
 
 // DeleteTokenByUser implements OAuth2Repository interface.
-func (repo *Repository) DeleteTokenByUser(userID uuid.UUID) error {
+func (repo *Repository) DeleteTokenByUser(ctx context.Context, userID uuid.UUID) error {
 	if userID == uuid.Nil {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{UserID: userID}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{UserID: userID}).Error
 }
 
 // DeleteTokenByClient implements OAuth2Repository interface.
-func (repo *Repository) DeleteTokenByClient(clientID string) error {
+func (repo *Repository) DeleteTokenByClient(ctx context.Context, clientID string) error {
 	if len(clientID) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{ClientID: clientID}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{ClientID: clientID}).Error
 }
 
-func (repo *Repository) DeleteUserTokensByClient(userID uuid.UUID, clientID string) error {
+func (repo *Repository) DeleteUserTokensByClient(ctx context.Context, userID uuid.UUID, clientID string) error {
 	if userID == uuid.Nil || len(clientID) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&model.OAuth2Token{}, &model.OAuth2Token{UserID: userID, ClientID: clientID}).Error
+	return repo.db.WithContext(ctx).Delete(&model.OAuth2Token{}, &model.OAuth2Token{UserID: userID, ClientID: clientID}).Error
 }

--- a/repository/gorm/ogp_cache.go
+++ b/repository/gorm/ogp_cache.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"crypto/sha1"
 	"fmt"
 	"time"
@@ -18,7 +19,7 @@ func getURLHash(url string) (string, error) {
 }
 
 // CreateOgpCache implements OgpRepository interface.
-func (repo *Repository) CreateOgpCache(url string, content *model.Ogp, cacheFor time.Duration) (*model.OgpCache, error) {
+func (repo *Repository) CreateOgpCache(ctx context.Context, url string, content *model.Ogp, cacheFor time.Duration) (*model.OgpCache, error) {
 	urlHash, err := getURLHash(url)
 	if err != nil {
 		return nil, err
@@ -36,7 +37,7 @@ func (repo *Repository) CreateOgpCache(url string, content *model.Ogp, cacheFor 
 		ogpCache.Content = *content
 	}
 
-	err = repo.db.Transaction(func(tx *gorm.DB) error {
+	err = repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return tx.Create(ogpCache).Error
 	})
 	if err != nil {
@@ -46,26 +47,26 @@ func (repo *Repository) CreateOgpCache(url string, content *model.Ogp, cacheFor 
 }
 
 // GetOgpCache implements OgpRepository interface.
-func (repo *Repository) GetOgpCache(url string) (c *model.OgpCache, err error) {
+func (repo *Repository) GetOgpCache(ctx context.Context, url string) (c *model.OgpCache, err error) {
 	urlHash, err := getURLHash(url)
 	if err != nil {
 		return nil, err
 	}
 
 	c = &model.OgpCache{}
-	if err = repo.db.Take(c, &model.OgpCache{URL: url, URLHash: urlHash}).Error; err != nil {
+	if err = repo.db.WithContext(ctx).Take(c, &model.OgpCache{URL: url, URLHash: urlHash}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return c, nil
 }
 
 // DeleteOgpCache implements OgpRepository interface.
-func (repo *Repository) DeleteOgpCache(url string) error {
-	c, err := repo.GetOgpCache(url)
+func (repo *Repository) DeleteOgpCache(ctx context.Context, url string) error {
+	c, err := repo.GetOgpCache(ctx, url)
 	if err != nil {
 		return err
 	}
-	result := repo.db.Delete(c)
+	result := repo.db.WithContext(ctx).Delete(c)
 	if result.Error != nil {
 		return convertError(result.Error)
 	}
@@ -76,8 +77,8 @@ func (repo *Repository) DeleteOgpCache(url string) error {
 }
 
 // DeleteStaleOgpCache implements OgpRepository interface.
-func (repo *Repository) DeleteStaleOgpCache() error {
-	return repo.db.
+func (repo *Repository) DeleteStaleOgpCache(ctx context.Context) error {
+	return repo.db.WithContext(ctx).
 		Where("expires_at < ?", time.Now()).
 		Delete(&model.OgpCache{}).
 		Error

--- a/repository/gorm/pin.go
+++ b/repository/gorm/pin.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
 	"gorm.io/gorm"
@@ -12,7 +14,7 @@ import (
 )
 
 // PinMessage implements PinRepository interface.
-func (repo *Repository) PinMessage(messageID, userID uuid.UUID) (*model.Pin, error) {
+func (repo *Repository) PinMessage(ctx context.Context, messageID, userID uuid.UUID) (*model.Pin, error) {
 	if messageID == uuid.Nil || userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -20,7 +22,7 @@ func (repo *Repository) PinMessage(messageID, userID uuid.UUID) (*model.Pin, err
 		p model.Pin
 		m model.Message
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&m, &model.Message{ID: messageID}).Error; err != nil {
 			return convertError(err)
 		}
@@ -49,12 +51,12 @@ func (repo *Repository) PinMessage(messageID, userID uuid.UUID) (*model.Pin, err
 }
 
 // UnpinMessage implements PinRepository interface.
-func (repo *Repository) UnpinMessage(messageID uuid.UUID) (*model.Pin, error) {
+func (repo *Repository) UnpinMessage(ctx context.Context, messageID uuid.UUID) (*model.Pin, error) {
 	if messageID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 	var pin model.Pin
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Preload("Message").Where(&model.Pin{MessageID: messageID}).First(&pin).Error; err != nil {
 			return convertError(err)
 		}
@@ -74,12 +76,12 @@ func (repo *Repository) UnpinMessage(messageID uuid.UUID) (*model.Pin, error) {
 }
 
 // GetPinnedMessageByChannelID implements PinRepository interface.
-func (repo *Repository) GetPinnedMessageByChannelID(channelID uuid.UUID) (pins []*model.Pin, err error) {
+func (repo *Repository) GetPinnedMessageByChannelID(ctx context.Context, channelID uuid.UUID) (pins []*model.Pin, err error) {
 	pins = make([]*model.Pin, 0)
 	if channelID == uuid.Nil {
 		return pins, nil
 	}
-	err = repo.db.
+	err = repo.db.WithContext(ctx).
 		Scopes(pinPreloads).
 		Joins("INNER JOIN messages ON messages.id = pins.message_id AND messages.channel_id = ?", channelID).
 		Find(&pins).

--- a/repository/gorm/pin_test.go
+++ b/repository/gorm/pin_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -16,33 +17,33 @@ func TestRepositoryImpl_PinMessage(t *testing.T) {
 	t.Run("nil id (message)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Nil, user.GetID())
+		_, err := repo.PinMessage(context.TODO(), uuid.Nil, user.GetID())
 		assert.Error(t, err)
 	})
 	t.Run("nil id (user - UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV4()), uuid.Nil)
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV4()), uuid.Nil)
 		assert.Error(t, err)
 	})
 	t.Run("nil id (user - UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV7()), uuid.Nil)
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV7()), uuid.Nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("message not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV4()), user.GetID())
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV4()), user.GetID())
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("message not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV7()), user.GetID())
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV7()), user.GetID())
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -50,7 +51,7 @@ func TestRepositoryImpl_PinMessage(t *testing.T) {
 		t.Parallel()
 		testMessage := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 
-		p, err := repo.PinMessage(testMessage.ID, user.GetID())
+		p, err := repo.PinMessage(context.TODO(), testMessage.ID, user.GetID())
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, testMessage.ID, p.MessageID)
 		}
@@ -61,7 +62,7 @@ func TestRepositoryImpl_PinMessage(t *testing.T) {
 		testMessage := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		mustMakePin(t, repo, testMessage.ID, user.GetID())
 
-		_, err := repo.PinMessage(testMessage.ID, user.GetID())
+		_, err := repo.PinMessage(context.TODO(), testMessage.ID, user.GetID())
 		assert.EqualError(t, err, repository.ErrAlreadyExists.Error())
 	})
 }
@@ -73,19 +74,19 @@ func TestRepositoryImpl_UnpinMessage(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.UnpinMessage(uuid.Nil)
+		_, err := repo.UnpinMessage(context.TODO(), uuid.Nil)
 		assert.Error(t, err)
 	})
 	t.Run("pin not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV4()), user.GetID())
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV4()), user.GetID())
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 	t.Run("pin not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.PinMessage(uuid.Must(uuid.NewV7()), user.GetID())
+		_, err := repo.PinMessage(context.TODO(), uuid.Must(uuid.NewV7()), user.GetID())
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -94,7 +95,7 @@ func TestRepositoryImpl_UnpinMessage(t *testing.T) {
 		testMessage := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		mustMakePin(t, repo, testMessage.ID, user.GetID())
 
-		pin, err := repo.UnpinMessage(testMessage.ID)
+		pin, err := repo.UnpinMessage(context.TODO(), testMessage.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, user.GetID(), pin.UserID)
 			assert.EqualValues(t, testMessage.ID, pin.MessageID)
@@ -109,12 +110,12 @@ func TestRepositoryImpl_GetPinnedMessageByChannelID(t *testing.T) {
 	testMessage := mustMakeMessage(t, repo, user.GetID(), channel.ID)
 	mustMakePin(t, repo, testMessage.ID, user.GetID())
 
-	pins, err := repo.GetPinnedMessageByChannelID(channel.ID)
+	pins, err := repo.GetPinnedMessageByChannelID(context.TODO(), channel.ID)
 	if assert.NoError(err) {
 		assert.Len(pins, 1)
 	}
 
-	pins, err = repo.GetPinnedMessageByChannelID(uuid.Nil)
+	pins, err = repo.GetPinnedMessageByChannelID(context.TODO(), uuid.Nil)
 	if assert.NoError(err) {
 		assert.Empty(pins)
 	}

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -294,7 +294,7 @@ func mustMakeWebhook(t *testing.T, repo repository.Repository, name string, chan
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	w, err := repo.CreateWebhook(name, "", channelID, mustMakeDummyFile(t, repo, false).ID, creatorID, secret)
+	w, err := repo.CreateWebhook(context.TODO(), name, "", channelID, mustMakeDummyFile(t, repo, false).ID, creatorID, secret)
 	require.NoError(t, err)
 	return w
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -210,7 +211,7 @@ func mustAddTagToUser(t *testing.T, repo repository.Repository, userID, tagID uu
 
 func mustMakePin(t *testing.T, repo repository.Repository, messageID, userID uuid.UUID) {
 	t.Helper()
-	_, err := repo.PinMessage(messageID, userID)
+	_, err := repo.PinMessage(context.TODO(), messageID, userID)
 	require.NoError(t, err)
 }
 

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -221,14 +221,14 @@ func mustMakeUserGroup(t *testing.T, repo repository.Repository, name string, ad
 		name = random.AlphaNumeric(20)
 	}
 	icon := mustMakeDummyFile(t, repo, false)
-	g, err := repo.CreateUserGroup(name, "", "", adminID, icon.ID)
+	g, err := repo.CreateUserGroup(context.TODO(), name, "", "", adminID, icon.ID)
 	require.NoError(t, err)
 	return g
 }
 
 func mustAddUserToGroup(t *testing.T, repo repository.Repository, userID, groupID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, repo.AddUserToGroup(userID, groupID, ""))
+	require.NoError(t, repo.AddUserToGroup(context.TODO(), userID, groupID, ""))
 }
 
 func mustMakeDummyFile(t *testing.T, repo repository.Repository, useUUIDv4 bool) *model.FileMeta {

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -189,7 +189,7 @@ func mustMakeUser(t *testing.T, repo repository.Repository, userName string, use
 	}
 	// パスワード無し・アイコンファイルは実際には存在しないことに注意
 	iconUUID := mustGenerateUUID(useUUIDv4)
-	u, err := repo.CreateUser(repository.CreateUserArgs{Name: userName, Role: role.User, IconFileID: iconUUID})
+	u, err := repo.CreateUser(context.TODO(), repository.CreateUserArgs{Name: userName, Role: role.User, IconFileID: iconUUID})
 	require.NoError(t, err)
 	return u
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -313,14 +313,14 @@ func mustMakeClipFolder(t *testing.T, repo repository.Repository, userID uuid.UU
 	if description == rand {
 		description = random.AlphaNumeric(100)
 	}
-	cf, err := repo.CreateClipFolder(userID, name, description)
+	cf, err := repo.CreateClipFolder(context.TODO(), userID, name, description)
 	require.NoError(t, err)
 	return cf
 }
 
 func mustMakeClipFolderMessage(t *testing.T, repo repository.Repository, folderID, messageID uuid.UUID) *model.ClipFolderMessage {
 	t.Helper()
-	cfm, err := repo.AddClipFolderMessage(folderID, messageID)
+	cfm, err := repo.AddClipFolderMessage(context.TODO(), folderID, messageID)
 	require.NoError(t, err)
 	return cfm
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -171,14 +171,14 @@ func mustMakeChannel(t *testing.T, repo repository.Repository, name string) *mod
 
 func mustMakeMessage(t *testing.T, repo repository.Repository, userID, channelID uuid.UUID) *model.Message {
 	t.Helper()
-	m, err := repo.CreateMessage(userID, channelID, "popopo")
+	m, err := repo.CreateMessage(context.TODO(), userID, channelID, "popopo")
 	require.NoError(t, err)
 	return m
 }
 
 func mustMakeMessageUnread(t *testing.T, repo repository.Repository, userID, messageID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, repo.SetMessageUnreads(map[uuid.UUID]bool{userID: false}, messageID))
+	require.NoError(t, repo.SetMessageUnreads(context.TODO(), map[uuid.UUID]bool{userID: false}, messageID))
 }
 
 func mustMakeUser(t *testing.T, repo repository.Repository, userName string, useUUIDv4 bool) model.UserInfo {
@@ -272,7 +272,7 @@ func mustMakeStamp(t *testing.T, repo repository.Repository, name string, userID
 
 func mustAddMessageStamp(t *testing.T, repo repository.Repository, messageID, stampID, userID uuid.UUID) {
 	t.Helper()
-	_, err := repo.AddStampToMessage(messageID, stampID, userID, 1)
+	_, err := repo.AddStampToMessage(context.TODO(), messageID, stampID, userID, 1)
 	require.NoError(t, err)
 }
 

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -252,7 +252,7 @@ func mustMakeDummyFile(t *testing.T, repo repository.Repository, useUUIDv4 bool)
 			},
 		},
 	}
-	err := repo.SaveFileMeta(meta, []*model.FileACLEntry{
+	err := repo.SaveFileMeta(context.TODO(), meta, []*model.FileACLEntry{
 		{UserID: uuid.Nil, Allow: true},
 	})
 	require.NoError(t, err)

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -265,7 +265,7 @@ func mustMakeStamp(t *testing.T, repo repository.Repository, name string, userID
 		name = random.AlphaNumeric(20)
 	}
 	fid := mustMakeDummyFile(t, repo, false).ID
-	s, err := repo.CreateStamp(repository.CreateStampArgs{Name: name, FileID: fid, CreatorID: userID})
+	s, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: name, FileID: fid, CreatorID: userID})
 	require.NoError(t, err)
 	return s
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -199,14 +199,14 @@ func mustMakeTag(t *testing.T, repo repository.Repository, name string) *model.T
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	tag, err := repo.GetOrCreateTag(name)
+	tag, err := repo.GetOrCreateTag(context.TODO(), name)
 	require.NoError(t, err)
 	return tag
 }
 
 func mustAddTagToUser(t *testing.T, repo repository.Repository, userID, tagID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, repo.AddUserTag(userID, tagID))
+	require.NoError(t, repo.AddUserTag(context.TODO(), userID, tagID))
 }
 
 func mustMakePin(t *testing.T, repo repository.Repository, messageID, userID uuid.UUID) {

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -160,7 +160,7 @@ func mustMakeChannel(t *testing.T, repo repository.Repository, name string) *mod
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	ch, err := repo.CreateChannel(model.Channel{
+	ch, err := repo.CreateChannel(context.TODO(), model.Channel{
 		Name:      name,
 		IsForced:  false,
 		IsVisible: true,
@@ -301,7 +301,7 @@ func mustMakeWebhook(t *testing.T, repo repository.Repository, name string, chan
 
 func mustChangeChannelSubscription(t *testing.T, repo repository.Repository, channelID, userID uuid.UUID) {
 	t.Helper()
-	_, _, err := repo.ChangeChannelSubscription(channelID, repository.ChangeChannelSubscriptionArgs{Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{userID: model.ChannelSubscribeLevelMarkAndNotify}})
+	_, _, err := repo.ChangeChannelSubscription(context.TODO(), channelID, repository.ChangeChannelSubscriptionArgs{Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{userID: model.ChannelSubscribeLevelMarkAndNotify}})
 	require.NoError(t, err)
 }
 

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -284,7 +284,7 @@ func mustMakeStampPalette(t *testing.T, repo repository.Repository, name, descri
 	if description == rand {
 		description = random.AlphaNumeric(100)
 	}
-	sp, err := repo.CreateStampPalette(name, description, stamps, userID)
+	sp, err := repo.CreateStampPalette(context.TODO(), name, description, stamps, userID)
 	require.NoError(t, err)
 	return sp
 }

--- a/repository/gorm/soundboard.go
+++ b/repository/gorm/soundboard.go
@@ -1,13 +1,15 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traQ/model"
 	"github.com/traPtitech/traQ/repository"
 )
 
-func (repo *Repository) CreateSoundboardItem(args repository.CreateSoundboardItemArgs) error {
-	return repo.db.Create(&model.SoundboardItem{
+func (repo *Repository) CreateSoundboardItem(ctx context.Context, args repository.CreateSoundboardItemArgs) error {
+	return repo.db.WithContext(ctx).Create(&model.SoundboardItem{
 		ID:        args.SoundID,
 		Name:      args.SoundName,
 		StampID:   args.StampID,
@@ -15,26 +17,26 @@ func (repo *Repository) CreateSoundboardItem(args repository.CreateSoundboardIte
 	}).Error
 }
 
-func (repo *Repository) GetAllSoundboardItems() ([]*model.SoundboardItem, error) {
+func (repo *Repository) GetAllSoundboardItems(ctx context.Context) ([]*model.SoundboardItem, error) {
 	items := make([]*model.SoundboardItem, 0)
-	if err := repo.db.Find(&items).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Find(&items).Error; err != nil {
 		return nil, err
 	}
 	return items, nil
 }
 
-func (repo *Repository) GetSoundboardByCreatorID(creatorID uuid.UUID) ([]*model.SoundboardItem, error) {
+func (repo *Repository) GetSoundboardByCreatorID(ctx context.Context, creatorID uuid.UUID) ([]*model.SoundboardItem, error) {
 	items := make([]*model.SoundboardItem, 0)
-	if err := repo.db.Where(&model.SoundboardItem{CreatorID: creatorID}).Find(&items).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Where(&model.SoundboardItem{CreatorID: creatorID}).Find(&items).Error; err != nil {
 		return nil, err
 	}
 	return items, nil
 }
 
-func (repo *Repository) UpdateSoundboardCreatorID(soundID uuid.UUID, creatorID uuid.UUID) error {
-	return repo.db.Model(&model.SoundboardItem{}).Where("id = ?", soundID).Update("creator_id", creatorID).Error
+func (repo *Repository) UpdateSoundboardCreatorID(ctx context.Context, soundID uuid.UUID, creatorID uuid.UUID) error {
+	return repo.db.WithContext(ctx).Model(&model.SoundboardItem{}).Where("id = ?", soundID).Update("creator_id", creatorID).Error
 }
 
-func (repo *Repository) DeleteSoundboardItem(soundID uuid.UUID) error {
-	return repo.db.Delete(&model.SoundboardItem{}, soundID).Error
+func (repo *Repository) DeleteSoundboardItem(ctx context.Context, soundID uuid.UUID) error {
+	return repo.db.WithContext(ctx).Delete(&model.SoundboardItem{}, soundID).Error
 }

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -137,7 +137,7 @@ func (r *stampRepository) allStampsExist(ids []uuid.UUID) (ok bool, err error) {
 }
 
 // CreateStamp implements StampRepository interface.
-func (r *stampRepository) CreateStamp(args repository.CreateStampArgs) (s *model.Stamp, err error) {
+func (r *stampRepository) CreateStamp(ctx context.Context, args repository.CreateStampArgs) (s *model.Stamp, err error) {
 	stamp := &model.Stamp{
 		ID:        uuid.Must(uuid.NewV7()),
 		Name:      args.Name,
@@ -146,7 +146,7 @@ func (r *stampRepository) CreateStamp(args repository.CreateStampArgs) (s *model
 		IsUnicode: args.IsUnicode,
 	}
 
-	err = r.db.Transaction(func(tx *gorm.DB) error {
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// 名前チェック
 		if err := vd.Validate(stamp.Name, validator.StampNameRuleRequired...); err != nil {
 			return repository.ArgError("name", "Name must be 1-32 characters of a-zA-Z0-9_-")
@@ -186,14 +186,14 @@ func (r *stampRepository) CreateStamp(args repository.CreateStampArgs) (s *model
 }
 
 // UpdateStamp implements StampRepository interface.
-func (r *stampRepository) UpdateStamp(id uuid.UUID, args repository.UpdateStampArgs) error {
+func (r *stampRepository) UpdateStamp(ctx context.Context, id uuid.UUID, args repository.UpdateStampArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	var s model.Stamp
 	changes := map[string]interface{}{}
-	err := r.db.Transaction(func(tx *gorm.DB) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.First(&s, &model.Stamp{ID: id}).Error; err != nil {
 			return convertError(err)
 		}
@@ -253,7 +253,7 @@ func (r *stampRepository) UpdateStamp(id uuid.UUID, args repository.UpdateStampA
 }
 
 // GetStamp implements StampRepository interface.
-func (r *stampRepository) GetStamp(id uuid.UUID) (s *model.Stamp, err error) {
+func (r *stampRepository) GetStamp(ctx context.Context, id uuid.UUID) (s *model.Stamp, err error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -269,24 +269,24 @@ func (r *stampRepository) GetStamp(id uuid.UUID) (s *model.Stamp, err error) {
 }
 
 // GetStampByName implements StampRepository interface.
-func (r *stampRepository) GetStampByName(name string) (s *model.Stamp, err error) {
+func (r *stampRepository) GetStampByName(ctx context.Context, name string) (s *model.Stamp, err error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	s = &model.Stamp{}
-	if err := r.db.First(s, &model.Stamp{Name: name}).Error; err != nil {
+	if err := r.db.WithContext(ctx).First(s, &model.Stamp{Name: name}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return s, nil
 }
 
 // DeleteStamp implements StampRepository interface.
-func (r *stampRepository) DeleteStamp(id uuid.UUID) (err error) {
+func (r *stampRepository) DeleteStamp(ctx context.Context, id uuid.UUID) (err error) {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
 
-	result := r.db.Delete(&model.Stamp{ID: id})
+	result := r.db.WithContext(ctx).Delete(&model.Stamp{ID: id})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -304,12 +304,12 @@ func (r *stampRepository) DeleteStamp(id uuid.UUID) (err error) {
 }
 
 // GetAllStampsWithThumbnail implements StampRepository interface.
-func (r *stampRepository) GetAllStampsWithThumbnail(stampType repository.StampType) (stampsWithThumbnail []*model.StampWithThumbnail, err error) {
-	return r.perType.Get(context.Background(), stampType)
+func (r *stampRepository) GetAllStampsWithThumbnail(ctx context.Context, stampType repository.StampType) (stampsWithThumbnail []*model.StampWithThumbnail, err error) {
+	return r.perType.Get(ctx, stampType)
 }
 
 // StampExists implements StampRepository interface.
-func (r *stampRepository) StampExists(id uuid.UUID) (bool, error) {
+func (r *stampRepository) StampExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	if id == uuid.Nil {
 		return false, nil
 	}
@@ -322,7 +322,7 @@ func (r *stampRepository) StampExists(id uuid.UUID) (bool, error) {
 }
 
 // ExistStamps implements StampPaletteRepository interface.
-func (r *stampRepository) ExistStamps(stampIDs []uuid.UUID) (err error) {
+func (r *stampRepository) ExistStamps(ctx context.Context, stampIDs []uuid.UUID) (err error) {
 	ok, err := r.allStampsExist(stampIDs)
 	if err != nil {
 		return err
@@ -334,13 +334,13 @@ func (r *stampRepository) ExistStamps(stampIDs []uuid.UUID) (err error) {
 }
 
 // GetUserStampHistory implements StampRepository interface.
-func (r *stampRepository) GetUserStampHistory(userID uuid.UUID, limit int) (h []*repository.UserStampHistory, err error) {
+func (r *stampRepository) GetUserStampHistory(ctx context.Context, userID uuid.UUID, limit int) (h []*repository.UserStampHistory, err error) {
 	h = make([]*repository.UserStampHistory, 0)
 	if userID == uuid.Nil {
 		return
 	}
 
-	err = r.db.
+	err = r.db.WithContext(ctx).
 		Table("messages_stamps ms1").
 		Select("ms1.stamp_id, ms1.updated_at AS datetime").
 		Joins("LEFT JOIN messages_stamps ms2 ON (ms1.updated_at < ms2.updated_at AND ms1.stamp_id = ms2.stamp_id AND ms1.user_id = ms2.user_id)").
@@ -358,7 +358,7 @@ func (r *stampRepository) GetUserStampHistory(userID uuid.UUID, limit int) (h []
 // 各スタンプの使用履歴に対して 1/(経過日数+1)^0.8 のスコアを計算し、合計値でランキングします。
 // これにより、使用頻度が高く、かつ直近で使用されたスタンプほど高いスコアを得ます。
 // 例: 今日使用 → 1.0, 7日前 → 0.19, 30日前 → 0.07
-func (r *stampRepository) GetUserStampRecommendations(userID uuid.UUID, limit int) (recs []*repository.UserStampRecommendation, err error) {
+func (r *stampRepository) GetUserStampRecommendations(ctx context.Context, userID uuid.UUID, limit int) (recs []*repository.UserStampRecommendation, err error) {
 	recs = make([]*repository.UserStampRecommendation, 0)
 	if userID == uuid.Nil {
 		return
@@ -367,14 +367,14 @@ func (r *stampRepository) GetUserStampRecommendations(userID uuid.UUID, limit in
 	// 最新のn件のみを対象に計算する (パフォーマンス対策)
 	const historyLimit = 10000
 
-	recentStamps := r.db.
+	recentStamps := r.db.WithContext(ctx).
 		Table("messages_stamps USE INDEX (idx_messages_stamps_user_id_updated_at_stamp_id)").
 		Select("stamp_id, updated_at").
 		Where("user_id = ?", userID).
 		Order("updated_at DESC").
 		Limit(historyLimit)
 
-	err = r.db.
+	err = r.db.WithContext(ctx).
 		Table("(?) AS recent_stamps", recentStamps).
 		Select("stamp_id, SUM(1 / POWER(GREATEST(DATEDIFF(NOW(), recent_stamps.updated_at), 0) + 1, 0.8)) AS score").
 		Group("stamp_id").
@@ -388,19 +388,19 @@ func (r *stampRepository) GetUserStampRecommendations(userID uuid.UUID, limit in
 }
 
 // GetStampStats implements StampRepository interface
-func (r *stampRepository) GetStampStats(stampID uuid.UUID) (*repository.StampStats, error) {
+func (r *stampRepository) GetStampStats(ctx context.Context, stampID uuid.UUID) (*repository.StampStats, error) {
 	if stampID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 
 	if ok, err := gormutil.
-		RecordExists(r.db, &model.MessageStamp{StampID: stampID}); err != nil {
+		RecordExists(r.db.WithContext(ctx), &model.MessageStamp{StampID: stampID}); err != nil {
 		return nil, err
 	} else if !ok {
 		return nil, repository.ErrNotFound
 	}
 	var stats repository.StampStats
-	if err := r.db.
+	if err := r.db.WithContext(ctx).
 		Unscoped().
 		Model(&model.MessageStamp{}).
 		Select("COUNT(stamp_id) AS count", "SUM(count) AS total_count").

--- a/repository/gorm/stamp.go
+++ b/repository/gorm/stamp.go
@@ -114,8 +114,8 @@ func (r *stampRepository) purgeCache() {
 	r.perType.Purge()
 }
 
-func (r *stampRepository) getStamp(id uuid.UUID) (s *model.Stamp, ok bool, err error) {
-	stamps, err := r.stamps.Get(context.Background(), struct{}{})
+func (r *stampRepository) getStamp(ctx context.Context, id uuid.UUID) (s *model.Stamp, ok bool, err error) {
+	stamps, err := r.stamps.Get(ctx, struct{}{})
 	if err != nil {
 		return nil, false, err
 	}
@@ -123,8 +123,8 @@ func (r *stampRepository) getStamp(id uuid.UUID) (s *model.Stamp, ok bool, err e
 	return
 }
 
-func (r *stampRepository) allStampsExist(ids []uuid.UUID) (ok bool, err error) {
-	stamps, err := r.stamps.Get(context.Background(), struct{}{})
+func (r *stampRepository) allStampsExist(ctx context.Context, ids []uuid.UUID) (ok bool, err error) {
+	stamps, err := r.stamps.Get(ctx, struct{}{})
 	if err != nil {
 		return false, err
 	}
@@ -258,7 +258,7 @@ func (r *stampRepository) GetStamp(ctx context.Context, id uuid.UUID) (s *model.
 		return nil, repository.ErrNotFound
 	}
 
-	s, ok, err := r.getStamp(id)
+	s, ok, err := r.getStamp(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (r *stampRepository) StampExists(ctx context.Context, id uuid.UUID) (bool, 
 		return false, nil
 	}
 
-	_, ok, err := r.getStamp(id)
+	_, ok, err := r.getStamp(ctx, id)
 	if err != nil {
 		return false, err
 	}
@@ -323,7 +323,7 @@ func (r *stampRepository) StampExists(ctx context.Context, id uuid.UUID) (bool, 
 
 // ExistStamps implements StampPaletteRepository interface.
 func (r *stampRepository) ExistStamps(ctx context.Context, stampIDs []uuid.UUID) (err error) {
-	ok, err := r.allStampsExist(stampIDs)
+	ok, err := r.allStampsExist(ctx, stampIDs)
 	if err != nil {
 		return err
 	}

--- a/repository/gorm/stamp_palette.go
+++ b/repository/gorm/stamp_palette.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	vd "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
@@ -13,7 +15,7 @@ import (
 )
 
 // CreateStampPalette implements StampPaletteRepository interface.
-func (repo *Repository) CreateStampPalette(name, description string, stamps model.UUIDs, userID uuid.UUID) (sp *model.StampPalette, err error) {
+func (repo *Repository) CreateStampPalette(ctx context.Context, name, description string, stamps model.UUIDs, userID uuid.UUID) (sp *model.StampPalette, err error) {
 	if userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -25,7 +27,7 @@ func (repo *Repository) CreateStampPalette(name, description string, stamps mode
 		CreatorID:   userID,
 	}
 
-	err = repo.db.Transaction(func(tx *gorm.DB) error {
+	err = repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// 名前チェック
 		if err := vd.Validate(name, validator.StampPaletteNameRuleRequired...); err != nil {
 			return repository.ArgError("name", "Name must be 1-30")
@@ -63,13 +65,13 @@ func (repo *Repository) CreateStampPalette(name, description string, stamps mode
 }
 
 // UpdateStampPalette implements StampPaletteRepository interface.
-func (repo *Repository) UpdateStampPalette(id uuid.UUID, args repository.UpdateStampPaletteArgs) error {
+func (repo *Repository) UpdateStampPalette(ctx context.Context, id uuid.UUID, args repository.UpdateStampPaletteArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var userID uuid.UUID
 	changes := map[string]interface{}{}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var sp model.StampPalette
 		if err := tx.First(&sp, &model.StampPalette{ID: id}).Error; err != nil {
 			return convertError(err)
@@ -120,27 +122,27 @@ func (repo *Repository) UpdateStampPalette(id uuid.UUID, args repository.UpdateS
 }
 
 // GetStampPalette implements StampPaletteRepository interface.
-func (repo *Repository) GetStampPalette(id uuid.UUID) (sp *model.StampPalette, err error) {
+func (repo *Repository) GetStampPalette(ctx context.Context, id uuid.UUID) (sp *model.StampPalette, err error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	sp = &model.StampPalette{}
-	if err := repo.db.Take(sp, &model.StampPalette{ID: id}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(sp, &model.StampPalette{ID: id}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return sp, nil
 }
 
 // DeleteStampPalette implements StampPaletteRepository interface.
-func (repo *Repository) DeleteStampPalette(id uuid.UUID) (err error) {
+func (repo *Repository) DeleteStampPalette(ctx context.Context, id uuid.UUID) (err error) {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
-	stampPalette, err := repo.GetStampPalette(id)
+	stampPalette, err := repo.GetStampPalette(ctx, id)
 	if err != nil {
 		return err
 	}
-	result := repo.db.Delete(&model.StampPalette{ID: id})
+	result := repo.db.WithContext(ctx).Delete(&model.StampPalette{ID: id})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -158,8 +160,8 @@ func (repo *Repository) DeleteStampPalette(id uuid.UUID) (err error) {
 }
 
 // GetStampPalettes implements StampPaletteRepository interface.
-func (repo *Repository) GetStampPalettes(userID uuid.UUID) (sps []*model.StampPalette, err error) {
+func (repo *Repository) GetStampPalettes(ctx context.Context, userID uuid.UUID) (sps []*model.StampPalette, err error) {
 	sps = make([]*model.StampPalette, 0)
-	tx := repo.db
+	tx := repo.db.WithContext(ctx)
 	return sps, tx.Where("creator_id = ?", userID).Find(&sps).Error
 }

--- a/repository/gorm/stamp_palette.go
+++ b/repository/gorm/stamp_palette.go
@@ -43,7 +43,7 @@ func (repo *Repository) CreateStampPalette(ctx context.Context, name, descriptio
 			return repository.ArgError("stamps", "stamps must be 0-200")
 		}
 		// スタンプ存在チェック
-		if err = repo.ExistStamps(stamps); err != nil {
+		if err = repo.ExistStamps(context.TODO(), stamps); err != nil {
 			return err
 		}
 
@@ -94,7 +94,7 @@ func (repo *Repository) UpdateStampPalette(ctx context.Context, id uuid.UUID, ar
 			if err := vd.Validate(uuids, validator.StampPaletteStampsRuleNotNil...); err != nil {
 				return repository.ArgError("args.Stamps", "stamps must be 0-200")
 			}
-			if err := repo.ExistStamps(args.Stamps); err != nil {
+			if err := repo.ExistStamps(context.TODO(), args.Stamps); err != nil {
 				return err
 			}
 			changes["stamps"] = args.Stamps

--- a/repository/gorm/stamp_palette_test.go
+++ b/repository/gorm/stamp_palette_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -19,7 +20,7 @@ func TestRepositoryImpl_CreateStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.CreateStampPalette(random2.AlphaNumeric(20), random2.AlphaNumeric(100), make([]uuid.UUID, 0), uuid.Nil)
+		_, err := repo.CreateStampPalette(context.TODO(), random2.AlphaNumeric(20), random2.AlphaNumeric(100), make([]uuid.UUID, 0), uuid.Nil)
 		assert.Error(err)
 	})
 
@@ -35,7 +36,7 @@ func TestRepositoryImpl_CreateStampPalette(t *testing.T) {
 			s := mustMakeStamp(t, repo, rand, user.GetID())
 			stamps = append(stamps, s.ID)
 		}
-		sp, err := repo.CreateStampPalette(name, description, stamps, user.GetID())
+		sp, err := repo.CreateStampPalette(context.TODO(), name, description, stamps, user.GetID())
 		if assert.NoError(err) {
 			assert.NotEmpty(sp.ID)
 			assert.Equal(name, sp.Name)
@@ -58,28 +59,28 @@ func TestRepositoryImpl_UpdateStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateStampPalette(uuid.Nil, repository.UpdateStampPaletteArgs{}), repository.ErrNilID.Error())
+		assert.EqualError(repo.UpdateStampPalette(context.TODO(), uuid.Nil, repository.UpdateStampPaletteArgs{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateStampPalette(uuid.Must(uuid.NewV4()), repository.UpdateStampPaletteArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateStampPalette(context.TODO(), uuid.Must(uuid.NewV4()), repository.UpdateStampPaletteArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.UpdateStampPalette(uuid.Must(uuid.NewV7()), repository.UpdateStampPaletteArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateStampPalette(context.TODO(), uuid.Must(uuid.NewV7()), repository.UpdateStampPaletteArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("no change", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.NoError(repo.UpdateStampPalette(stampPalette.ID, repository.UpdateStampPaletteArgs{}))
+		assert.NoError(repo.UpdateStampPalette(context.TODO(), stampPalette.ID, repository.UpdateStampPaletteArgs{}))
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -90,12 +91,12 @@ func TestRepositoryImpl_UpdateStampPalette(t *testing.T) {
 		newName := random2.AlphaNumeric(20)
 		newDescription := random2.AlphaNumeric(100)
 
-		if assert.NoError(repo.UpdateStampPalette(stampPalette.ID, repository.UpdateStampPaletteArgs{
+		if assert.NoError(repo.UpdateStampPalette(context.TODO(), stampPalette.ID, repository.UpdateStampPaletteArgs{
 			Name:        optional.From(newName),
 			Description: optional.From(newDescription),
 			Stamps:      make([]uuid.UUID, 0),
 		})) {
-			newStampPalette, err := repo.GetStampPalette(stampPalette.ID)
+			newStampPalette, err := repo.GetStampPalette(context.TODO(), stampPalette.ID)
 			require.NoError(err)
 			assert.Equal(newDescription, newStampPalette.Description)
 			assert.Equal(newName, newStampPalette.Name)
@@ -111,7 +112,7 @@ func TestRepositoryImpl_GetStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetStampPalette(uuid.Nil)
+		_, err := repo.GetStampPalette(context.TODO(), uuid.Nil)
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -119,7 +120,7 @@ func TestRepositoryImpl_GetStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetStampPalette(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetStampPalette(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -127,7 +128,7 @@ func TestRepositoryImpl_GetStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetStampPalette(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetStampPalette(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(err, repository.ErrNotFound.Error())
 	})
 
@@ -136,7 +137,7 @@ func TestRepositoryImpl_GetStampPalette(t *testing.T) {
 		assert := assert.New(t)
 		createdStampPalette := mustMakeStampPalette(t, repo, rand, rand, make([]uuid.UUID, 0), user.GetID())
 
-		stampPalette, err := repo.GetStampPalette(createdStampPalette.ID)
+		stampPalette, err := repo.GetStampPalette(context.TODO(), createdStampPalette.ID)
 		if assert.NoError(err) {
 			assert.Equal(createdStampPalette.ID, stampPalette.ID)
 			assert.Equal(createdStampPalette.Name, stampPalette.Name)
@@ -154,21 +155,21 @@ func TestRepositoryImpl_DeleteStampPalette(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteStampPalette(uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(repo.DeleteStampPalette(context.TODO(), uuid.Nil), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteStampPalette(uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteStampPalette(context.TODO(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.EqualError(repo.DeleteStampPalette(uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(repo.DeleteStampPalette(context.TODO(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -176,8 +177,8 @@ func TestRepositoryImpl_DeleteStampPalette(t *testing.T) {
 		assert := assert.New(t)
 
 		stampPalette := mustMakeStampPalette(t, repo, rand, rand, make([]uuid.UUID, 0), user.GetID())
-		if assert.NoError(repo.DeleteStampPalette(stampPalette.ID)) {
-			_, err := repo.GetStampPalette(stampPalette.ID)
+		if assert.NoError(repo.DeleteStampPalette(context.TODO(), stampPalette.ID)) {
+			_, err := repo.GetStampPalette(context.TODO(), stampPalette.ID)
 			assert.EqualError(err, repository.ErrNotFound.Error())
 		}
 	})
@@ -194,7 +195,7 @@ func TestRepositoryImpl_GetStampPalettes(t *testing.T) {
 	}
 	mustMakeStampPalette(t, repo, rand, rand, make([]uuid.UUID, 0), otherUser.GetID())
 
-	arr, err := repo.GetStampPalettes(user.GetID())
+	arr, err := repo.GetStampPalettes(context.TODO(), user.GetID())
 	if assert.NoError(err) {
 		assert.Len(arr, n)
 		for _, stampPalette := range arr {

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,28 +24,28 @@ func TestRepositoryImpl_CreateStamp(t *testing.T) {
 	t.Run("nil file id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateStamp(repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Nil, CreatorID: user.GetID()})
+		_, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Nil, CreatorID: user.GetID()})
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid name", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateStamp(repository.CreateStampArgs{Name: "あ", FileID: fid, CreatorID: user.GetID()})
+		_, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: "あ", FileID: fid, CreatorID: user.GetID()})
 		assert.Error(t, err)
 	})
 
 	t.Run("file not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateStamp(repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Must(uuid.NewV4()), CreatorID: user.GetID()})
+		_, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Must(uuid.NewV4()), CreatorID: user.GetID()})
 		assert.Error(t, err)
 	})
 
 	t.Run("file not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateStamp(repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Must(uuid.NewV7()), CreatorID: user.GetID()})
+		_, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: random2.AlphaNumeric(20), FileID: uuid.Must(uuid.NewV7()), CreatorID: user.GetID()})
 		assert.Error(t, err)
 	})
 
@@ -52,7 +53,7 @@ func TestRepositoryImpl_CreateStamp(t *testing.T) {
 		t.Parallel()
 		s := mustMakeStamp(t, repo, rand, uuid.Nil)
 
-		_, err := repo.CreateStamp(repository.CreateStampArgs{Name: s.Name, FileID: fid, CreatorID: user.GetID()})
+		_, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: s.Name, FileID: fid, CreatorID: user.GetID()})
 		assert.Error(t, err)
 	})
 
@@ -61,7 +62,7 @@ func TestRepositoryImpl_CreateStamp(t *testing.T) {
 		assert := assert.New(t)
 
 		name := random2.AlphaNumeric(20)
-		s, err := repo.CreateStamp(repository.CreateStampArgs{Name: name, FileID: fid, CreatorID: user.GetID()})
+		s, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: name, FileID: fid, CreatorID: user.GetID()})
 		if assert.NoError(err) {
 			assert.NotEmpty(s.ID)
 			assert.Equal(name, s.Name)
@@ -83,56 +84,56 @@ func TestRepositoryImpl_UpdateStamp(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateStamp(uuid.Nil, repository.UpdateStampArgs{}), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.UpdateStamp(context.TODO(), uuid.Nil, repository.UpdateStampArgs{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateStamp(uuid.Must(uuid.NewV4()), repository.UpdateStampArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateStamp(context.TODO(), uuid.Must(uuid.NewV4()), repository.UpdateStampArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateStamp(uuid.Must(uuid.NewV7()), repository.UpdateStampArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateStamp(context.TODO(), uuid.Must(uuid.NewV7()), repository.UpdateStampArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("no change", func(t *testing.T) {
 		t.Parallel()
 
-		assert.NoError(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{}))
+		assert.NoError(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{}))
 	})
 
 	t.Run("invalid name", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{Name: optional.From("あ")}))
+		assert.Error(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{Name: optional.From("あ")}))
 	})
 
 	t.Run("duplicate name", func(t *testing.T) {
 		t.Parallel()
 		s2 := mustMakeStamp(t, repo, rand, uuid.Nil)
 
-		assert.Error(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{Name: optional.From(s2.Name)}))
+		assert.Error(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{Name: optional.From(s2.Name)}))
 	})
 
 	t.Run("nil file id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Nil)}))
+		assert.Error(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Nil)}))
 	})
 
 	t.Run("file not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Must(uuid.NewV4()))}))
+		assert.Error(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Must(uuid.NewV4()))}))
 	})
 
 	t.Run("file not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.UpdateStamp(s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Must(uuid.NewV7()))}))
+		assert.Error(t, repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{FileID: optional.From(uuid.Must(uuid.NewV7()))}))
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -143,12 +144,12 @@ func TestRepositoryImpl_UpdateStamp(t *testing.T) {
 		newFile := mustMakeDummyFile(t, repo, false).ID
 		newName := random2.AlphaNumeric(20)
 
-		if assert.NoError(repo.UpdateStamp(s.ID, repository.UpdateStampArgs{
+		if assert.NoError(repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{
 			Name:      optional.From(newName),
 			FileID:    optional.From(newFile),
 			CreatorID: optional.From(uuid.Nil),
 		})) {
-			a, err := repo.GetStamp(s.ID)
+			a, err := repo.GetStamp(context.TODO(), s.ID)
 			require.NoError(err)
 			assert.Equal(newFile, a.FileID)
 			assert.Equal(newName, a.Name)
@@ -163,21 +164,21 @@ func TestRepositoryImpl_GetStamp(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStamp(uuid.Nil)
+		_, err := repo.GetStamp(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStamp(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetStamp(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStamp(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetStamp(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -186,7 +187,7 @@ func TestRepositoryImpl_GetStamp(t *testing.T) {
 		assert := assert.New(t)
 		a := mustMakeStamp(t, repo, rand, uuid.Nil)
 
-		s, err := repo.GetStamp(a.ID)
+		s, err := repo.GetStamp(context.TODO(), a.ID)
 		if assert.NoError(err) {
 			assert.Equal(a.ID, s.ID)
 			assert.Equal(a.Name, s.Name)
@@ -203,19 +204,19 @@ func TestRepositoryImpl_DeleteStamp(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteStamp(uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.DeleteStamp(context.TODO(), uuid.Nil), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteStamp(uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteStamp(context.TODO(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteStamp(uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteStamp(context.TODO(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -223,8 +224,8 @@ func TestRepositoryImpl_DeleteStamp(t *testing.T) {
 		assert := assert.New(t)
 
 		s := mustMakeStamp(t, repo, rand, uuid.Nil)
-		if assert.NoError(repo.DeleteStamp(s.ID)) {
-			_, err := repo.GetStamp(s.ID)
+		if assert.NoError(repo.DeleteStamp(context.TODO(), s.ID)) {
+			_, err := repo.GetStamp(context.TODO(), s.ID)
 			assert.EqualError(err, repository.ErrNotFound.Error())
 		}
 	})
@@ -247,7 +248,7 @@ func TestRepositoryImpl_GetAllStampsWithThumbnail(t *testing.T) {
 
 	t.Run("without thumbnail", func(t *testing.T) {
 		t.Parallel()
-		arr, err := repo.GetAllStampsWithThumbnail(repository.StampTypeAll)
+		arr, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
 		if !assert.NoError(err) {
 			t.FailNow()
 		}
@@ -262,7 +263,7 @@ func TestRepositoryImpl_GetAllStampsWithThumbnail(t *testing.T) {
 	})
 	t.Run("with thumbnail", func(t *testing.T) {
 		t.Parallel()
-		arr, err := repo.GetAllStampsWithThumbnail(repository.StampTypeAll)
+		arr, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
 		if !assert.NoError(err) {
 			t.FailNow()
 		}
@@ -286,7 +287,7 @@ func TestRepositoryImpl_StampExists(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.StampExists(uuid.Nil)
+		ok, err := repo.StampExists(context.TODO(), uuid.Nil)
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}
@@ -295,7 +296,7 @@ func TestRepositoryImpl_StampExists(t *testing.T) {
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.StampExists(uuid.Must(uuid.NewV4()))
+		ok, err := repo.StampExists(context.TODO(), uuid.Must(uuid.NewV4()))
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}
@@ -303,7 +304,7 @@ func TestRepositoryImpl_StampExists(t *testing.T) {
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.StampExists(uuid.Must(uuid.NewV7()))
+		ok, err := repo.StampExists(context.TODO(), uuid.Must(uuid.NewV7()))
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}
@@ -312,7 +313,7 @@ func TestRepositoryImpl_StampExists(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		t.Parallel()
 
-		ok, err := repo.StampExists(s.ID)
+		ok, err := repo.StampExists(context.TODO(), s.ID)
 		if assert.NoError(t, err) {
 			assert.True(t, ok)
 		}
@@ -339,7 +340,7 @@ func TestRepositoryImpl_ExistStamps(t *testing.T) {
 		if assert.True(len(stampIDsCopy) > 0) {
 			stampIDsCopy[0] = uuid.Must(uuid.NewV4())
 		}
-		assert.Error(repo.ExistStamps(stampIDsCopy))
+		assert.Error(repo.ExistStamps(context.TODO(), stampIDsCopy))
 	})
 	t.Run("argument err(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
@@ -350,14 +351,14 @@ func TestRepositoryImpl_ExistStamps(t *testing.T) {
 		if assert.True(len(stampIDsCopy) > 0) {
 			stampIDsCopy[0] = uuid.Must(uuid.NewV7())
 		}
-		assert.Error(repo.ExistStamps(stampIDsCopy))
+		assert.Error(repo.ExistStamps(context.TODO(), stampIDsCopy))
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.NoError(repo.ExistStamps(stampIDs))
+		assert.NoError(repo.ExistStamps(context.TODO(), stampIDs))
 	})
 }
 
@@ -378,7 +379,7 @@ func TestRepositoryImpl_GetUserStampHistory(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampHistory(uuid.Nil, 0)
+		ms, err := repo.GetUserStampHistory(context.TODO(), uuid.Nil, 0)
 		if assert.NoError(t, err) {
 			assert.Empty(t, ms)
 		}
@@ -386,7 +387,7 @@ func TestRepositoryImpl_GetUserStampHistory(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampHistory(user.GetID(), -1)
+		ms, err := repo.GetUserStampHistory(context.TODO(), user.GetID(), -1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 3) {
 			assert.Equal(t, ms[0].StampID, stamp2.ID)
 			assert.Equal(t, ms[1].StampID, stamp3.ID)
@@ -396,7 +397,7 @@ func TestRepositoryImpl_GetUserStampHistory(t *testing.T) {
 
 	t.Run("Success (Limit 1)", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampHistory(user.GetID(), 1)
+		ms, err := repo.GetUserStampHistory(context.TODO(), user.GetID(), 1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 1) {
 			assert.Equal(t, ms[0].StampID, stamp2.ID)
 		}
@@ -426,7 +427,7 @@ func TestRepositoryImpl_GetUserStampRecommendations(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampRecommendations(uuid.Nil, 0)
+		ms, err := repo.GetUserStampRecommendations(context.TODO(), uuid.Nil, 0)
 		if assert.NoError(t, err) {
 			assert.Empty(t, ms)
 		}
@@ -434,7 +435,7 @@ func TestRepositoryImpl_GetUserStampRecommendations(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampRecommendations(user.GetID(), -1)
+		ms, err := repo.GetUserStampRecommendations(context.TODO(), user.GetID(), -1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 3) {
 			assert.Equal(t, stamp1.ID, ms[0].StampID)
 			assert.Equal(t, stamp2.ID, ms[1].StampID)
@@ -444,7 +445,7 @@ func TestRepositoryImpl_GetUserStampRecommendations(t *testing.T) {
 
 	t.Run("Success (Limit 1)", func(t *testing.T) {
 		t.Parallel()
-		ms, err := repo.GetUserStampRecommendations(user.GetID(), 1)
+		ms, err := repo.GetUserStampRecommendations(context.TODO(), user.GetID(), 1)
 		if assert.NoError(t, err) && assert.Len(t, ms, 1) {
 			assert.Equal(t, stamp1.ID, ms[0].StampID)
 		}
@@ -458,21 +459,21 @@ func TestGormRepository_GetStampStats(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStampStats(uuid.Nil)
+		_, err := repo.GetStampStats(context.TODO(), uuid.Nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStampStats(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetStampStats(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetStampStats(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetStampStats(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.Error(t, err)
 	})
 
@@ -495,7 +496,7 @@ func TestGormRepository_GetStampStats(t *testing.T) {
 			}
 		}
 
-		stats, err := repo.GetStampStats(stamp.ID)
+		stats, err := repo.GetStampStats(context.TODO(), stamp.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, 15, stats.Count)
 			assert.EqualValues(t, 45, stats.TotalCount)

--- a/repository/gorm/stamp_test.go
+++ b/repository/gorm/stamp_test.go
@@ -242,7 +242,7 @@ func TestRepositoryImpl_GetAllStampsWithThumbnail(t *testing.T) {
 	}
 	for range 10 {
 		stamp := mustMakeStamp(t, repo, rand, uuid.Nil)
-		err := repo.DeleteFileMeta(stamp.FileID)
+		err := repo.DeleteFileMeta(context.TODO(), stamp.FileID)
 		require.NoError(err)
 	}
 

--- a/repository/gorm/star.go
+++ b/repository/gorm/star.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/leandro-lugaresi/hub"
 
@@ -11,12 +13,12 @@ import (
 )
 
 // AddStar implements StarRepository interface.
-func (repo *Repository) AddStar(userID, channelID uuid.UUID) error {
+func (repo *Repository) AddStar(ctx context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var s model.Star
-	result := repo.db.FirstOrCreate(&s, &model.Star{UserID: userID, ChannelID: channelID})
+	result := repo.db.WithContext(ctx).FirstOrCreate(&s, &model.Star{UserID: userID, ChannelID: channelID})
 	if result.Error != nil {
 		if !gormutil.IsMySQLDuplicatedRecordErr(result.Error) {
 			return result.Error
@@ -33,11 +35,11 @@ func (repo *Repository) AddStar(userID, channelID uuid.UUID) error {
 }
 
 // RemoveStar implements StarRepository interface.
-func (repo *Repository) RemoveStar(userID, channelID uuid.UUID) error {
+func (repo *Repository) RemoveStar(ctx context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	result := repo.db.Delete(&model.Star{}, &model.Star{UserID: userID, ChannelID: channelID})
+	result := repo.db.WithContext(ctx).Delete(&model.Star{}, &model.Star{UserID: userID, ChannelID: channelID})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -54,10 +56,10 @@ func (repo *Repository) RemoveStar(userID, channelID uuid.UUID) error {
 }
 
 // GetStaredChannels implements StarRepository interface.
-func (repo *Repository) GetStaredChannels(userID uuid.UUID) (ids []uuid.UUID, err error) {
+func (repo *Repository) GetStaredChannels(ctx context.Context, userID uuid.UUID) (ids []uuid.UUID, err error) {
 	ids = make([]uuid.UUID, 0)
 	if userID == uuid.Nil {
 		return ids, nil
 	}
-	return ids, repo.db.Model(&model.Star{}).Where(&model.Star{UserID: userID}).Pluck("channel_id", &ids).Error
+	return ids, repo.db.WithContext(ctx).Model(&model.Star{}).Where(&model.Star{UserID: userID}).Pluck("channel_id", &ids).Error
 }

--- a/repository/gorm/star_test.go
+++ b/repository/gorm/star_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -12,12 +13,12 @@ func TestRepositoryImpl_AddStar(t *testing.T) {
 	t.Parallel()
 	repo, assert, _, user, channel := setupWithUserAndChannel(t, common2, false)
 
-	assert.Error(repo.AddStar(user.GetID(), uuid.Nil))
-	assert.Error(repo.AddStar(uuid.Nil, channel.ID))
-	if assert.NoError(repo.AddStar(user.GetID(), channel.ID)) {
+	assert.Error(repo.AddStar(context.TODO(), user.GetID(), uuid.Nil))
+	assert.Error(repo.AddStar(context.TODO(), uuid.Nil, channel.ID))
+	if assert.NoError(repo.AddStar(context.TODO(), user.GetID(), channel.ID)) {
 		assert.Equal(1, count(t, getDB(repo).Model(model.Star{}).Where(model.Star{UserID: user.GetID()})))
 	}
-	if assert.NoError(repo.AddStar(user.GetID(), channel.ID)) {
+	if assert.NoError(repo.AddStar(context.TODO(), user.GetID(), channel.ID)) {
 		assert.Equal(1, count(t, getDB(repo).Model(model.Star{}).Where(model.Star{UserID: user.GetID()})))
 	}
 }
@@ -26,15 +27,15 @@ func TestRepositoryImpl_RemoveStar(t *testing.T) {
 	t.Parallel()
 	repo, assert, require, user, channel := setupWithUserAndChannel(t, common2, false)
 
-	require.NoError(repo.AddStar(user.GetID(), channel.ID))
+	require.NoError(repo.AddStar(context.TODO(), user.GetID(), channel.ID))
 
-	assert.Error(repo.RemoveStar(uuid.Nil, channel.ID))
-	assert.Error(repo.RemoveStar(user.GetID(), uuid.Nil))
+	assert.Error(repo.RemoveStar(context.TODO(), uuid.Nil, channel.ID))
+	assert.Error(repo.RemoveStar(context.TODO(), user.GetID(), uuid.Nil))
 
-	if assert.NoError(repo.RemoveStar(user.GetID(), channel.ID)) {
+	if assert.NoError(repo.RemoveStar(context.TODO(), user.GetID(), channel.ID)) {
 		assert.Equal(0, count(t, getDB(repo).Model(model.Star{}).Where(model.Star{UserID: user.GetID(), ChannelID: channel.ID})))
 	}
-	if assert.NoError(repo.RemoveStar(user.GetID(), channel.ID)) {
+	if assert.NoError(repo.RemoveStar(context.TODO(), user.GetID(), channel.ID)) {
 		assert.Equal(0, count(t, getDB(repo).Model(model.Star{}).Where(model.Star{UserID: user.GetID(), ChannelID: channel.ID})))
 	}
 }
@@ -46,15 +47,15 @@ func TestRepositoryImpl_GetStaredChannels(t *testing.T) {
 	n := 5
 	for range n {
 		ch := mustMakeChannel(t, repo, rand)
-		require.NoError(repo.AddStar(user.GetID(), ch.ID))
+		require.NoError(repo.AddStar(context.TODO(), user.GetID(), ch.ID))
 	}
 
-	ch, err := repo.GetStaredChannels(user.GetID())
+	ch, err := repo.GetStaredChannels(context.TODO(), user.GetID())
 	if assert.NoError(err) {
 		assert.Len(ch, n)
 	}
 
-	ch, err = repo.GetStaredChannels(uuid.Nil)
+	ch, err = repo.GetStaredChannels(context.TODO(), uuid.Nil)
 	if assert.NoError(err) {
 		assert.Len(ch, 0)
 	}

--- a/repository/gorm/tag.go
+++ b/repository/gorm/tag.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"unicode/utf8"
 
 	"github.com/gofrs/uuid"
@@ -13,19 +14,19 @@ import (
 )
 
 // GetTagByID implements TagRepository interface.
-func (repo *Repository) GetTagByID(id uuid.UUID) (*model.Tag, error) {
+func (repo *Repository) GetTagByID(ctx context.Context, id uuid.UUID) (*model.Tag, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	tag := &model.Tag{}
-	if err := repo.db.Take(tag, &model.Tag{ID: id}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Take(tag, &model.Tag{ID: id}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return tag, nil
 }
 
 // GetOrCreateTag implements TagRepository interface.
-func (repo *Repository) GetOrCreateTag(name string) (*model.Tag, error) {
+func (repo *Repository) GetOrCreateTag(ctx context.Context, name string) (*model.Tag, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
@@ -33,7 +34,7 @@ func (repo *Repository) GetOrCreateTag(name string) (*model.Tag, error) {
 		return nil, repository.ArgError("name", "tag must be non-empty and shorter than 31 characters")
 	}
 	tag := &model.Tag{}
-	err := repo.db.
+	err := repo.db.WithContext(ctx).
 		Where(&model.Tag{Name: name}).
 		Attrs(&model.Tag{ID: uuid.Must(uuid.NewV7())}).
 		FirstOrCreate(tag).
@@ -42,7 +43,7 @@ func (repo *Repository) GetOrCreateTag(name string) (*model.Tag, error) {
 }
 
 // AddUserTag implements TagRepository interface.
-func (repo *Repository) AddUserTag(userID, tagID uuid.UUID) error {
+func (repo *Repository) AddUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -51,7 +52,7 @@ func (repo *Repository) AddUserTag(userID, tagID uuid.UUID) error {
 		TagID:  tagID,
 	}
 	// TODO タグの存在確認
-	if err := repo.db.Create(ut).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Create(ut).Error; err != nil {
 		if gormutil.IsMySQLDuplicatedRecordErr(err) {
 			return repository.ErrAlreadyExists
 		}
@@ -68,12 +69,12 @@ func (repo *Repository) AddUserTag(userID, tagID uuid.UUID) error {
 }
 
 // ChangeUserTagLock implements TagRepository interface.
-func (repo *Repository) ChangeUserTagLock(userID, tagID uuid.UUID, locked bool) error {
+func (repo *Repository) ChangeUserTagLock(ctx context.Context, userID, tagID uuid.UUID, locked bool) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
-	result := repo.db.Model(&model.UsersTag{UserID: userID, TagID: tagID}).Update("is_locked", locked)
+	result := repo.db.WithContext(ctx).Model(&model.UsersTag{UserID: userID, TagID: tagID}).Update("is_locked", locked)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -91,11 +92,11 @@ func (repo *Repository) ChangeUserTagLock(userID, tagID uuid.UUID, locked bool) 
 }
 
 // DeleteUserTag implements TagRepository interface.
-func (repo *Repository) DeleteUserTag(userID, tagID uuid.UUID) error {
+func (repo *Repository) DeleteUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
-	result := repo.db.Delete(&model.UsersTag{}, &model.UsersTag{UserID: userID, TagID: tagID})
+	result := repo.db.WithContext(ctx).Delete(&model.UsersTag{}, &model.UsersTag{UserID: userID, TagID: tagID})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -112,24 +113,24 @@ func (repo *Repository) DeleteUserTag(userID, tagID uuid.UUID) error {
 }
 
 // GetUserTag implements TagRepository interface.
-func (repo *Repository) GetUserTag(userID, tagID uuid.UUID) (model.UserTag, error) {
+func (repo *Repository) GetUserTag(ctx context.Context, userID, tagID uuid.UUID) (model.UserTag, error) {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	ut := &model.UsersTag{}
-	if err := repo.db.Preload("Tag").Take(ut, &model.UsersTag{UserID: userID, TagID: tagID}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Preload("Tag").Take(ut, &model.UsersTag{UserID: userID, TagID: tagID}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return ut, nil
 }
 
 // GetUserTagsByUserID implements TagRepository interface.
-func (repo *Repository) GetUserTagsByUserID(userID uuid.UUID) (tags []model.UserTag, err error) {
+func (repo *Repository) GetUserTagsByUserID(ctx context.Context, userID uuid.UUID) (tags []model.UserTag, err error) {
 	var tmp []*model.UsersTag
 	if userID == uuid.Nil {
 		return tags, nil
 	}
-	err = repo.db.
+	err = repo.db.WithContext(ctx).
 		Preload("Tag").
 		Where(&model.UsersTag{UserID: userID}).
 		Order("created_at").
@@ -143,12 +144,12 @@ func (repo *Repository) GetUserTagsByUserID(userID uuid.UUID) (tags []model.User
 }
 
 // GetUserIDsByTagID implements TagRepository interface.
-func (repo *Repository) GetUserIDsByTagID(tagID uuid.UUID) (arr []uuid.UUID, err error) {
+func (repo *Repository) GetUserIDsByTagID(ctx context.Context, tagID uuid.UUID) (arr []uuid.UUID, err error) {
 	arr = make([]uuid.UUID, 0)
 	if tagID == uuid.Nil {
 		return arr, nil
 	}
-	err = repo.db.
+	err = repo.db.WithContext(ctx).
 		Model(&model.UsersTag{}).
 		Where(&model.UsersTag{TagID: tagID}).
 		Pluck("user_id", &arr).

--- a/repository/gorm/tag_test.go
+++ b/repository/gorm/tag_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -14,9 +15,9 @@ func TestRepositoryImpl_AddUserTag(t *testing.T) {
 	repo, assert, _, user := setupWithUser(t, common2, false)
 
 	tag := mustMakeTag(t, repo, rand)
-	assert.NoError(repo.AddUserTag(user.GetID(), tag.ID))
-	assert.Error(repo.AddUserTag(user.GetID(), tag.ID))
-	assert.Error(repo.AddUserTag(user.GetID(), uuid.Nil))
+	assert.NoError(repo.AddUserTag(context.TODO(), user.GetID(), tag.ID))
+	assert.Error(repo.AddUserTag(context.TODO(), user.GetID(), tag.ID))
+	assert.Error(repo.AddUserTag(context.TODO(), user.GetID(), uuid.Nil))
 }
 
 func TestRepositoryImpl_ChangeUserTagLock(t *testing.T) {
@@ -26,19 +27,19 @@ func TestRepositoryImpl_ChangeUserTagLock(t *testing.T) {
 	tag := mustMakeTag(t, repo, rand)
 	mustAddTagToUser(t, repo, user.GetID(), tag.ID)
 
-	if assert.NoError(repo.ChangeUserTagLock(user.GetID(), tag.ID, true)) {
-		tag, err := repo.GetUserTag(user.GetID(), tag.ID)
+	if assert.NoError(repo.ChangeUserTagLock(context.TODO(), user.GetID(), tag.ID, true)) {
+		tag, err := repo.GetUserTag(context.TODO(), user.GetID(), tag.ID)
 		require.NoError(err)
 		assert.True(tag.GetIsLocked())
 	}
 
-	if assert.NoError(repo.ChangeUserTagLock(user.GetID(), tag.ID, false)) {
-		tag, err := repo.GetUserTag(user.GetID(), tag.ID)
+	if assert.NoError(repo.ChangeUserTagLock(context.TODO(), user.GetID(), tag.ID, false)) {
+		tag, err := repo.GetUserTag(context.TODO(), user.GetID(), tag.ID)
 		require.NoError(err)
 		assert.False(tag.GetIsLocked())
 	}
 
-	assert.Error(repo.ChangeUserTagLock(uuid.Nil, tag.ID, true))
+	assert.Error(repo.ChangeUserTagLock(context.TODO(), uuid.Nil, tag.ID, true))
 }
 
 func TestRepositoryImpl_DeleteUserTag(t *testing.T) {
@@ -54,19 +55,19 @@ func TestRepositoryImpl_DeleteUserTag(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		if assert.NoError(repo.DeleteUserTag(user.GetID(), tag.ID)) {
-			_, err := repo.GetUserTag(user.GetID(), tag.ID)
+		if assert.NoError(repo.DeleteUserTag(context.TODO(), user.GetID(), tag.ID)) {
+			_, err := repo.GetUserTag(context.TODO(), user.GetID(), tag.ID)
 			assert.Error(err)
 		}
 
-		_, err := repo.GetUserTag(user.GetID(), tag2.ID)
+		_, err := repo.GetUserTag(context.TODO(), user.GetID(), tag2.ID)
 		assert.NoError(err)
 	})
 
 	t.Run("nil", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.DeleteUserTag(uuid.Nil, tag.ID))
+		assert.Error(t, repo.DeleteUserTag(context.TODO(), uuid.Nil, tag.ID))
 	})
 }
 
@@ -85,7 +86,7 @@ func TestRepositoryImpl_GetUserTagsByUserID(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		tags, err := repo.GetUserTagsByUserID(user.GetID())
+		tags, err := repo.GetUserTagsByUserID(context.TODO(), user.GetID())
 		if assert.NoError(err) {
 			temp := make([]string, len(tags))
 			for i, v := range tags {
@@ -99,7 +100,7 @@ func TestRepositoryImpl_GetUserTagsByUserID(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		tags, err := repo.GetUserTagsByUserID(uuid.Nil)
+		tags, err := repo.GetUserTagsByUserID(context.TODO(), uuid.Nil)
 		if assert.NoError(err) {
 			assert.Empty(tags)
 		}
@@ -117,7 +118,7 @@ func TestRepositoryImpl_GetUserTag(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		ut, err := repo.GetUserTag(user.GetID(), tag.ID)
+		ut, err := repo.GetUserTag(context.TODO(), user.GetID(), tag.ID)
 		if assert.NoError(err) {
 			assert.Equal(user.GetID(), ut.GetUserID())
 			assert.Equal(tag.ID, ut.GetTagID())
@@ -132,7 +133,7 @@ func TestRepositoryImpl_GetUserTag(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		_, err := repo.GetUserTag(user.GetID(), uuid.Nil)
+		_, err := repo.GetUserTag(context.TODO(), user.GetID(), uuid.Nil)
 		assert.Error(err)
 	})
 }
@@ -150,7 +151,7 @@ func TestRepositoryImpl_GetUserIDsByTagID(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		ids, err := repo.GetUserIDsByTagID(tag.ID)
+		ids, err := repo.GetUserIDsByTagID(context.TODO(), tag.ID)
 		if assert.NoError(err) {
 			assert.Len(ids, 10)
 		}
@@ -160,7 +161,7 @@ func TestRepositoryImpl_GetUserIDsByTagID(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		ids, err := repo.GetUserIDsByTagID(uuid.Nil)
+		ids, err := repo.GetUserIDsByTagID(context.TODO(), uuid.Nil)
 		if assert.NoError(err) {
 			assert.Len(ids, 0)
 		}
@@ -173,18 +174,18 @@ func TestRepositoryImpl_GetTagByID(t *testing.T) {
 
 	tag := mustMakeTag(t, repo, rand)
 
-	r, err := repo.GetTagByID(tag.ID)
+	r, err := repo.GetTagByID(context.TODO(), tag.ID)
 	if assert.NoError(err) {
 		assert.Equal(tag.Name, r.Name)
 	}
 
-	_, err = repo.GetTagByID(uuid.Must(uuid.NewV4()))
+	_, err = repo.GetTagByID(context.TODO(), uuid.Must(uuid.NewV4()))
 	assert.Error(err)
 
-	_, err = repo.GetTagByID(uuid.Must(uuid.NewV7()))
+	_, err = repo.GetTagByID(context.TODO(), uuid.Must(uuid.NewV7()))
 	assert.Error(err)
 
-	_, err = repo.GetTagByID(uuid.Nil)
+	_, err = repo.GetTagByID(context.TODO(), uuid.Nil)
 	assert.Error(err)
 }
 
@@ -195,13 +196,13 @@ func TestRepositoryImpl_GetOrCreateTagByName(t *testing.T) {
 	s := random2.AlphaNumeric(20)
 	tag := mustMakeTag(t, repo, s)
 
-	r, err := repo.GetOrCreateTag(s)
+	r, err := repo.GetOrCreateTag(context.TODO(), s)
 	if assert.NoError(err) {
 		assert.Equal(tag.ID, r.ID)
 	}
 
 	b := random2.AlphaNumeric(20)
-	r, err = repo.GetOrCreateTag(b)
+	r, err = repo.GetOrCreateTag(context.TODO(), b)
 	if assert.NoError(err) {
 		assert.NotZero(r.ID)
 		assert.Equal(b, r.Name)
@@ -209,9 +210,9 @@ func TestRepositoryImpl_GetOrCreateTagByName(t *testing.T) {
 		assert.NotZero(r.UpdatedAt)
 	}
 
-	_, err = repo.GetOrCreateTag("")
+	_, err = repo.GetOrCreateTag(context.TODO(), "")
 	assert.Error(err)
 
-	_, err = repo.GetOrCreateTag(random2.AlphaNumeric(31))
+	_, err = repo.GetOrCreateTag(context.TODO(), random2.AlphaNumeric(31))
 	assert.Error(err)
 }

--- a/repository/gorm/user.go
+++ b/repository/gorm/user.go
@@ -39,8 +39,8 @@ func makeUserRepository(db *gorm.DB, hub *hub.Hub) *userRepository {
 	return r
 }
 
-func (r *userRepository) getUser(_ context.Context, arg getUserArg) (model.UserInfo, error) {
-	tx := r.db
+func (r *userRepository) getUser(ctx context.Context, arg getUserArg) (model.UserInfo, error) {
+	tx := r.db.WithContext(ctx)
 	if arg.withProfile {
 		tx = tx.Preload("Profile")
 	}
@@ -57,7 +57,7 @@ func (r *userRepository) forgetCache(id uuid.UUID) {
 }
 
 // CreateUser implements UserRepository interface.
-func (r *userRepository) CreateUser(args repository.CreateUserArgs) (model.UserInfo, error) {
+func (r *userRepository) CreateUser(ctx context.Context, args repository.CreateUserArgs) (model.UserInfo, error) {
 	uid := uuid.Must(uuid.NewV7())
 	user := &model.User{
 		ID:          uid,
@@ -80,7 +80,7 @@ func (r *userRepository) CreateUser(args repository.CreateUserArgs) (model.UserI
 		args.ExternalLogin.UserID = uid
 	}
 
-	err := r.db.Transaction(func(tx *gorm.DB) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if exist, err := gormutil.RecordExists(tx, &model.User{Name: user.Name}); err != nil {
 			return err
 		} else if exist {
@@ -112,20 +112,20 @@ func (r *userRepository) CreateUser(args repository.CreateUserArgs) (model.UserI
 }
 
 // GetUser implements UserRepository interface.
-func (r *userRepository) GetUser(id uuid.UUID, withProfile bool) (model.UserInfo, error) {
+func (r *userRepository) GetUser(ctx context.Context, id uuid.UUID, withProfile bool) (model.UserInfo, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
-	return r.users.Get(context.Background(), getUserArg{id, withProfile})
+	return r.users.Get(ctx, getUserArg{id, withProfile})
 }
 
 // GetUserByName implements UserRepository interface.
-func (r *userRepository) GetUserByName(name string, withProfile bool) (model.UserInfo, error) {
+func (r *userRepository) GetUserByName(ctx context.Context, name string, withProfile bool) (model.UserInfo, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
 
-	tx := r.db
+	tx := r.db.WithContext(ctx)
 	if withProfile {
 		tx = tx.Preload("Profile")
 	}
@@ -137,21 +137,21 @@ func (r *userRepository) GetUserByName(name string, withProfile bool) (model.Use
 }
 
 // GetUserByExternalID implements UserRepository interface.
-func (r *userRepository) GetUserByExternalID(providerName, externalID string, withProfile bool) (model.UserInfo, error) {
+func (r *userRepository) GetUserByExternalID(ctx context.Context, providerName, externalID string, withProfile bool) (model.UserInfo, error) {
 	if len(providerName) == 0 || len(externalID) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	var extUser model.ExternalProviderUser
-	if err := r.db.First(&extUser, &model.ExternalProviderUser{ProviderName: providerName, ExternalID: externalID}).Error; err != nil {
+	if err := r.db.WithContext(ctx).First(&extUser, &model.ExternalProviderUser{ProviderName: providerName, ExternalID: externalID}).Error; err != nil {
 		return nil, convertError(err)
 	}
-	return r.users.Get(context.Background(), getUserArg{extUser.UserID, withProfile})
+	return r.users.Get(ctx, getUserArg{extUser.UserID, withProfile})
 }
 
 // GetUsers implements UserRepository interface.
-func (r *userRepository) GetUsers(query repository.UsersQuery) (users []model.UserInfo, err error) {
+func (r *userRepository) GetUsers(ctx context.Context, query repository.UsersQuery) (users []model.UserInfo, err error) {
 	arr := make([]*model.User, 0)
-	if err = r.makeGetUsersTx(query).Find(&arr).Error; err != nil {
+	if err = r.makeGetUsersTx(ctx, query).Find(&arr).Error; err != nil {
 		return nil, err
 	}
 
@@ -163,14 +163,14 @@ func (r *userRepository) GetUsers(query repository.UsersQuery) (users []model.Us
 }
 
 // GetUserIDs implements UserRepository interface.
-func (r *userRepository) GetUserIDs(query repository.UsersQuery) (ids []uuid.UUID, err error) {
+func (r *userRepository) GetUserIDs(ctx context.Context, query repository.UsersQuery) (ids []uuid.UUID, err error) {
 	ids = make([]uuid.UUID, 0)
-	err = r.makeGetUsersTx(query).Pluck("users.id", &ids).Error
+	err = r.makeGetUsersTx(ctx, query).Pluck("users.id", &ids).Error
 	return ids, err
 }
 
-func (r *userRepository) makeGetUsersTx(query repository.UsersQuery) *gorm.DB {
-	tx := r.db.Table("users")
+func (r *userRepository) makeGetUsersTx(ctx context.Context, query repository.UsersQuery) *gorm.DB {
+	tx := r.db.WithContext(ctx).Table("users")
 
 	if query.Name.Valid {
 		tx = tx.Where("users.name = ?", query.Name.V)
@@ -205,15 +205,15 @@ func (r *userRepository) makeGetUsersTx(query repository.UsersQuery) *gorm.DB {
 }
 
 // UserExists implements UserRepository interface.
-func (r *userRepository) UserExists(id uuid.UUID) (bool, error) {
+func (r *userRepository) UserExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	if id == uuid.Nil {
 		return false, nil
 	}
-	return gormutil.RecordExists(r.db, &model.User{ID: id})
+	return gormutil.RecordExists(r.db.WithContext(ctx), &model.User{ID: id})
 }
 
 // UpdateUser implements UserRepository interface.
-func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs) error {
+func (r *userRepository) UpdateUser(ctx context.Context, id uuid.UUID, args repository.UpdateUserArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -225,7 +225,7 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 		changed bool
 		count   int
 	)
-	err := r.db.Transaction(func(tx *gorm.DB) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Preload("Profile").First(&u, model.User{ID: id}).Error; err != nil {
 			return convertError(err)
 		}
@@ -335,7 +335,7 @@ func (r *userRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs
 }
 
 // LinkExternalUserAccount implements UserRepository interface.
-func (r *userRepository) LinkExternalUserAccount(userID uuid.UUID, args repository.LinkExternalUserAccountArgs) error {
+func (r *userRepository) LinkExternalUserAccount(ctx context.Context, userID uuid.UUID, args repository.LinkExternalUserAccountArgs) error {
 	if userID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -346,7 +346,7 @@ func (r *userRepository) LinkExternalUserAccount(userID uuid.UUID, args reposito
 		return repository.ArgError("args.ExternalID", "ExternalID must not be empty")
 	}
 
-	return r.db.Transaction(func(tx *gorm.DB) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if exist, err := gormutil.RecordExists(tx, &model.User{ID: userID}); err != nil {
 			return err
 		} else if !exist {
@@ -375,21 +375,21 @@ func (r *userRepository) LinkExternalUserAccount(userID uuid.UUID, args reposito
 }
 
 // GetLinkedExternalUserAccounts implements UserRepository interface.
-func (r *userRepository) GetLinkedExternalUserAccounts(userID uuid.UUID) ([]*model.ExternalProviderUser, error) {
+func (r *userRepository) GetLinkedExternalUserAccounts(ctx context.Context, userID uuid.UUID) ([]*model.ExternalProviderUser, error) {
 	result := make([]*model.ExternalProviderUser, 0)
 	if userID == uuid.Nil {
 		return result, nil
 	}
-	return result, r.db.Find(&result, &model.ExternalProviderUser{UserID: userID}).Error
+	return result, r.db.WithContext(ctx).Find(&result, &model.ExternalProviderUser{UserID: userID}).Error
 }
 
 // UnlinkExternalUserAccount implements UserRepository interface.
-func (r *userRepository) UnlinkExternalUserAccount(userID uuid.UUID, providerName string) error {
+func (r *userRepository) UnlinkExternalUserAccount(ctx context.Context, userID uuid.UUID, providerName string) error {
 	if userID == uuid.Nil || len(providerName) == 0 {
 		return repository.ErrNilID
 	}
 
-	result := r.db.Delete(model.ExternalProviderUser{}, &model.ExternalProviderUser{UserID: userID, ProviderName: providerName})
+	result := r.db.WithContext(ctx).Delete(model.ExternalProviderUser{}, &model.ExternalProviderUser{UserID: userID, ProviderName: providerName})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -400,18 +400,19 @@ func (r *userRepository) UnlinkExternalUserAccount(userID uuid.UUID, providerNam
 }
 
 // GetUserStats implements UserRepository interface
-func (r *userRepository) GetUserStats(userID uuid.UUID) (*repository.UserStats, error) {
+func (r *userRepository) GetUserStats(ctx context.Context, userID uuid.UUID) (*repository.UserStats, error) {
 	if userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 	if ok, err := gormutil.
-		RecordExists(r.db, &model.User{ID: userID}); err != nil {
+		RecordExists(r.db.WithContext(ctx), &model.User{ID: userID}); err != nil {
 		return nil, err
 	} else if !ok {
 		return nil, repository.ErrNotFound
 	}
 	var stats repository.UserStats
 	if err := r.db.
+		WithContext(ctx).
 		Unscoped().
 		Model(&model.Message{}).
 		Where(&model.Message{UserID: userID}).
@@ -421,6 +422,7 @@ func (r *userRepository) GetUserStats(userID uuid.UUID) (*repository.UserStats, 
 	}
 
 	if err := r.db.
+		WithContext(ctx).
 		Unscoped().
 		Model(&model.MessageStamp{}).
 		Select("stamp_id AS id", "COUNT(stamp_id) AS count", "SUM(count) AS total").

--- a/repository/gorm/user_group.go
+++ b/repository/gorm/user_group.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -15,7 +16,7 @@ import (
 )
 
 // CreateUserGroup implements UserGroupRepository interface.
-func (repo *Repository) CreateUserGroup(name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
+func (repo *Repository) CreateUserGroup(ctx context.Context, name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
 	g := &model.UserGroup{
 		ID:          uuid.Must(uuid.NewV7()),
 		Name:        name,
@@ -23,7 +24,7 @@ func (repo *Repository) CreateUserGroup(name, description, gType string, adminID
 		Icon:        iconFileID,
 		Type:        gType,
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		err := tx.Create(g).Error
 		if gormutil.IsMySQLDuplicatedRecordErr(err) {
 			return repository.ErrAlreadyExists
@@ -47,13 +48,13 @@ func (repo *Repository) CreateUserGroup(name, description, gType string, adminID
 }
 
 // UpdateUserGroup implements UserGroupRepository interface.
-func (repo *Repository) UpdateUserGroup(id uuid.UUID, args repository.UpdateUserGroupArgs) error {
+func (repo *Repository) UpdateUserGroup(ctx context.Context, id uuid.UUID, args repository.UpdateUserGroupArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	var updated bool
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.First(&g, &model.UserGroup{ID: id}).Error; err != nil {
 			return convertError(err)
@@ -100,11 +101,11 @@ func (repo *Repository) UpdateUserGroup(id uuid.UUID, args repository.UpdateUser
 }
 
 // DeleteUserGroup implements UserGroupRepository interface.
-func (repo *Repository) DeleteUserGroup(id uuid.UUID) error {
+func (repo *Repository) DeleteUserGroup(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where(&model.UserGroupMember{GroupID: id}).Delete(&model.UserGroupMember{}).Error; err != nil {
 			return err
 		}
@@ -133,36 +134,36 @@ func (repo *Repository) DeleteUserGroup(id uuid.UUID) error {
 }
 
 // GetUserGroup implements UserGroupRepository interface.
-func (repo *Repository) GetUserGroup(id uuid.UUID) (*model.UserGroup, error) {
+func (repo *Repository) GetUserGroup(ctx context.Context, id uuid.UUID) (*model.UserGroup, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	var g model.UserGroup
-	if err := repo.db.Scopes(userGroupPreloads).First(&g, &model.UserGroup{ID: id}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Scopes(userGroupPreloads).First(&g, &model.UserGroup{ID: id}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return &g, nil
 }
 
 // GetUserGroupByName implements UserGroupRepository interface.
-func (repo *Repository) GetUserGroupByName(name string) (*model.UserGroup, error) {
+func (repo *Repository) GetUserGroupByName(ctx context.Context, name string) (*model.UserGroup, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
 	var g model.UserGroup
-	if err := repo.db.Scopes(userGroupPreloads).First(&g, &model.UserGroup{Name: name}).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Scopes(userGroupPreloads).First(&g, &model.UserGroup{Name: name}).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return &g, nil
 }
 
 // GetUserBelongingGroupIDs implements UserGroupRepository interface.
-func (repo *Repository) GetUserBelongingGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *Repository) GetUserBelongingGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
 	groups := make([]uuid.UUID, 0)
 	if userID == uuid.Nil {
 		return groups, nil
 	}
-	err := repo.db.
+	err := repo.db.WithContext(ctx).
 		Model(&model.UserGroupMember{}).
 		Where(&model.UserGroupMember{UserID: userID}).
 		Pluck("group_id", &groups).
@@ -171,14 +172,14 @@ func (repo *Repository) GetUserBelongingGroupIDs(userID uuid.UUID) ([]uuid.UUID,
 }
 
 // GetAllUserGroups implements UserGroupRepository interface.
-func (repo *Repository) GetAllUserGroups() ([]*model.UserGroup, error) {
+func (repo *Repository) GetAllUserGroups(ctx context.Context) ([]*model.UserGroup, error) {
 	groups := make([]*model.UserGroup, 0)
-	err := repo.db.Scopes(userGroupPreloads).Find(&groups).Error
+	err := repo.db.WithContext(ctx).Scopes(userGroupPreloads).Find(&groups).Error
 	return groups, err
 }
 
 // AddUserToGroup implements UserGroupRepository interface.
-func (repo *Repository) AddUserToGroup(userID, groupID uuid.UUID, role string) error {
+func (repo *Repository) AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID, role string) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -186,7 +187,7 @@ func (repo *Repository) AddUserToGroup(userID, groupID uuid.UUID, role string) e
 		added   bool
 		updated bool
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Members").First(&g, &model.UserGroup{ID: groupID}).Error; err != nil {
 			return convertError(err)
@@ -230,12 +231,12 @@ func (repo *Repository) AddUserToGroup(userID, groupID uuid.UUID, role string) e
 }
 
 // AddUsersToGroup implements UserGroupRepository interface.
-func (repo *Repository) AddUsersToGroup(users []model.UserGroupMember, groupID uuid.UUID) error {
+func (repo *Repository) AddUsersToGroup(ctx context.Context, users []model.UserGroupMember, groupID uuid.UUID) error {
 	if groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Members").First(&g, &model.UserGroup{ID: groupID}).Error; err != nil {
 			return convertError(err)
@@ -277,12 +278,12 @@ func (repo *Repository) AddUsersToGroup(users []model.UserGroupMember, groupID u
 }
 
 // RemoveUserFromGroup implements UserGroupRepository interface.
-func (repo *Repository) RemoveUserFromGroup(userID, groupID uuid.UUID) error {
+func (repo *Repository) RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
 	var changed bool
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.Scopes(userGroupPreloads).First(&g, &model.UserGroup{ID: groupID}).Error; err != nil {
 			return convertError(err)
@@ -314,14 +315,14 @@ func (repo *Repository) RemoveUserFromGroup(userID, groupID uuid.UUID) error {
 }
 
 // RemoveUsersFromGroup implements UserGroupRepository interface.
-func (repo *Repository) RemoveUsersFromGroup(groupID uuid.UUID) error {
+func (repo *Repository) RemoveUsersFromGroup(ctx context.Context, groupID uuid.UUID) error {
 	if groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	var removedUsers []model.UserGroupMember
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("group_id = ?", groupID).Find(&removedUsers).Delete(&model.UserGroupMember{}).Error; err != nil {
 			return err
 		}
@@ -344,13 +345,13 @@ func (repo *Repository) RemoveUsersFromGroup(groupID uuid.UUID) error {
 }
 
 // AddUserToGroupAdmin implements UserGroupRepository interface.
-func (repo *Repository) AddUserToGroupAdmin(userID, groupID uuid.UUID) error {
+func (repo *Repository) AddUserToGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	var added bool
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.First(&g, &model.UserGroup{ID: groupID}).Error; err != nil {
 			return convertError(err)
@@ -382,13 +383,13 @@ func (repo *Repository) AddUserToGroupAdmin(userID, groupID uuid.UUID) error {
 }
 
 // RemoveUserFromGroupAdmin implements UserGroupRepository interface.
-func (repo *Repository) RemoveUserFromGroupAdmin(userID, groupID uuid.UUID) error {
+func (repo *Repository) RemoveUserFromGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	var removed bool
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var g model.UserGroup
 		if err := tx.Scopes(userGroupPreloads).First(&g, &model.UserGroup{ID: groupID}).Error; err != nil {
 			return convertError(err)

--- a/repository/gorm/user_group_test.go
+++ b/repository/gorm/user_group_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -20,14 +21,14 @@ func TestRepositoryImpl_CreateUserGroup(t *testing.T) {
 
 	// Success
 	a := random2.AlphaNumeric(20)
-	if g, err := repo.CreateUserGroup(a, "", "", user.GetID(), file.ID); assert.NoError(t, err) {
+	if g, err := repo.CreateUserGroup(context.TODO(), a, "", "", user.GetID(), file.ID); assert.NoError(t, err) {
 		assert.NotNil(t, g)
 	}
 
 	t.Run("duplicate", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateUserGroup(a, "", "", user.GetID(), file.ID)
+		_, err := repo.CreateUserGroup(context.TODO(), a, "", "", user.GetID(), file.ID)
 		assert.EqualError(t, err, repository.ErrAlreadyExists.Error())
 	})
 }
@@ -39,7 +40,7 @@ func TestRepositoryImpl_UpdateUserGroup(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateUserGroup(uuid.Nil, repository.UpdateUserGroupArgs{}), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.UpdateUserGroup(context.TODO(), uuid.Nil, repository.UpdateUserGroupArgs{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -48,12 +49,12 @@ func TestRepositoryImpl_UpdateUserGroup(t *testing.T) {
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
 		a := random2.AlphaNumeric(20)
-		if assert.NoError(repo.UpdateUserGroup(g.ID, repository.UpdateUserGroupArgs{
+		if assert.NoError(repo.UpdateUserGroup(context.TODO(), g.ID, repository.UpdateUserGroupArgs{
 			Name:        optional.From(a),
 			Description: optional.From(a),
 			Type:        optional.From(a),
 		})) {
-			g, err := repo.GetUserGroup(g.ID)
+			g, err := repo.GetUserGroup(context.TODO(), g.ID)
 			require.NoError(err)
 			assert.Equal(a, g.Name)
 			assert.Equal(a, g.Description)
@@ -65,19 +66,19 @@ func TestRepositoryImpl_UpdateUserGroup(t *testing.T) {
 		t.Parallel()
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		assert.NoError(t, repo.UpdateUserGroup(g.ID, repository.UpdateUserGroupArgs{}))
+		assert.NoError(t, repo.UpdateUserGroup(context.TODO(), g.ID, repository.UpdateUserGroupArgs{}))
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateUserGroup(uuid.Must(uuid.NewV4()), repository.UpdateUserGroupArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateUserGroup(context.TODO(), uuid.Must(uuid.NewV4()), repository.UpdateUserGroupArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.UpdateUserGroup(uuid.Must(uuid.NewV7()), repository.UpdateUserGroupArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateUserGroup(context.TODO(), uuid.Must(uuid.NewV7()), repository.UpdateUserGroupArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("duplicate", func(t *testing.T) {
@@ -86,7 +87,7 @@ func TestRepositoryImpl_UpdateUserGroup(t *testing.T) {
 		mustMakeUserGroup(t, repo, a, user.GetID())
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		assert.EqualError(t, repo.UpdateUserGroup(g.ID, repository.UpdateUserGroupArgs{Name: optional.From(a)}), repository.ErrAlreadyExists.Error())
+		assert.EqualError(t, repo.UpdateUserGroup(context.TODO(), g.ID, repository.UpdateUserGroupArgs{Name: optional.From(a)}), repository.ErrAlreadyExists.Error())
 	})
 }
 
@@ -97,26 +98,26 @@ func TestRepositoryImpl_DeleteUserGroup(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Error(t, repo.DeleteUserGroup(uuid.Nil))
+		assert.Error(t, repo.DeleteUserGroup(context.TODO(), uuid.Nil))
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteUserGroup(uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteUserGroup(context.TODO(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.DeleteUserGroup(uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteUserGroup(context.TODO(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		assert.NoError(t, repo.DeleteUserGroup(g.ID))
+		assert.NoError(t, repo.DeleteUserGroup(context.TODO(), g.ID))
 	})
 }
 
@@ -127,21 +128,21 @@ func TestRepositoryImpl_GetUserGroup(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserGroup(uuid.Nil)
+		_, err := repo.GetUserGroup(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserGroup(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetUserGroup(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserGroup(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetUserGroup(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -150,7 +151,7 @@ func TestRepositoryImpl_GetUserGroup(t *testing.T) {
 		assert := assert.New(t)
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		a, err := repo.GetUserGroup(g.ID)
+		a, err := repo.GetUserGroup(context.TODO(), g.ID)
 		if assert.NoError(err) {
 			assert.Equal(g.ID, a.ID)
 			assert.Equal(g.Name, a.Name)
@@ -166,14 +167,14 @@ func TestRepositoryImpl_GetUserGroupByName(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserGroupByName("")
+		_, err := repo.GetUserGroupByName(context.TODO(), "")
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserGroupByName(random2.AlphaNumeric(20))
+		_, err := repo.GetUserGroupByName(context.TODO(), random2.AlphaNumeric(20))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -182,7 +183,7 @@ func TestRepositoryImpl_GetUserGroupByName(t *testing.T) {
 		assert := assert.New(t)
 		g := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		a, err := repo.GetUserGroupByName(g.Name)
+		a, err := repo.GetUserGroupByName(context.TODO(), g.Name)
 		if assert.NoError(err) {
 			assert.Equal(g.ID, a.ID)
 			assert.Equal(g.Name, a.Name)
@@ -207,7 +208,7 @@ func TestRepositoryImpl_GetUserBelongingGroups(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		gs, err := repo.GetUserBelongingGroupIDs(uuid.Nil)
+		gs, err := repo.GetUserBelongingGroupIDs(context.TODO(), uuid.Nil)
 		if assert.NoError(t, err) {
 			assert.Empty(t, gs)
 		}
@@ -216,7 +217,7 @@ func TestRepositoryImpl_GetUserBelongingGroups(t *testing.T) {
 	t.Run("success1", func(t *testing.T) {
 		t.Parallel()
 
-		gs, err := repo.GetUserBelongingGroupIDs(user.GetID())
+		gs, err := repo.GetUserBelongingGroupIDs(context.TODO(), user.GetID())
 		if assert.NoError(t, err) {
 			assert.ElementsMatch(t, gs, []uuid.UUID{g1.ID, g2.ID})
 		}
@@ -225,7 +226,7 @@ func TestRepositoryImpl_GetUserBelongingGroups(t *testing.T) {
 	t.Run("success2", func(t *testing.T) {
 		t.Parallel()
 
-		gs, err := repo.GetUserBelongingGroupIDs(user2.GetID())
+		gs, err := repo.GetUserBelongingGroupIDs(context.TODO(), user2.GetID())
 		if assert.NoError(t, err) {
 			assert.ElementsMatch(t, gs, []uuid.UUID{g1.ID})
 		}
@@ -240,7 +241,7 @@ func TestRepositoryImpl_GetAllUserGroups(t *testing.T) {
 	mustMakeUserGroup(t, repo, rand, user.GetID())
 	mustMakeUserGroup(t, repo, rand, user.GetID())
 
-	gs, err := repo.GetAllUserGroups()
+	gs, err := repo.GetAllUserGroups(context.TODO())
 	if assert.NoError(err) {
 		assert.Len(gs, 3)
 	}
@@ -255,19 +256,19 @@ func TestRepositoryImpl_AddUserToGroup(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.AddUserToGroup(uuid.Nil, g.ID, ""), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.AddUserToGroup(context.TODO(), uuid.Nil, g.ID, ""), repository.ErrNilID.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		assert.NoError(t, repo.AddUserToGroup(user.GetID(), g.ID, ""))
+		assert.NoError(t, repo.AddUserToGroup(context.TODO(), user.GetID(), g.ID, ""))
 
-		g, err := repo.GetUserGroup(g.ID)
+		g, err := repo.GetUserGroup(context.TODO(), g.ID)
 		require.NoError(t, err)
 		assert.True(t, g.IsMember(user.GetID()))
 
-		assert.NoError(t, repo.AddUserToGroup(user.GetID(), g.ID, ""))
+		assert.NoError(t, repo.AddUserToGroup(context.TODO(), user.GetID(), g.ID, ""))
 	})
 
 	t.Run("success concurrently", func(t *testing.T) {
@@ -279,7 +280,7 @@ func TestRepositoryImpl_AddUserToGroup(t *testing.T) {
 			wg.Add(1)
 			go func(t *testing.T) {
 				defer wg.Done()
-				assert.NoError(t, repo.AddUserToGroup(user.GetID(), g.ID, ""))
+				assert.NoError(t, repo.AddUserToGroup(context.TODO(), user.GetID(), g.ID, ""))
 			}(t)
 		}
 
@@ -297,19 +298,19 @@ func TestRepositoryImpl_RemoveUserFromGroup(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.RemoveUserFromGroup(uuid.Nil, g.ID), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.RemoveUserFromGroup(context.TODO(), uuid.Nil, g.ID), repository.ErrNilID.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		assert.NoError(t, repo.RemoveUserFromGroup(user.GetID(), g.ID))
+		assert.NoError(t, repo.RemoveUserFromGroup(context.TODO(), user.GetID(), g.ID))
 
-		g, err := repo.GetUserGroup(g.ID)
+		g, err := repo.GetUserGroup(context.TODO(), g.ID)
 		require.NoError(t, err)
 		assert.False(t, g.IsMember(user.GetID()))
 
-		assert.NoError(t, repo.RemoveUserFromGroup(user.GetID(), g.ID))
+		assert.NoError(t, repo.RemoveUserFromGroup(context.TODO(), user.GetID(), g.ID))
 	})
 }
 
@@ -323,32 +324,32 @@ func TestRepositoryImpl_AddUserToGroupAdmin(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.AddUserToGroupAdmin(uuid.Nil, g.ID), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.AddUserToGroupAdmin(context.TODO(), uuid.Nil, g.ID), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.AddUserToGroupAdmin(user2.GetID(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.AddUserToGroupAdmin(context.TODO(), user2.GetID(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.AddUserToGroupAdmin(user2.GetID(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.AddUserToGroupAdmin(context.TODO(), user2.GetID(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		assert.NoError(t, repo.AddUserToGroupAdmin(user2.GetID(), g.ID))
+		assert.NoError(t, repo.AddUserToGroupAdmin(context.TODO(), user2.GetID(), g.ID))
 
-		g, err := repo.GetUserGroup(g.ID)
+		g, err := repo.GetUserGroup(context.TODO(), g.ID)
 		require.NoError(t, err)
 		assert.True(t, g.IsAdmin(user.GetID()))
 		assert.True(t, g.IsAdmin(user2.GetID()))
 
-		assert.NoError(t, repo.AddUserToGroupAdmin(user2.GetID(), g.ID))
+		assert.NoError(t, repo.AddUserToGroupAdmin(context.TODO(), user2.GetID(), g.ID))
 	})
 }
 
@@ -358,43 +359,43 @@ func TestRepositoryImpl_RemoveUserFromGroupAdmin(t *testing.T) {
 	user2 := mustMakeUser(t, repo, rand, false)
 
 	g := mustMakeUserGroup(t, repo, rand, user.GetID())
-	require.NoError(t, repo.AddUserToGroupAdmin(user2.GetID(), g.ID))
+	require.NoError(t, repo.AddUserToGroupAdmin(context.TODO(), user2.GetID(), g.ID))
 
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(uuid.Nil, g.ID), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), uuid.Nil, g.ID), repository.ErrNilID.Error())
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(user2.GetID(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), user2.GetID(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(user2.GetID(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), user2.GetID(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("cannot remove last admin", func(t *testing.T) {
 		t.Parallel()
 		g2 := mustMakeUserGroup(t, repo, rand, user.GetID())
 
-		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(user.GetID(), g2.ID), repository.ErrForbidden.Error())
+		assert.EqualError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), user.GetID(), g2.ID), repository.ErrForbidden.Error())
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		assert.NoError(t, repo.RemoveUserFromGroupAdmin(user2.GetID(), g.ID))
+		assert.NoError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), user2.GetID(), g.ID))
 
-		g, err := repo.GetUserGroup(g.ID)
+		g, err := repo.GetUserGroup(context.TODO(), g.ID)
 		require.NoError(t, err)
 		assert.True(t, g.IsAdmin(user.GetID()))
 		assert.False(t, g.IsAdmin(user2.GetID()))
 
-		assert.NoError(t, repo.RemoveUserFromGroupAdmin(user2.GetID(), g.ID))
+		assert.NoError(t, repo.RemoveUserFromGroupAdmin(context.TODO(), user2.GetID(), g.ID))
 	})
 }

--- a/repository/gorm/user_role.go
+++ b/repository/gorm/user_role.go
@@ -1,15 +1,19 @@
 package gorm
 
-import "github.com/traPtitech/traQ/model"
+import (
+	"context"
+
+	"github.com/traPtitech/traQ/model"
+)
 
 // CreateUserRoles implements UserRoleRepository interface.
-func (repo *Repository) CreateUserRoles(roles ...*model.UserRole) error {
-	return repo.db.Create(roles).Error
+func (repo *Repository) CreateUserRoles(ctx context.Context, roles ...*model.UserRole) error {
+	return repo.db.WithContext(ctx).Create(roles).Error
 }
 
 // GetAllUserRoles implements UserRoleRepository interface.
-func (repo *Repository) GetAllUserRoles() ([]*model.UserRole, error) {
+func (repo *Repository) GetAllUserRoles(ctx context.Context) ([]*model.UserRole, error) {
 	var roles []*model.UserRole
-	err := repo.db.Preload("Inheritances").Preload("Permissions").Find(&roles).Error
+	err := repo.db.WithContext(ctx).Preload("Inheritances").Preload("Permissions").Find(&roles).Error
 	return roles, err
 }

--- a/repository/gorm/user_role_test.go
+++ b/repository/gorm/user_role_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestGormRepository_CreateUserRoles(t *testing.T) {
 	r2.Inheritances = append(r2.Inheritances, r3)
 	r3.Inheritances = append(r3.Inheritances, r4)
 
-	err := repo.CreateUserRoles(r1, r2, r3, r4)
+	err := repo.CreateUserRoles(context.TODO(), r1, r2, r3, r4)
 	assert.NoError(err)
 }
 
@@ -37,10 +38,10 @@ func TestGormRepository_GetAllUserRoles(t *testing.T) {
 	r2.Inheritances = append(r2.Inheritances, r3)
 	r3.Inheritances = append(r3.Inheritances, r4)
 
-	err := repo.CreateUserRoles(r1, r2, r3, r4)
+	err := repo.CreateUserRoles(context.TODO(), r1, r2, r3, r4)
 	require.NoError(err)
 
-	roles, err := repo.GetAllUserRoles()
+	roles, err := repo.GetAllUserRoles(context.TODO())
 	if assert.NoError(err) {
 		assert.Len(roles, 4)
 		sort.Slice(roles, func(i, j int) bool {

--- a/repository/gorm/user_settings.go
+++ b/repository/gorm/user_settings.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -10,24 +12,24 @@ import (
 const defaultNotifyCitation = false
 
 // UpdateNotifyCitation implements UserSettingsRepository interface
-func (repo *Repository) UpdateNotifyCitation(userID uuid.UUID, isEnable bool) error {
+func (repo *Repository) UpdateNotifyCitation(ctx context.Context, userID uuid.UUID, isEnable bool) error {
 	if userID == uuid.Nil {
 		return repository.ErrNilID
 	}
 
 	settings := model.UserSettings{}
 
-	if err := repo.db.First(&settings, "user_id=?", userID).Error; err != nil {
+	if err := repo.db.WithContext(ctx).First(&settings, "user_id=?", userID).Error; err != nil {
 		err = convertError(err)
 		if err == repository.ErrNotFound {
-			return repo.db.Create(&model.UserSettings{
+			return repo.db.WithContext(ctx).Create(&model.UserSettings{
 				UserID:         userID,
 				NotifyCitation: isEnable,
 			}).Error
 		}
 		return err
 	}
-	if err := repo.db.Model(&settings).Updates(map[string]interface{}{
+	if err := repo.db.WithContext(ctx).Model(&settings).Updates(map[string]interface{}{
 		"user_id":         userID,
 		"notify_citation": isEnable,
 	}).Error; err != nil {
@@ -38,14 +40,14 @@ func (repo *Repository) UpdateNotifyCitation(userID uuid.UUID, isEnable bool) er
 }
 
 // GetNotifyCitation implements UserSettingsRepository interface
-func (repo *Repository) GetNotifyCitation(userID uuid.UUID) (bool, error) {
+func (repo *Repository) GetNotifyCitation(ctx context.Context, userID uuid.UUID) (bool, error) {
 	if userID == uuid.Nil {
 		return defaultNotifyCitation, repository.ErrNilID
 	}
 
 	settings := model.UserSettings{}
 
-	if err := repo.db.First(&settings, "user_id=?", userID).Error; err != nil {
+	if err := repo.db.WithContext(ctx).First(&settings, "user_id=?", userID).Error; err != nil {
 		err = convertError(err)
 		if err == repository.ErrNotFound {
 			return defaultNotifyCitation, nil
@@ -57,13 +59,13 @@ func (repo *Repository) GetNotifyCitation(userID uuid.UUID) (bool, error) {
 }
 
 // GetUserSettings implements UserSettingsRepository interface
-func (repo *Repository) GetUserSettings(userID uuid.UUID) (*model.UserSettings, error) {
+func (repo *Repository) GetUserSettings(ctx context.Context, userID uuid.UUID) (*model.UserSettings, error) {
 	if userID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
 	settings := model.UserSettings{}
 
-	if err := repo.db.First(&settings, "user_id=?", userID).Error; err != nil {
+	if err := repo.db.WithContext(ctx).First(&settings, "user_id=?", userID).Error; err != nil {
 		err = convertError(err)
 		dus := &model.UserSettings{
 			UserID:         userID,

--- a/repository/gorm/user_test.go
+++ b/repository/gorm/user_test.go
@@ -290,8 +290,8 @@ func TestGormRepository_GetUserStats(t *testing.T) {
 		for i := range 15 {
 			messages[i] = mustMakeMessage(t, repo, user.GetID(), channel.ID)
 		}
-		require.NoError(t, repo.DeleteMessage(messages[14].ID))
-		require.NoError(t, repo.DeleteMessage(messages[13].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), messages[14].ID))
+		require.NoError(t, repo.DeleteMessage(context.TODO(), messages[13].ID))
 
 		for i := range 5 {
 			for range 3 {

--- a/repository/gorm/user_test.go
+++ b/repository/gorm/user_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestRepositoryImpl_GetUsers(t *testing.T) {
 	repo, assert, require := setup(t, ex2)
 	mustMakeUser(t, repo, "traq", false)
 
-	u0, err := repo.GetUserByName("traq", false)
+	u0, err := repo.GetUserByName(context.TODO(), "traq", false)
 	require.NoError(err)
 	g1 := mustMakeUserGroup(t, repo, rand, u0.GetID())
 	us := make([]uuid.UUID, 0)
@@ -106,7 +107,7 @@ func TestRepositoryImpl_GetUsers(t *testing.T) {
 				q.IsGMemberOf = optional.From(g1.ID)
 			}
 
-			uids, err := repo.GetUserIDs(q)
+			uids, err := repo.GetUserIDs(context.TODO(), q)
 			if assert.NoError(err) {
 				assert.ElementsMatch(uids, ans)
 			}
@@ -116,7 +117,7 @@ func TestRepositoryImpl_GetUsers(t *testing.T) {
 	t.Run("GetUsers", func(t *testing.T) {
 		t.Parallel()
 
-		users, err := repo.GetUsers(repository.UsersQuery{})
+		users, err := repo.GetUsers(context.TODO(), repository.UsersQuery{})
 		if assert.NoError(err) {
 			assert.Len(users, len(us))
 		}
@@ -127,10 +128,10 @@ func TestRepositoryImpl_GetUser(t *testing.T) {
 	t.Parallel()
 	repo, assert, _, user := setupWithUser(t, common2, false)
 
-	_, err := repo.GetUser(uuid.Nil, false)
+	_, err := repo.GetUser(context.TODO(), uuid.Nil, false)
 	assert.Error(err)
 
-	u, err := repo.GetUser(user.GetID(), false)
+	u, err := repo.GetUser(context.TODO(), user.GetID(), false)
 	if assert.NoError(err) {
 		assert.Equal(user.GetID(), u.GetID())
 		assert.Equal(user.GetName(), u.GetName())
@@ -141,10 +142,10 @@ func TestRepositoryImpl_GetUserByName(t *testing.T) {
 	t.Parallel()
 	repo, assert, _, user := setupWithUser(t, common2, false)
 
-	_, err := repo.GetUserByName("", false)
+	_, err := repo.GetUserByName(context.TODO(), "", false)
 	assert.Error(err)
 
-	u, err := repo.GetUserByName(user.GetName(), false)
+	u, err := repo.GetUserByName(context.TODO(), user.GetName(), false)
 	if assert.NoError(err) {
 		assert.Equal(user.GetID(), u.GetID())
 		assert.Equal(user.GetName(), u.GetName())
@@ -159,25 +160,25 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		assert.NoError(repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{}))
+		assert.NoError(repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{}))
 	})
 
 	t.Run("Nil ID", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		assert.EqualError(repo.UpdateUser(uuid.Nil, repository.UpdateUserArgs{}), repository.ErrNilID.Error())
+		assert.EqualError(repo.UpdateUser(context.TODO(), uuid.Nil, repository.UpdateUserArgs{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("Unknown User(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		assert.EqualError(repo.UpdateUser(uuid.Must(uuid.NewV4()), repository.UpdateUserArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateUser(context.TODO(), uuid.Must(uuid.NewV4()), repository.UpdateUserArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("Unknown User(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		assert.EqualError(repo.UpdateUser(uuid.Must(uuid.NewV7()), repository.UpdateUserArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(repo.UpdateUser(context.TODO(), uuid.Must(uuid.NewV7()), repository.UpdateUserArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("DisplayName", func(t *testing.T) {
@@ -189,8 +190,8 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 			assert, require := assertAndRequire(t)
 			newDN := random2.AlphaNumeric(32)
 
-			if assert.NoError(repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{DisplayName: optional.From(newDN)})) {
-				u, err := repo.GetUser(user.GetID(), true)
+			if assert.NoError(repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{DisplayName: optional.From(newDN)})) {
+				u, err := repo.GetUser(context.TODO(), user.GetID(), true)
 				require.NoError(err)
 				assert.Equal(newDN, u.GetDisplayName())
 			}
@@ -205,7 +206,7 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 		t.Run("Failed", func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From("ああああ")})
+			err := repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From("ああああ")})
 			if assert.IsType(&repository.ArgumentError{}, err) {
 				assert.Equal("args.TwitterID", err.(*repository.ArgumentError).FieldName)
 			}
@@ -215,8 +216,8 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 			assert, require := assertAndRequire(t)
 			newTwitter := "aiueo"
 
-			if assert.NoError(repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From(newTwitter)})) {
-				u, err := repo.GetUser(user.GetID(), true)
+			if assert.NoError(repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From(newTwitter)})) {
+				u, err := repo.GetUser(context.TODO(), user.GetID(), true)
 				require.NoError(err)
 				assert.Equal(newTwitter, u.GetTwitterID())
 			}
@@ -226,8 +227,8 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 			assert, require := assertAndRequire(t)
 			newTwitter := ""
 
-			if assert.NoError(repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From(newTwitter)})) {
-				u, err := repo.GetUser(user.GetID(), true)
+			if assert.NoError(repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{TwitterID: optional.From(newTwitter)})) {
+				u, err := repo.GetUser(context.TODO(), user.GetID(), true)
 				require.NoError(err)
 				assert.Equal(newTwitter, u.GetTwitterID())
 			}
@@ -242,8 +243,8 @@ func TestRepositoryImpl_UpdateUser(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			assert, require := assertAndRequire(t)
 
-			if assert.NoError(repo.UpdateUser(user.GetID(), repository.UpdateUserArgs{Role: optional.From("admin")})) {
-				u, err := repo.GetUser(user.GetID(), false)
+			if assert.NoError(repo.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{Role: optional.From("admin")})) {
+				u, err := repo.GetUser(context.TODO(), user.GetID(), false)
 				require.NoError(err)
 				assert.Equal("admin", u.GetRole())
 			}
@@ -258,21 +259,21 @@ func TestGormRepository_GetUserStats(t *testing.T) {
 	t.Run("nil id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserStats(uuid.Nil)
+		_, err := repo.GetUserStats(context.TODO(), uuid.Nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserStats(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetUserStats(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.Error(t, err)
 	})
 
 	t.Run("not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.GetUserStats(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetUserStats(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.Error(t, err)
 	})
 
@@ -302,7 +303,7 @@ func TestGormRepository_GetUserStats(t *testing.T) {
 			mustAddMessageStamp(t, repo, messages[i].ID, stamp2.ID, user.GetID())
 		}
 
-		stats, err := repo.GetUserStats(user.GetID())
+		stats, err := repo.GetUserStats(context.TODO(), user.GetID())
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, stats.DateTime)
 

--- a/repository/gorm/webhook.go
+++ b/repository/gorm/webhook.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"encoding/base64"
 	"unicode/utf8"
 
@@ -15,7 +16,7 @@ import (
 )
 
 // CreateWebhook implements WebhookRepository interface.
-func (repo *Repository) CreateWebhook(name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
+func (repo *Repository) CreateWebhook(ctx context.Context, name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
 	if len(name) == 0 || utf8.RuneCountInString(name) > 32 {
 		return nil, repository.ArgError("name", "Name must be non-empty and shorter than 33 characters")
 	}
@@ -41,7 +42,7 @@ func (repo *Repository) CreateWebhook(name, description string, channelID, iconF
 		CreatorID:   creatorID,
 	}
 
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// チャンネル検証
 		var ch model.Channel
 		if err := tx.First(&ch, &model.Channel{ID: channelID}).Error; err != nil {
@@ -83,7 +84,7 @@ func (repo *Repository) CreateWebhook(name, description string, channelID, iconF
 }
 
 // UpdateWebhook implements WebhookRepository interface.
-func (repo *Repository) UpdateWebhook(id uuid.UUID, args repository.UpdateWebhookArgs) error {
+func (repo *Repository) UpdateWebhook(ctx context.Context, id uuid.UUID, args repository.UpdateWebhookArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -92,7 +93,7 @@ func (repo *Repository) UpdateWebhook(id uuid.UUID, args repository.UpdateWebhoo
 		updated     bool
 		userUpdated bool
 	)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where(&model.WebhookBot{ID: id}).First(&w).Error; err != nil {
 			return convertError(err)
 		}
@@ -176,11 +177,11 @@ func (repo *Repository) UpdateWebhook(id uuid.UUID, args repository.UpdateWebhoo
 }
 
 // DeleteWebhook implements WebhookRepository interface.
-func (repo *Repository) DeleteWebhook(id uuid.UUID) error {
+func (repo *Repository) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var b model.WebhookBot
 		if err := tx.Take(&b, &model.WebhookBot{ID: id}).Error; err != nil {
 			return convertError(err)
@@ -204,33 +205,33 @@ func (repo *Repository) DeleteWebhook(id uuid.UUID) error {
 }
 
 // GetWebhook implements WebhookRepository interface.
-func (repo *Repository) GetWebhook(id uuid.UUID) (model.Webhook, error) {
+func (repo *Repository) GetWebhook(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	b := &model.WebhookBot{}
-	if err := repo.db.Preload("BotUser").Where(&model.WebhookBot{ID: id}).Take(b).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Preload("BotUser").Where(&model.WebhookBot{ID: id}).Take(b).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return b, nil
 }
 
 // GetWebhookByBotUserID implements WebhookRepository interface.
-func (repo *Repository) GetWebhookByBotUserID(id uuid.UUID) (model.Webhook, error) {
+func (repo *Repository) GetWebhookByBotUserID(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
 	b := &model.WebhookBot{}
-	if err := repo.db.Preload("BotUser").Where(&model.WebhookBot{BotUserID: id}).Take(b).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Preload("BotUser").Where(&model.WebhookBot{BotUserID: id}).Take(b).Error; err != nil {
 		return nil, convertError(err)
 	}
 	return b, nil
 }
 
 // GetAllWebhooks implements WebhookRepository interface.
-func (repo *Repository) GetAllWebhooks() (arr []model.Webhook, err error) {
+func (repo *Repository) GetAllWebhooks(ctx context.Context) (arr []model.Webhook, err error) {
 	var webhooks []*model.WebhookBot
-	err = repo.db.Preload("BotUser").Find(&webhooks).Error
+	err = repo.db.WithContext(ctx).Preload("BotUser").Find(&webhooks).Error
 	if err != nil {
 		return nil, err
 	}
@@ -242,14 +243,14 @@ func (repo *Repository) GetAllWebhooks() (arr []model.Webhook, err error) {
 }
 
 // GetWebhooksByCreator implements WebhookRepository interface.
-func (repo *Repository) GetWebhooksByCreator(creatorID uuid.UUID) (arr []model.Webhook, err error) {
+func (repo *Repository) GetWebhooksByCreator(ctx context.Context, creatorID uuid.UUID) (arr []model.Webhook, err error) {
 	arr = make([]model.Webhook, 0)
 	if creatorID == uuid.Nil {
 		return arr, nil
 	}
 
 	var webhooks []*model.WebhookBot
-	err = repo.db.Preload("BotUser").Where(&model.WebhookBot{CreatorID: creatorID}).Find(&webhooks).Error
+	err = repo.db.WithContext(ctx).Preload("BotUser").Where(&model.WebhookBot{CreatorID: creatorID}).Find(&webhooks).Error
 	if err != nil {
 		return nil, err
 	}

--- a/repository/gorm/webhook.go
+++ b/repository/gorm/webhook.go
@@ -122,7 +122,7 @@ func (repo *Repository) UpdateWebhook(ctx context.Context, id uuid.UUID, args re
 		}
 		if args.CreatorID.Valid {
 			// 作成者検証
-			user, err := repo.GetUser(args.CreatorID.V, false)
+			user, err := repo.GetUser(context.TODO(), args.CreatorID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.CreatorID", "the Creator is not found")

--- a/repository/gorm/webhook_test.go
+++ b/repository/gorm/webhook_test.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -21,23 +22,23 @@ func TestRepositoryImpl_CreateWebhook(t *testing.T) {
 	fid := mustMakeDummyFile(t, repo, false).ID
 	t.Run("Invalid name", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.CreateWebhook("", "", channel.ID, fid, user.GetID(), "")
+		_, err := repo.CreateWebhook(context.TODO(), "", "", channel.ID, fid, user.GetID(), "")
 		assert.Error(t, err)
-		_, err = repo.CreateWebhook(strings.Repeat("a", 40), "", channel.ID, fid, user.GetID(), "")
+		_, err = repo.CreateWebhook(context.TODO(), strings.Repeat("a", 40), "", channel.ID, fid, user.GetID(), "")
 		assert.Error(t, err)
 	})
 
 	t.Run("channel not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateWebhook(random2.AlphaNumeric(20), "aaa", uuid.Must(uuid.NewV4()), fid, user.GetID(), "test")
+		_, err := repo.CreateWebhook(context.TODO(), random2.AlphaNumeric(20), "aaa", uuid.Must(uuid.NewV4()), fid, user.GetID(), "test")
 		assert.Error(t, err)
 	})
 
 	t.Run("channel not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := repo.CreateWebhook(random2.AlphaNumeric(20), "aaa", uuid.Must(uuid.NewV7()), fid, user.GetID(), "test")
+		_, err := repo.CreateWebhook(context.TODO(), random2.AlphaNumeric(20), "aaa", uuid.Must(uuid.NewV7()), fid, user.GetID(), "test")
 		assert.Error(t, err)
 	})
 
@@ -45,7 +46,7 @@ func TestRepositoryImpl_CreateWebhook(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		wb, err := repo.CreateWebhook("test", "aaa", channel.ID, fid, user.GetID(), "test")
+		wb, err := repo.CreateWebhook(context.TODO(), "test", "aaa", channel.ID, fid, user.GetID(), "test")
 		if assert.NoError(err) {
 			assert.Equal("test", wb.GetName())
 			assert.Equal("aaa", wb.GetDescription())
@@ -69,23 +70,23 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.UpdateWebhook(uuid.Nil, repository.UpdateWebhookArgs{}), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.UpdateWebhook(context.TODO(), uuid.Nil, repository.UpdateWebhookArgs{}), repository.ErrNilID.Error())
 	})
 
 	t.Run("Not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.UpdateWebhook(uuid.Must(uuid.NewV4()), repository.UpdateWebhookArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateWebhook(context.TODO(), uuid.Must(uuid.NewV4()), repository.UpdateWebhookArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.UpdateWebhook(uuid.Must(uuid.NewV7()), repository.UpdateWebhookArgs{}), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.UpdateWebhook(context.TODO(), uuid.Must(uuid.NewV7()), repository.UpdateWebhookArgs{}), repository.ErrNotFound.Error())
 	})
 
 	t.Run("Invalid name", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			Name: optional.From(strings.Repeat("a", 40)),
 		})
 		assert.Error(t, err)
@@ -94,7 +95,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("channel not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			ChannelID: optional.From(uuid.Must(uuid.NewV4())),
 		})
 		assert.Error(t, err)
@@ -103,7 +104,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("channel not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			ChannelID: optional.From(uuid.Must(uuid.NewV7())),
 		})
 		assert.Error(t, err)
@@ -112,7 +113,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("creator not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			CreatorID: optional.From(uuid.Must(uuid.NewV4())),
 		})
 		assert.Error(t, err)
@@ -121,7 +122,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("creator not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			CreatorID: optional.From(uuid.Must(uuid.NewV7())),
 		})
 		assert.Error(t, err)
@@ -130,7 +131,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("invalid creator", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			CreatorID: optional.From(wb.GetBotUserID()),
 		})
 		assert.Error(t, err)
@@ -139,7 +140,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 	t.Run("No changes", func(t *testing.T) {
 		t.Parallel()
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{})
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{})
 		assert.NoError(t, err)
 	})
 
@@ -149,7 +150,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 		ch := mustMakeChannel(t, repo, rand)
 		assert, require := assertAndRequire(t)
 
-		err := repo.UpdateWebhook(wb.GetID(), repository.UpdateWebhookArgs{
+		err := repo.UpdateWebhook(context.TODO(), wb.GetID(), repository.UpdateWebhookArgs{
 			Description: optional.From("new description"),
 			Name:        optional.From("new name"),
 			Secret:      optional.From("new secret"),
@@ -157,7 +158,7 @@ func TestRepositoryImpl_UpdateWebhook(t *testing.T) {
 			CreatorID:   optional.From(user.GetID()),
 		})
 		if assert.NoError(err) {
-			wb, err := repo.GetWebhook(wb.GetID())
+			wb, err := repo.GetWebhook(context.TODO(), wb.GetID())
 			require.NoError(err)
 			assert.Equal("new name", wb.GetName())
 			assert.Equal("new description", wb.GetDescription())
@@ -174,17 +175,17 @@ func TestRepositoryImpl_DeleteWebhook(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.DeleteWebhook(uuid.Nil), repository.ErrNilID.Error())
+		assert.EqualError(t, repo.DeleteWebhook(context.TODO(), uuid.Nil), repository.ErrNilID.Error())
 	})
 
 	t.Run("Not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.DeleteWebhook(uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteWebhook(context.TODO(), uuid.Must(uuid.NewV4())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
-		assert.EqualError(t, repo.DeleteWebhook(uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
+		assert.EqualError(t, repo.DeleteWebhook(context.TODO(), uuid.Must(uuid.NewV7())), repository.ErrNotFound.Error())
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -192,9 +193,9 @@ func TestRepositoryImpl_DeleteWebhook(t *testing.T) {
 		assert := assert.New(t)
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
 
-		err := repo.DeleteWebhook(wb.GetID())
+		err := repo.DeleteWebhook(context.TODO(), wb.GetID())
 		if assert.NoError(err) {
-			_, err := repo.GetWebhook(wb.GetID())
+			_, err := repo.GetWebhook(context.TODO(), wb.GetID())
 			assert.EqualError(err, repository.ErrNotFound.Error())
 		}
 	})
@@ -206,19 +207,19 @@ func TestRepositoryImpl_GetWebhook(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhook(uuid.Nil)
+		_, err := repo.GetWebhook(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhook(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetWebhook(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhook(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetWebhook(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -227,7 +228,7 @@ func TestRepositoryImpl_GetWebhook(t *testing.T) {
 		assert := assert.New(t)
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
 
-		w, err := repo.GetWebhook(wb.GetID())
+		w, err := repo.GetWebhook(context.TODO(), wb.GetID())
 		if assert.NoError(err) {
 			assert.Equal(wb.GetID(), w.GetID())
 			assert.Equal(wb.GetName(), w.GetName())
@@ -246,19 +247,19 @@ func TestRepositoryImpl_GetWebhookByBotUserId(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhookByBotUserID(uuid.Nil)
+		_, err := repo.GetWebhookByBotUserID(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv4)", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhookByBotUserID(uuid.Must(uuid.NewV4()))
+		_, err := repo.GetWebhookByBotUserID(context.TODO(), uuid.Must(uuid.NewV4()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("Not found(UUIDv7)", func(t *testing.T) {
 		t.Parallel()
-		_, err := repo.GetWebhookByBotUserID(uuid.Must(uuid.NewV7()))
+		_, err := repo.GetWebhookByBotUserID(context.TODO(), uuid.Must(uuid.NewV7()))
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -267,7 +268,7 @@ func TestRepositoryImpl_GetWebhookByBotUserId(t *testing.T) {
 		assert := assert.New(t)
 		wb := mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
 
-		w, err := repo.GetWebhookByBotUserID(wb.GetBotUserID())
+		w, err := repo.GetWebhookByBotUserID(context.TODO(), wb.GetBotUserID())
 		if assert.NoError(err) {
 			assert.Equal(wb.GetID(), w.GetID())
 			assert.Equal(wb.GetName(), w.GetName())
@@ -289,7 +290,7 @@ func TestRepositoryImpl_GetAllWebhooks(t *testing.T) {
 		mustMakeWebhook(t, repo, rand, channel.ID, user.GetID(), "test")
 	}
 
-	arr, err := repo.GetAllWebhooks()
+	arr, err := repo.GetAllWebhooks(context.TODO())
 	if assert.NoError(err) {
 		assert.Len(arr, n)
 	}
@@ -308,7 +309,7 @@ func TestRepositoryImpl_GetWebhooksByCreator(t *testing.T) {
 
 	t.Run("Nil id", func(t *testing.T) {
 		t.Parallel()
-		arr, err := repo.GetWebhooksByCreator(uuid.Nil)
+		arr, err := repo.GetWebhooksByCreator(context.TODO(), uuid.Nil)
 		if assert.NoError(t, err) {
 			assert.Empty(t, arr)
 		}
@@ -316,7 +317,7 @@ func TestRepositoryImpl_GetWebhooksByCreator(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		arr, err := repo.GetWebhooksByCreator(user.GetID())
+		arr, err := repo.GetWebhooksByCreator(context.TODO(), user.GetID())
 		if assert.NoError(t, err) {
 			assert.Len(t, arr, n)
 		}

--- a/repository/gorm/webhook_test.go
+++ b/repository/gorm/webhook_test.go
@@ -54,7 +54,7 @@ func TestRepositoryImpl_CreateWebhook(t *testing.T) {
 			assert.Equal(user.GetID(), wb.GetCreatorID())
 			assert.Equal("test", wb.GetSecret())
 
-			u, err := repo.GetUser(wb.GetBotUserID(), false)
+			u, err := repo.GetUser(context.TODO(), wb.GetBotUserID(), false)
 			if assert.NoError(err) {
 				assert.True(u.IsBot())
 				assert.Equal(role.Bot, u.GetRole())

--- a/repository/message.go
+++ b/repository/message.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/traPtitech/traQ/utils/optional"
@@ -43,87 +44,87 @@ type MessageRepository interface {
 	// 成功した場合、メッセージとnilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	CreateMessage(userID, channelID uuid.UUID, text string) (*model.Message, error)
+	CreateMessage(ctx context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error)
 	// UpdateMessage 指定したメッセージを更新します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateMessage(messageID uuid.UUID, text string) error
+	UpdateMessage(ctx context.Context, messageID uuid.UUID, text string) error
 	// DeleteMessage 指定したメッセージを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteMessage(messageID uuid.UUID) error
+	DeleteMessage(ctx context.Context, messageID uuid.UUID) error
 	// GetMessageByID 指定したメッセージを取得します
 	//
 	// 成功した場合、メッセージとnilを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetMessageByID(messageID uuid.UUID) (*model.Message, error)
+	GetMessageByID(ctx context.Context, messageID uuid.UUID) (*model.Message, error)
 	// GetMessages 指定したクエリでメッセージを取得します
 	//
 	// 成功した場合、メッセージの配列を返します。負のoffset, limitは無視されます。
 	// 指定した範囲内にlimitを超えてメッセージが存在していた場合、trueを返します。
 	// DBによるエラーを返すことがあります。
-	GetMessages(query MessagesQuery) (messages []*model.Message, more bool, err error)
+	GetMessages(ctx context.Context, query MessagesQuery) (messages []*model.Message, more bool, err error)
 	// GetUpdatedMessagesAfter 指定した時間より後に更新されたメッセージを取得します
 	//
 	// 成功した場合、updatedAtで昇順ソートされたメッセージの配列を返します。
 	// 指定した範囲内にlimitを超えてメッセージが存在していた場合、trueを返します。
 	// DBによるエラーを返すことがあります。
-	GetUpdatedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error)
+	GetUpdatedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error)
 	// GetDeletedMessagesAfter 指定した時間より後に削除されたメッセージを取得します
 	//
 	// 成功した場合、deletedAtで昇順ソートされたメッセージの配列を返します。
 	// 指定した範囲内にlimitを超えてメッセージが存在していた場合、trueを返します。
 	// DBによるエラーを返すことがあります。
-	GetDeletedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error)
+	GetDeletedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error)
 	// SetMessageUnreads ユーザーの集合について、指定したメッセージを未読にします
 	//
 	// 成功した場合、nilを返します。
 	// userNoticeableMap には、未読を追加するユーザーと、指定した各ユーザーに対しそのメッセージが noticeable (自分宛のメッセージが含まれているか) かどうかのマッピングを指定します。
 	// 引数にuuid.Nilを指定するもしくは引数中の要素にuuid.Nilが含まれるものを指定すると ErrNilID を返します。
 	// DBによるエラーを返すことがあります。
-	SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error
+	SetMessageUnreads(ctx context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error
 	// GetUnreadMessagesByUserID 指定したユーザーの未読メッセージをすべて取得します
 	//
 	// 成功した場合、メッセージの配列とnilを返します。
 	// 存在しないユーザーを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUnreadMessagesByUserID(userID uuid.UUID) ([]*model.Message, error)
+	GetUnreadMessagesByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Message, error)
 	// DeleteUnreadsByChannelID 指定したチャンネルに存在する、指定したユーザーの未読レコードをすべて削除します
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteUnreadsByChannelID(channelID, userID uuid.UUID) error
+	DeleteUnreadsByChannelID(ctx context.Context, channelID, userID uuid.UUID) error
 	// GetUserUnreadChannels 指定したユーザーの未読チャンネル一覧を取得します
 	//
 	// 成功した場合、UserUnreadChannelの配列とnilを返します。
 	// 存在しないユーザーを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserUnreadChannels(userID uuid.UUID) ([]*UserUnreadChannel, error)
+	GetUserUnreadChannels(ctx context.Context, userID uuid.UUID) ([]*UserUnreadChannel, error)
 	// GetChannelLatestMessages 全てのパブリックチャンネルの最新のメッセージの一覧を取得します
 	//
 	// 成功した場合、メッセージの配列とnilを返します。非正のlimitは無視されます。
 	// DBによるエラーを返すことがあります。
-	GetChannelLatestMessages(query ChannelLatestMessagesQuery) ([]*model.Message, error)
+	GetChannelLatestMessages(ctx context.Context, query ChannelLatestMessagesQuery) ([]*model.Message, error)
 	// AddStampToMessage 指定したメッセージに指定したユーザーの指定したスタンプを追加します
 	//
 	// 成功した場合、そのメッセージスタンプとnilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddStampToMessage(messageID, stampID, userID uuid.UUID, count int) (ms *model.MessageStamp, err error)
+	AddStampToMessage(ctx context.Context, messageID, stampID, userID uuid.UUID, count int) (ms *model.MessageStamp, err error)
 	// RemoveStampFromMessage 指定したメッセージから指定したユーザーの指定したスタンプを全て削除します
 	//
 	// 成功した、或いは既に削除されていた場合、nilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveStampFromMessage(messageID, stampID, userID uuid.UUID) (err error)
+	RemoveStampFromMessage(ctx context.Context, messageID, stampID, userID uuid.UUID) (err error)
 }
 
 // UserUnreadChannel ユーザーの未読チャンネル構造体

--- a/repository/message_report.go
+++ b/repository/message_report.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -14,22 +16,22 @@ type MessageReportRepository interface {
 	// 既に通報がされていた場合、ErrAlreadyExistsを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	CreateMessageReport(messageID, reporterID uuid.UUID, reason string) error
+	CreateMessageReport(ctx context.Context, messageID, reporterID uuid.UUID, reason string) error
 	// GetMessageReports メッセージ通報を通報日時の昇順で取得します
 	//
 	// 成功した場合、メッセージ通報の配列とnilを返します。負のoffset, limitは無視されます。
 	// DBによるエラーを返すことがあります。
-	GetMessageReports(offset, limit int) ([]*model.MessageReport, error)
+	GetMessageReports(ctx context.Context, offset, limit int) ([]*model.MessageReport, error)
 	// GetMessageReportsByMessageID 指定したメッセージのメッセージ通報を全て取得します
 	//
 	// 成功した場合、メッセージ通報の配列とnilを返します。
 	// 存在しないメッセージを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetMessageReportsByMessageID(messageID uuid.UUID) ([]*model.MessageReport, error)
+	GetMessageReportsByMessageID(ctx context.Context, messageID uuid.UUID) ([]*model.MessageReport, error)
 	// GetMessageReportsByReporterID 指定したユーザーによるメッセージ通報を全て取得します
 	//
 	// 成功した場合、メッセージ通報の配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetMessageReportsByReporterID(reporterID uuid.UUID) ([]*model.MessageReport, error)
+	GetMessageReportsByReporterID(ctx context.Context, reporterID uuid.UUID) ([]*model.MessageReport, error)
 }

--- a/repository/mock_repository/mock_bot.go
+++ b/repository/mock_repository/mock_bot.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -38,219 +39,219 @@ func (m *MockBotRepository) EXPECT() *MockBotRepositoryMockRecorder {
 }
 
 // AddBotToChannel mocks base method.
-func (m *MockBotRepository) AddBotToChannel(botID, channelID uuid.UUID) error {
+func (m *MockBotRepository) AddBotToChannel(ctx context.Context, botID, channelID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBotToChannel", botID, channelID)
+	ret := m.ctrl.Call(m, "AddBotToChannel", ctx, botID, channelID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddBotToChannel indicates an expected call of AddBotToChannel.
-func (mr *MockBotRepositoryMockRecorder) AddBotToChannel(botID, channelID interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) AddBotToChannel(ctx, botID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBotToChannel", reflect.TypeOf((*MockBotRepository)(nil).AddBotToChannel), botID, channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBotToChannel", reflect.TypeOf((*MockBotRepository)(nil).AddBotToChannel), ctx, botID, channelID)
 }
 
 // ChangeBotState mocks base method.
-func (m *MockBotRepository) ChangeBotState(id uuid.UUID, state model.BotState) error {
+func (m *MockBotRepository) ChangeBotState(ctx context.Context, id uuid.UUID, state model.BotState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeBotState", id, state)
+	ret := m.ctrl.Call(m, "ChangeBotState", ctx, id, state)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ChangeBotState indicates an expected call of ChangeBotState.
-func (mr *MockBotRepositoryMockRecorder) ChangeBotState(id, state interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) ChangeBotState(ctx, id, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeBotState", reflect.TypeOf((*MockBotRepository)(nil).ChangeBotState), id, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeBotState", reflect.TypeOf((*MockBotRepository)(nil).ChangeBotState), ctx, id, state)
 }
 
 // CreateBot mocks base method.
-func (m *MockBotRepository) CreateBot(name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error) {
+func (m *MockBotRepository) CreateBot(ctx context.Context, name, displayName, description string, iconFileID, creatorID uuid.UUID, mode model.BotMode, state model.BotState, webhookURL string) (*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBot", name, displayName, description, iconFileID, creatorID, mode, state, webhookURL)
+	ret := m.ctrl.Call(m, "CreateBot", ctx, name, displayName, description, iconFileID, creatorID, mode, state, webhookURL)
 	ret0, _ := ret[0].(*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateBot indicates an expected call of CreateBot.
-func (mr *MockBotRepositoryMockRecorder) CreateBot(name, displayName, description, iconFileID, creatorID, mode, state, webhookURL interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) CreateBot(ctx, name, displayName, description, iconFileID, creatorID, mode, state, webhookURL interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBot", reflect.TypeOf((*MockBotRepository)(nil).CreateBot), name, displayName, description, iconFileID, creatorID, mode, state, webhookURL)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBot", reflect.TypeOf((*MockBotRepository)(nil).CreateBot), ctx, name, displayName, description, iconFileID, creatorID, mode, state, webhookURL)
 }
 
 // DeleteBot mocks base method.
-func (m *MockBotRepository) DeleteBot(id uuid.UUID) error {
+func (m *MockBotRepository) DeleteBot(ctx context.Context, id uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBot", id)
+	ret := m.ctrl.Call(m, "DeleteBot", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteBot indicates an expected call of DeleteBot.
-func (mr *MockBotRepositoryMockRecorder) DeleteBot(id interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) DeleteBot(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBot", reflect.TypeOf((*MockBotRepository)(nil).DeleteBot), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBot", reflect.TypeOf((*MockBotRepository)(nil).DeleteBot), ctx, id)
 }
 
 // GetBotByBotUserID mocks base method.
-func (m *MockBotRepository) GetBotByBotUserID(id uuid.UUID) (*model.Bot, error) {
+func (m *MockBotRepository) GetBotByBotUserID(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBotByBotUserID", id)
+	ret := m.ctrl.Call(m, "GetBotByBotUserID", ctx, id)
 	ret0, _ := ret[0].(*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBotByBotUserID indicates an expected call of GetBotByBotUserID.
-func (mr *MockBotRepositoryMockRecorder) GetBotByBotUserID(id interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetBotByBotUserID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByBotUserID", reflect.TypeOf((*MockBotRepository)(nil).GetBotByBotUserID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByBotUserID", reflect.TypeOf((*MockBotRepository)(nil).GetBotByBotUserID), ctx, id)
 }
 
 // GetBotByCode mocks base method.
-func (m *MockBotRepository) GetBotByCode(code string) (*model.Bot, error) {
+func (m *MockBotRepository) GetBotByCode(ctx context.Context, code string) (*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBotByCode", code)
+	ret := m.ctrl.Call(m, "GetBotByCode", ctx, code)
 	ret0, _ := ret[0].(*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBotByCode indicates an expected call of GetBotByCode.
-func (mr *MockBotRepositoryMockRecorder) GetBotByCode(code interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetBotByCode(ctx, code interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByCode", reflect.TypeOf((*MockBotRepository)(nil).GetBotByCode), code)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByCode", reflect.TypeOf((*MockBotRepository)(nil).GetBotByCode), ctx, code)
 }
 
 // GetBotByID mocks base method.
-func (m *MockBotRepository) GetBotByID(id uuid.UUID) (*model.Bot, error) {
+func (m *MockBotRepository) GetBotByID(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBotByID", id)
+	ret := m.ctrl.Call(m, "GetBotByID", ctx, id)
 	ret0, _ := ret[0].(*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBotByID indicates an expected call of GetBotByID.
-func (mr *MockBotRepositoryMockRecorder) GetBotByID(id interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetBotByID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByID", reflect.TypeOf((*MockBotRepository)(nil).GetBotByID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotByID", reflect.TypeOf((*MockBotRepository)(nil).GetBotByID), ctx, id)
 }
 
 // GetBotEventLogs mocks base method.
-func (m *MockBotRepository) GetBotEventLogs(botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error) {
+func (m *MockBotRepository) GetBotEventLogs(ctx context.Context, botID uuid.UUID, limit, offset int) ([]*model.BotEventLog, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBotEventLogs", botID, limit, offset)
+	ret := m.ctrl.Call(m, "GetBotEventLogs", ctx, botID, limit, offset)
 	ret0, _ := ret[0].([]*model.BotEventLog)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBotEventLogs indicates an expected call of GetBotEventLogs.
-func (mr *MockBotRepositoryMockRecorder) GetBotEventLogs(botID, limit, offset interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetBotEventLogs(ctx, botID, limit, offset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotEventLogs", reflect.TypeOf((*MockBotRepository)(nil).GetBotEventLogs), botID, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBotEventLogs", reflect.TypeOf((*MockBotRepository)(nil).GetBotEventLogs), ctx, botID, limit, offset)
 }
 
 // GetBots mocks base method.
-func (m *MockBotRepository) GetBots(query repository.BotsQuery) ([]*model.Bot, error) {
+func (m *MockBotRepository) GetBots(ctx context.Context, query repository.BotsQuery) ([]*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBots", query)
+	ret := m.ctrl.Call(m, "GetBots", ctx, query)
 	ret0, _ := ret[0].([]*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBots indicates an expected call of GetBots.
-func (mr *MockBotRepositoryMockRecorder) GetBots(query interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetBots(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBots", reflect.TypeOf((*MockBotRepository)(nil).GetBots), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBots", reflect.TypeOf((*MockBotRepository)(nil).GetBots), ctx, query)
 }
 
 // GetParticipatingChannelIDsByBot mocks base method.
-func (m *MockBotRepository) GetParticipatingChannelIDsByBot(botID uuid.UUID) ([]uuid.UUID, error) {
+func (m *MockBotRepository) GetParticipatingChannelIDsByBot(ctx context.Context, botID uuid.UUID) ([]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetParticipatingChannelIDsByBot", botID)
+	ret := m.ctrl.Call(m, "GetParticipatingChannelIDsByBot", ctx, botID)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetParticipatingChannelIDsByBot indicates an expected call of GetParticipatingChannelIDsByBot.
-func (mr *MockBotRepositoryMockRecorder) GetParticipatingChannelIDsByBot(botID interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) GetParticipatingChannelIDsByBot(ctx, botID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParticipatingChannelIDsByBot", reflect.TypeOf((*MockBotRepository)(nil).GetParticipatingChannelIDsByBot), botID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParticipatingChannelIDsByBot", reflect.TypeOf((*MockBotRepository)(nil).GetParticipatingChannelIDsByBot), ctx, botID)
 }
 
 // PurgeBotEventLogs mocks base method.
-func (m *MockBotRepository) PurgeBotEventLogs(before time.Time) error {
+func (m *MockBotRepository) PurgeBotEventLogs(ctx context.Context, before time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PurgeBotEventLogs", before)
+	ret := m.ctrl.Call(m, "PurgeBotEventLogs", ctx, before)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PurgeBotEventLogs indicates an expected call of PurgeBotEventLogs.
-func (mr *MockBotRepositoryMockRecorder) PurgeBotEventLogs(before interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) PurgeBotEventLogs(ctx, before interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurgeBotEventLogs", reflect.TypeOf((*MockBotRepository)(nil).PurgeBotEventLogs), before)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurgeBotEventLogs", reflect.TypeOf((*MockBotRepository)(nil).PurgeBotEventLogs), ctx, before)
 }
 
 // ReissueBotTokens mocks base method.
-func (m *MockBotRepository) ReissueBotTokens(id uuid.UUID) (*model.Bot, error) {
+func (m *MockBotRepository) ReissueBotTokens(ctx context.Context, id uuid.UUID) (*model.Bot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReissueBotTokens", id)
+	ret := m.ctrl.Call(m, "ReissueBotTokens", ctx, id)
 	ret0, _ := ret[0].(*model.Bot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReissueBotTokens indicates an expected call of ReissueBotTokens.
-func (mr *MockBotRepositoryMockRecorder) ReissueBotTokens(id interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) ReissueBotTokens(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReissueBotTokens", reflect.TypeOf((*MockBotRepository)(nil).ReissueBotTokens), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReissueBotTokens", reflect.TypeOf((*MockBotRepository)(nil).ReissueBotTokens), ctx, id)
 }
 
 // RemoveBotFromChannel mocks base method.
-func (m *MockBotRepository) RemoveBotFromChannel(botID, channelID uuid.UUID) error {
+func (m *MockBotRepository) RemoveBotFromChannel(ctx context.Context, botID, channelID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveBotFromChannel", botID, channelID)
+	ret := m.ctrl.Call(m, "RemoveBotFromChannel", ctx, botID, channelID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveBotFromChannel indicates an expected call of RemoveBotFromChannel.
-func (mr *MockBotRepositoryMockRecorder) RemoveBotFromChannel(botID, channelID interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) RemoveBotFromChannel(ctx, botID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveBotFromChannel", reflect.TypeOf((*MockBotRepository)(nil).RemoveBotFromChannel), botID, channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveBotFromChannel", reflect.TypeOf((*MockBotRepository)(nil).RemoveBotFromChannel), ctx, botID, channelID)
 }
 
 // UpdateBot mocks base method.
-func (m *MockBotRepository) UpdateBot(id uuid.UUID, args repository.UpdateBotArgs) error {
+func (m *MockBotRepository) UpdateBot(ctx context.Context, id uuid.UUID, args repository.UpdateBotArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBot", id, args)
+	ret := m.ctrl.Call(m, "UpdateBot", ctx, id, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateBot indicates an expected call of UpdateBot.
-func (mr *MockBotRepositoryMockRecorder) UpdateBot(id, args interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) UpdateBot(ctx, id, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBot", reflect.TypeOf((*MockBotRepository)(nil).UpdateBot), id, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBot", reflect.TypeOf((*MockBotRepository)(nil).UpdateBot), ctx, id, args)
 }
 
 // WriteBotEventLog mocks base method.
-func (m *MockBotRepository) WriteBotEventLog(log *model.BotEventLog) error {
+func (m *MockBotRepository) WriteBotEventLog(ctx context.Context, log *model.BotEventLog) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteBotEventLog", log)
+	ret := m.ctrl.Call(m, "WriteBotEventLog", ctx, log)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteBotEventLog indicates an expected call of WriteBotEventLog.
-func (mr *MockBotRepositoryMockRecorder) WriteBotEventLog(log interface{}) *gomock.Call {
+func (mr *MockBotRepositoryMockRecorder) WriteBotEventLog(ctx, log interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBotEventLog", reflect.TypeOf((*MockBotRepository)(nil).WriteBotEventLog), log)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBotEventLog", reflect.TypeOf((*MockBotRepository)(nil).WriteBotEventLog), ctx, log)
 }

--- a/repository/mock_repository/mock_channel.go
+++ b/repository/mock_repository/mock_channel.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -39,24 +40,24 @@ func (m *MockChannelRepository) EXPECT() *MockChannelRepositoryMockRecorder {
 }
 
 // ArchiveChannels mocks base method.
-func (m *MockChannelRepository) ArchiveChannels(ids []uuid.UUID) ([]*model.Channel, error) {
+func (m *MockChannelRepository) ArchiveChannels(ctx context.Context, ids []uuid.UUID) ([]*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ArchiveChannels", ids)
+	ret := m.ctrl.Call(m, "ArchiveChannels", ctx, ids)
 	ret0, _ := ret[0].([]*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ArchiveChannels indicates an expected call of ArchiveChannels.
-func (mr *MockChannelRepositoryMockRecorder) ArchiveChannels(ids interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) ArchiveChannels(ctx, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveChannels", reflect.TypeOf((*MockChannelRepository)(nil).ArchiveChannels), ids)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveChannels", reflect.TypeOf((*MockChannelRepository)(nil).ArchiveChannels), ctx, ids)
 }
 
 // ChangeChannelSubscription mocks base method.
-func (m *MockChannelRepository) ChangeChannelSubscription(channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) ([]uuid.UUID, []uuid.UUID, error) {
+func (m *MockChannelRepository) ChangeChannelSubscription(ctx context.Context, channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) ([]uuid.UUID, []uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeChannelSubscription", channelID, args)
+	ret := m.ctrl.Call(m, "ChangeChannelSubscription", ctx, channelID, args)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].([]uuid.UUID)
 	ret2, _ := ret[2].(error)
@@ -64,45 +65,45 @@ func (m *MockChannelRepository) ChangeChannelSubscription(channelID uuid.UUID, a
 }
 
 // ChangeChannelSubscription indicates an expected call of ChangeChannelSubscription.
-func (mr *MockChannelRepositoryMockRecorder) ChangeChannelSubscription(channelID, args interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) ChangeChannelSubscription(ctx, channelID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeChannelSubscription", reflect.TypeOf((*MockChannelRepository)(nil).ChangeChannelSubscription), channelID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeChannelSubscription", reflect.TypeOf((*MockChannelRepository)(nil).ChangeChannelSubscription), ctx, channelID, args)
 }
 
 // CreateChannel mocks base method.
-func (m *MockChannelRepository) CreateChannel(ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
+func (m *MockChannelRepository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateChannel", ch, privateMembers, dm)
+	ret := m.ctrl.Call(m, "CreateChannel", ctx, ch, privateMembers, dm)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateChannel indicates an expected call of CreateChannel.
-func (mr *MockChannelRepositoryMockRecorder) CreateChannel(ch, privateMembers, dm interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) CreateChannel(ctx, ch, privateMembers, dm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannel", reflect.TypeOf((*MockChannelRepository)(nil).CreateChannel), ch, privateMembers, dm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannel", reflect.TypeOf((*MockChannelRepository)(nil).CreateChannel), ctx, ch, privateMembers, dm)
 }
 
 // GetChannel mocks base method.
-func (m *MockChannelRepository) GetChannel(channelID uuid.UUID) (*model.Channel, error) {
+func (m *MockChannelRepository) GetChannel(ctx context.Context, channelID uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannel", channelID)
+	ret := m.ctrl.Call(m, "GetChannel", ctx, channelID)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannel indicates an expected call of GetChannel.
-func (mr *MockChannelRepositoryMockRecorder) GetChannel(channelID interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetChannel(ctx, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannel", reflect.TypeOf((*MockChannelRepository)(nil).GetChannel), channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannel", reflect.TypeOf((*MockChannelRepository)(nil).GetChannel), ctx, channelID)
 }
 
 // GetChannelEvents mocks base method.
-func (m *MockChannelRepository) GetChannelEvents(query repository.ChannelEventsQuery) ([]*model.ChannelEvent, bool, error) {
+func (m *MockChannelRepository) GetChannelEvents(ctx context.Context, query repository.ChannelEventsQuery) ([]*model.ChannelEvent, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelEvents", query)
+	ret := m.ctrl.Call(m, "GetChannelEvents", ctx, query)
 	ret0, _ := ret[0].([]*model.ChannelEvent)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -110,126 +111,126 @@ func (m *MockChannelRepository) GetChannelEvents(query repository.ChannelEventsQ
 }
 
 // GetChannelEvents indicates an expected call of GetChannelEvents.
-func (mr *MockChannelRepositoryMockRecorder) GetChannelEvents(query interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetChannelEvents(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelEvents", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelEvents), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelEvents", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelEvents), ctx, query)
 }
 
 // GetChannelStats mocks base method.
-func (m *MockChannelRepository) GetChannelStats(channelID uuid.UUID, excludeDeletedMessages bool) (*repository.ChannelStats, error) {
+func (m *MockChannelRepository) GetChannelStats(ctx context.Context, channelID uuid.UUID, excludeDeletedMessages bool) (*repository.ChannelStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelStats", channelID, excludeDeletedMessages)
+	ret := m.ctrl.Call(m, "GetChannelStats", ctx, channelID, excludeDeletedMessages)
 	ret0, _ := ret[0].(*repository.ChannelStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannelStats indicates an expected call of GetChannelStats.
-func (mr *MockChannelRepositoryMockRecorder) GetChannelStats(channelID, excludeDeletedMessages interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetChannelStats(ctx, channelID, excludeDeletedMessages interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelStats", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelStats), channelID, excludeDeletedMessages)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelStats", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelStats), ctx, channelID, excludeDeletedMessages)
 }
 
 // GetChannelSubscriptions mocks base method.
-func (m *MockChannelRepository) GetChannelSubscriptions(query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
+func (m *MockChannelRepository) GetChannelSubscriptions(ctx context.Context, query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelSubscriptions", query)
+	ret := m.ctrl.Call(m, "GetChannelSubscriptions", ctx, query)
 	ret0, _ := ret[0].([]*model.UserSubscribeChannel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannelSubscriptions indicates an expected call of GetChannelSubscriptions.
-func (mr *MockChannelRepositoryMockRecorder) GetChannelSubscriptions(query interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetChannelSubscriptions(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelSubscriptions", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelSubscriptions), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelSubscriptions", reflect.TypeOf((*MockChannelRepository)(nil).GetChannelSubscriptions), ctx, query)
 }
 
 // GetDirectMessageChannel mocks base method.
-func (m *MockChannelRepository) GetDirectMessageChannel(user1, user2 uuid.UUID) (*model.Channel, error) {
+func (m *MockChannelRepository) GetDirectMessageChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDirectMessageChannel", user1, user2)
+	ret := m.ctrl.Call(m, "GetDirectMessageChannel", ctx, user1, user2)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDirectMessageChannel indicates an expected call of GetDirectMessageChannel.
-func (mr *MockChannelRepositoryMockRecorder) GetDirectMessageChannel(user1, user2 interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetDirectMessageChannel(ctx, user1, user2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectMessageChannel", reflect.TypeOf((*MockChannelRepository)(nil).GetDirectMessageChannel), user1, user2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectMessageChannel", reflect.TypeOf((*MockChannelRepository)(nil).GetDirectMessageChannel), ctx, user1, user2)
 }
 
 // GetDirectMessageChannelMapping mocks base method.
-func (m *MockChannelRepository) GetDirectMessageChannelMapping(userID uuid.UUID) ([]*model.DMChannelMapping, error) {
+func (m *MockChannelRepository) GetDirectMessageChannelMapping(ctx context.Context, userID uuid.UUID) ([]*model.DMChannelMapping, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDirectMessageChannelMapping", userID)
+	ret := m.ctrl.Call(m, "GetDirectMessageChannelMapping", ctx, userID)
 	ret0, _ := ret[0].([]*model.DMChannelMapping)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDirectMessageChannelMapping indicates an expected call of GetDirectMessageChannelMapping.
-func (mr *MockChannelRepositoryMockRecorder) GetDirectMessageChannelMapping(userID interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetDirectMessageChannelMapping(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectMessageChannelMapping", reflect.TypeOf((*MockChannelRepository)(nil).GetDirectMessageChannelMapping), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectMessageChannelMapping", reflect.TypeOf((*MockChannelRepository)(nil).GetDirectMessageChannelMapping), ctx, userID)
 }
 
 // GetPrivateChannelMemberIDs mocks base method.
-func (m *MockChannelRepository) GetPrivateChannelMemberIDs(channelID uuid.UUID) ([]uuid.UUID, error) {
+func (m *MockChannelRepository) GetPrivateChannelMemberIDs(ctx context.Context, channelID uuid.UUID) ([]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPrivateChannelMemberIDs", channelID)
+	ret := m.ctrl.Call(m, "GetPrivateChannelMemberIDs", ctx, channelID)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPrivateChannelMemberIDs indicates an expected call of GetPrivateChannelMemberIDs.
-func (mr *MockChannelRepositoryMockRecorder) GetPrivateChannelMemberIDs(channelID interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetPrivateChannelMemberIDs(ctx, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateChannelMemberIDs", reflect.TypeOf((*MockChannelRepository)(nil).GetPrivateChannelMemberIDs), channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateChannelMemberIDs", reflect.TypeOf((*MockChannelRepository)(nil).GetPrivateChannelMemberIDs), ctx, channelID)
 }
 
 // GetPublicChannels mocks base method.
-func (m *MockChannelRepository) GetPublicChannels() ([]*model.Channel, error) {
+func (m *MockChannelRepository) GetPublicChannels(ctx context.Context) ([]*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicChannels")
+	ret := m.ctrl.Call(m, "GetPublicChannels", ctx)
 	ret0, _ := ret[0].([]*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicChannels indicates an expected call of GetPublicChannels.
-func (mr *MockChannelRepositoryMockRecorder) GetPublicChannels() *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) GetPublicChannels(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicChannels", reflect.TypeOf((*MockChannelRepository)(nil).GetPublicChannels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicChannels", reflect.TypeOf((*MockChannelRepository)(nil).GetPublicChannels), ctx)
 }
 
 // RecordChannelEvent mocks base method.
-func (m *MockChannelRepository) RecordChannelEvent(channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error {
+func (m *MockChannelRepository) RecordChannelEvent(ctx context.Context, channelID uuid.UUID, eventType model.ChannelEventType, detail model.ChannelEventDetail, datetime time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordChannelEvent", channelID, eventType, detail, datetime)
+	ret := m.ctrl.Call(m, "RecordChannelEvent", ctx, channelID, eventType, detail, datetime)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordChannelEvent indicates an expected call of RecordChannelEvent.
-func (mr *MockChannelRepositoryMockRecorder) RecordChannelEvent(channelID, eventType, detail, datetime interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) RecordChannelEvent(ctx, channelID, eventType, detail, datetime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordChannelEvent", reflect.TypeOf((*MockChannelRepository)(nil).RecordChannelEvent), channelID, eventType, detail, datetime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordChannelEvent", reflect.TypeOf((*MockChannelRepository)(nil).RecordChannelEvent), ctx, channelID, eventType, detail, datetime)
 }
 
 // UpdateChannel mocks base method.
-func (m *MockChannelRepository) UpdateChannel(channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
+func (m *MockChannelRepository) UpdateChannel(ctx context.Context, channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateChannel", channelID, args)
+	ret := m.ctrl.Call(m, "UpdateChannel", ctx, channelID, args)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateChannel indicates an expected call of UpdateChannel.
-func (mr *MockChannelRepositoryMockRecorder) UpdateChannel(channelID, args interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) UpdateChannel(ctx, channelID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockChannelRepository)(nil).UpdateChannel), channelID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockChannelRepository)(nil).UpdateChannel), ctx, channelID, args)
 }

--- a/repository/mock_repository/mock_file.go
+++ b/repository/mock_repository/mock_file.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,52 +38,52 @@ func (m *MockFileRepository) EXPECT() *MockFileRepositoryMockRecorder {
 }
 
 // DeleteFileMeta mocks base method.
-func (m *MockFileRepository) DeleteFileMeta(fileID uuid.UUID) error {
+func (m *MockFileRepository) DeleteFileMeta(ctx context.Context, fileID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFileMeta", fileID)
+	ret := m.ctrl.Call(m, "DeleteFileMeta", ctx, fileID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteFileMeta indicates an expected call of DeleteFileMeta.
-func (mr *MockFileRepositoryMockRecorder) DeleteFileMeta(fileID interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) DeleteFileMeta(ctx, fileID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileMeta", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileMeta), fileID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileMeta", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileMeta), ctx, fileID)
 }
 
 // DeleteFileThumbnail mocks base method.
-func (m *MockFileRepository) DeleteFileThumbnail(fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
+func (m *MockFileRepository) DeleteFileThumbnail(ctx context.Context, fileID uuid.UUID, thumbnailType model.ThumbnailType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFileThumbnail", fileID, thumbnailType)
+	ret := m.ctrl.Call(m, "DeleteFileThumbnail", ctx, fileID, thumbnailType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteFileThumbnail indicates an expected call of DeleteFileThumbnail.
-func (mr *MockFileRepositoryMockRecorder) DeleteFileThumbnail(fileID, thumbnailType interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) DeleteFileThumbnail(ctx, fileID, thumbnailType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileThumbnail", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileThumbnail), fileID, thumbnailType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileThumbnail", reflect.TypeOf((*MockFileRepository)(nil).DeleteFileThumbnail), ctx, fileID, thumbnailType)
 }
 
 // GetFileMeta mocks base method.
-func (m *MockFileRepository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error) {
+func (m *MockFileRepository) GetFileMeta(ctx context.Context, fileID uuid.UUID) (*model.FileMeta, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileMeta", fileID)
+	ret := m.ctrl.Call(m, "GetFileMeta", ctx, fileID)
 	ret0, _ := ret[0].(*model.FileMeta)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileMeta indicates an expected call of GetFileMeta.
-func (mr *MockFileRepositoryMockRecorder) GetFileMeta(fileID interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) GetFileMeta(ctx, fileID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileMeta", reflect.TypeOf((*MockFileRepository)(nil).GetFileMeta), fileID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileMeta", reflect.TypeOf((*MockFileRepository)(nil).GetFileMeta), ctx, fileID)
 }
 
 // GetFileMetas mocks base method.
-func (m *MockFileRepository) GetFileMetas(q repository.FilesQuery) ([]*model.FileMeta, bool, error) {
+func (m *MockFileRepository) GetFileMetas(ctx context.Context, q repository.FilesQuery) ([]*model.FileMeta, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileMetas", q)
+	ret := m.ctrl.Call(m, "GetFileMetas", ctx, q)
 	ret0, _ := ret[0].([]*model.FileMeta)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -90,36 +91,36 @@ func (m *MockFileRepository) GetFileMetas(q repository.FilesQuery) ([]*model.Fil
 }
 
 // GetFileMetas indicates an expected call of GetFileMetas.
-func (mr *MockFileRepositoryMockRecorder) GetFileMetas(q interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) GetFileMetas(ctx, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileMetas", reflect.TypeOf((*MockFileRepository)(nil).GetFileMetas), q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileMetas", reflect.TypeOf((*MockFileRepository)(nil).GetFileMetas), ctx, q)
 }
 
 // IsFileAccessible mocks base method.
-func (m *MockFileRepository) IsFileAccessible(fileID, userID uuid.UUID) (bool, error) {
+func (m *MockFileRepository) IsFileAccessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsFileAccessible", fileID, userID)
+	ret := m.ctrl.Call(m, "IsFileAccessible", ctx, fileID, userID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsFileAccessible indicates an expected call of IsFileAccessible.
-func (mr *MockFileRepositoryMockRecorder) IsFileAccessible(fileID, userID interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) IsFileAccessible(ctx, fileID, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFileAccessible", reflect.TypeOf((*MockFileRepository)(nil).IsFileAccessible), fileID, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFileAccessible", reflect.TypeOf((*MockFileRepository)(nil).IsFileAccessible), ctx, fileID, userID)
 }
 
 // SaveFileMeta mocks base method.
-func (m *MockFileRepository) SaveFileMeta(meta *model.FileMeta, acl []*model.FileACLEntry) error {
+func (m *MockFileRepository) SaveFileMeta(ctx context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveFileMeta", meta, acl)
+	ret := m.ctrl.Call(m, "SaveFileMeta", ctx, meta, acl)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveFileMeta indicates an expected call of SaveFileMeta.
-func (mr *MockFileRepositoryMockRecorder) SaveFileMeta(meta, acl interface{}) *gomock.Call {
+func (mr *MockFileRepositoryMockRecorder) SaveFileMeta(ctx, meta, acl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveFileMeta", reflect.TypeOf((*MockFileRepository)(nil).SaveFileMeta), meta, acl)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveFileMeta", reflect.TypeOf((*MockFileRepository)(nil).SaveFileMeta), ctx, meta, acl)
 }

--- a/repository/mock_repository/mock_message.go
+++ b/repository/mock_repository/mock_message.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -38,82 +39,82 @@ func (m *MockMessageRepository) EXPECT() *MockMessageRepositoryMockRecorder {
 }
 
 // AddStampToMessage mocks base method.
-func (m *MockMessageRepository) AddStampToMessage(messageID, stampID, userID uuid.UUID, count int) (*model.MessageStamp, error) {
+func (m *MockMessageRepository) AddStampToMessage(ctx context.Context, messageID, stampID, userID uuid.UUID, count int) (*model.MessageStamp, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddStampToMessage", messageID, stampID, userID, count)
+	ret := m.ctrl.Call(m, "AddStampToMessage", ctx, messageID, stampID, userID, count)
 	ret0, _ := ret[0].(*model.MessageStamp)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddStampToMessage indicates an expected call of AddStampToMessage.
-func (mr *MockMessageRepositoryMockRecorder) AddStampToMessage(messageID, stampID, userID, count interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) AddStampToMessage(ctx, messageID, stampID, userID, count interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStampToMessage", reflect.TypeOf((*MockMessageRepository)(nil).AddStampToMessage), messageID, stampID, userID, count)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStampToMessage", reflect.TypeOf((*MockMessageRepository)(nil).AddStampToMessage), ctx, messageID, stampID, userID, count)
 }
 
 // CreateMessage mocks base method.
-func (m *MockMessageRepository) CreateMessage(userID, channelID uuid.UUID, text string) (*model.Message, error) {
+func (m *MockMessageRepository) CreateMessage(ctx context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMessage", userID, channelID, text)
+	ret := m.ctrl.Call(m, "CreateMessage", ctx, userID, channelID, text)
 	ret0, _ := ret[0].(*model.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMessage indicates an expected call of CreateMessage.
-func (mr *MockMessageRepositoryMockRecorder) CreateMessage(userID, channelID, text interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) CreateMessage(ctx, userID, channelID, text interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMessage", reflect.TypeOf((*MockMessageRepository)(nil).CreateMessage), userID, channelID, text)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMessage", reflect.TypeOf((*MockMessageRepository)(nil).CreateMessage), ctx, userID, channelID, text)
 }
 
 // DeleteMessage mocks base method.
-func (m *MockMessageRepository) DeleteMessage(messageID uuid.UUID) error {
+func (m *MockMessageRepository) DeleteMessage(ctx context.Context, messageID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMessage", messageID)
+	ret := m.ctrl.Call(m, "DeleteMessage", ctx, messageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMessage indicates an expected call of DeleteMessage.
-func (mr *MockMessageRepositoryMockRecorder) DeleteMessage(messageID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) DeleteMessage(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessage", reflect.TypeOf((*MockMessageRepository)(nil).DeleteMessage), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessage", reflect.TypeOf((*MockMessageRepository)(nil).DeleteMessage), ctx, messageID)
 }
 
 // DeleteUnreadsByChannelID mocks base method.
-func (m *MockMessageRepository) DeleteUnreadsByChannelID(channelID, userID uuid.UUID) error {
+func (m *MockMessageRepository) DeleteUnreadsByChannelID(ctx context.Context, channelID, userID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUnreadsByChannelID", channelID, userID)
+	ret := m.ctrl.Call(m, "DeleteUnreadsByChannelID", ctx, channelID, userID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteUnreadsByChannelID indicates an expected call of DeleteUnreadsByChannelID.
-func (mr *MockMessageRepositoryMockRecorder) DeleteUnreadsByChannelID(channelID, userID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) DeleteUnreadsByChannelID(ctx, channelID, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnreadsByChannelID", reflect.TypeOf((*MockMessageRepository)(nil).DeleteUnreadsByChannelID), channelID, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUnreadsByChannelID", reflect.TypeOf((*MockMessageRepository)(nil).DeleteUnreadsByChannelID), ctx, channelID, userID)
 }
 
 // GetChannelLatestMessages mocks base method.
-func (m *MockMessageRepository) GetChannelLatestMessages(query repository.ChannelLatestMessagesQuery) ([]*model.Message, error) {
+func (m *MockMessageRepository) GetChannelLatestMessages(ctx context.Context, query repository.ChannelLatestMessagesQuery) ([]*model.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelLatestMessages", query)
+	ret := m.ctrl.Call(m, "GetChannelLatestMessages", ctx, query)
 	ret0, _ := ret[0].([]*model.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannelLatestMessages indicates an expected call of GetChannelLatestMessages.
-func (mr *MockMessageRepositoryMockRecorder) GetChannelLatestMessages(query interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetChannelLatestMessages(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelLatestMessages", reflect.TypeOf((*MockMessageRepository)(nil).GetChannelLatestMessages), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelLatestMessages", reflect.TypeOf((*MockMessageRepository)(nil).GetChannelLatestMessages), ctx, query)
 }
 
 // GetDeletedMessagesAfter mocks base method.
-func (m *MockMessageRepository) GetDeletedMessagesAfter(after time.Time, limit int) ([]*model.Message, bool, error) {
+func (m *MockMessageRepository) GetDeletedMessagesAfter(ctx context.Context, after time.Time, limit int) ([]*model.Message, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeletedMessagesAfter", after, limit)
+	ret := m.ctrl.Call(m, "GetDeletedMessagesAfter", ctx, after, limit)
 	ret0, _ := ret[0].([]*model.Message)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -121,30 +122,30 @@ func (m *MockMessageRepository) GetDeletedMessagesAfter(after time.Time, limit i
 }
 
 // GetDeletedMessagesAfter indicates an expected call of GetDeletedMessagesAfter.
-func (mr *MockMessageRepositoryMockRecorder) GetDeletedMessagesAfter(after, limit interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetDeletedMessagesAfter(ctx, after, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeletedMessagesAfter", reflect.TypeOf((*MockMessageRepository)(nil).GetDeletedMessagesAfter), after, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeletedMessagesAfter", reflect.TypeOf((*MockMessageRepository)(nil).GetDeletedMessagesAfter), ctx, after, limit)
 }
 
 // GetMessageByID mocks base method.
-func (m *MockMessageRepository) GetMessageByID(messageID uuid.UUID) (*model.Message, error) {
+func (m *MockMessageRepository) GetMessageByID(ctx context.Context, messageID uuid.UUID) (*model.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMessageByID", messageID)
+	ret := m.ctrl.Call(m, "GetMessageByID", ctx, messageID)
 	ret0, _ := ret[0].(*model.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMessageByID indicates an expected call of GetMessageByID.
-func (mr *MockMessageRepositoryMockRecorder) GetMessageByID(messageID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetMessageByID(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessageByID", reflect.TypeOf((*MockMessageRepository)(nil).GetMessageByID), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessageByID", reflect.TypeOf((*MockMessageRepository)(nil).GetMessageByID), ctx, messageID)
 }
 
 // GetMessages mocks base method.
-func (m *MockMessageRepository) GetMessages(query repository.MessagesQuery) ([]*model.Message, bool, error) {
+func (m *MockMessageRepository) GetMessages(ctx context.Context, query repository.MessagesQuery) ([]*model.Message, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMessages", query)
+	ret := m.ctrl.Call(m, "GetMessages", ctx, query)
 	ret0, _ := ret[0].([]*model.Message)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -152,30 +153,30 @@ func (m *MockMessageRepository) GetMessages(query repository.MessagesQuery) ([]*
 }
 
 // GetMessages indicates an expected call of GetMessages.
-func (mr *MockMessageRepositoryMockRecorder) GetMessages(query interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetMessages(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessages", reflect.TypeOf((*MockMessageRepository)(nil).GetMessages), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessages", reflect.TypeOf((*MockMessageRepository)(nil).GetMessages), ctx, query)
 }
 
 // GetUnreadMessagesByUserID mocks base method.
-func (m *MockMessageRepository) GetUnreadMessagesByUserID(userID uuid.UUID) ([]*model.Message, error) {
+func (m *MockMessageRepository) GetUnreadMessagesByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnreadMessagesByUserID", userID)
+	ret := m.ctrl.Call(m, "GetUnreadMessagesByUserID", ctx, userID)
 	ret0, _ := ret[0].([]*model.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUnreadMessagesByUserID indicates an expected call of GetUnreadMessagesByUserID.
-func (mr *MockMessageRepositoryMockRecorder) GetUnreadMessagesByUserID(userID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetUnreadMessagesByUserID(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreadMessagesByUserID", reflect.TypeOf((*MockMessageRepository)(nil).GetUnreadMessagesByUserID), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreadMessagesByUserID", reflect.TypeOf((*MockMessageRepository)(nil).GetUnreadMessagesByUserID), ctx, userID)
 }
 
 // GetUpdatedMessagesAfter mocks base method.
-func (m *MockMessageRepository) GetUpdatedMessagesAfter(after time.Time, limit int) ([]*model.Message, bool, error) {
+func (m *MockMessageRepository) GetUpdatedMessagesAfter(ctx context.Context, after time.Time, limit int) ([]*model.Message, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUpdatedMessagesAfter", after, limit)
+	ret := m.ctrl.Call(m, "GetUpdatedMessagesAfter", ctx, after, limit)
 	ret0, _ := ret[0].([]*model.Message)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -183,64 +184,64 @@ func (m *MockMessageRepository) GetUpdatedMessagesAfter(after time.Time, limit i
 }
 
 // GetUpdatedMessagesAfter indicates an expected call of GetUpdatedMessagesAfter.
-func (mr *MockMessageRepositoryMockRecorder) GetUpdatedMessagesAfter(after, limit interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetUpdatedMessagesAfter(ctx, after, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdatedMessagesAfter", reflect.TypeOf((*MockMessageRepository)(nil).GetUpdatedMessagesAfter), after, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdatedMessagesAfter", reflect.TypeOf((*MockMessageRepository)(nil).GetUpdatedMessagesAfter), ctx, after, limit)
 }
 
 // GetUserUnreadChannels mocks base method.
-func (m *MockMessageRepository) GetUserUnreadChannels(userID uuid.UUID) ([]*repository.UserUnreadChannel, error) {
+func (m *MockMessageRepository) GetUserUnreadChannels(ctx context.Context, userID uuid.UUID) ([]*repository.UserUnreadChannel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserUnreadChannels", userID)
+	ret := m.ctrl.Call(m, "GetUserUnreadChannels", ctx, userID)
 	ret0, _ := ret[0].([]*repository.UserUnreadChannel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserUnreadChannels indicates an expected call of GetUserUnreadChannels.
-func (mr *MockMessageRepositoryMockRecorder) GetUserUnreadChannels(userID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) GetUserUnreadChannels(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserUnreadChannels", reflect.TypeOf((*MockMessageRepository)(nil).GetUserUnreadChannels), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserUnreadChannels", reflect.TypeOf((*MockMessageRepository)(nil).GetUserUnreadChannels), ctx, userID)
 }
 
 // RemoveStampFromMessage mocks base method.
-func (m *MockMessageRepository) RemoveStampFromMessage(messageID, stampID, userID uuid.UUID) error {
+func (m *MockMessageRepository) RemoveStampFromMessage(ctx context.Context, messageID, stampID, userID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveStampFromMessage", messageID, stampID, userID)
+	ret := m.ctrl.Call(m, "RemoveStampFromMessage", ctx, messageID, stampID, userID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveStampFromMessage indicates an expected call of RemoveStampFromMessage.
-func (mr *MockMessageRepositoryMockRecorder) RemoveStampFromMessage(messageID, stampID, userID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) RemoveStampFromMessage(ctx, messageID, stampID, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStampFromMessage", reflect.TypeOf((*MockMessageRepository)(nil).RemoveStampFromMessage), messageID, stampID, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStampFromMessage", reflect.TypeOf((*MockMessageRepository)(nil).RemoveStampFromMessage), ctx, messageID, stampID, userID)
 }
 
 // SetMessageUnreads mocks base method.
-func (m *MockMessageRepository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
+func (m *MockMessageRepository) SetMessageUnreads(ctx context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetMessageUnreads", userNoticeableMap, messageID)
+	ret := m.ctrl.Call(m, "SetMessageUnreads", ctx, userNoticeableMap, messageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetMessageUnreads indicates an expected call of SetMessageUnreads.
-func (mr *MockMessageRepositoryMockRecorder) SetMessageUnreads(userNoticeableMap, messageID interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) SetMessageUnreads(ctx, userNoticeableMap, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMessageUnreads", reflect.TypeOf((*MockMessageRepository)(nil).SetMessageUnreads), userNoticeableMap, messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMessageUnreads", reflect.TypeOf((*MockMessageRepository)(nil).SetMessageUnreads), ctx, userNoticeableMap, messageID)
 }
 
 // UpdateMessage mocks base method.
-func (m *MockMessageRepository) UpdateMessage(messageID uuid.UUID, text string) error {
+func (m *MockMessageRepository) UpdateMessage(ctx context.Context, messageID uuid.UUID, text string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMessage", messageID, text)
+	ret := m.ctrl.Call(m, "UpdateMessage", ctx, messageID, text)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMessage indicates an expected call of UpdateMessage.
-func (mr *MockMessageRepositoryMockRecorder) UpdateMessage(messageID, text interface{}) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) UpdateMessage(ctx, messageID, text interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessage", reflect.TypeOf((*MockMessageRepository)(nil).UpdateMessage), messageID, text)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessage", reflect.TypeOf((*MockMessageRepository)(nil).UpdateMessage), ctx, messageID, text)
 }

--- a/repository/mock_repository/mock_pin.go
+++ b/repository/mock_repository/mock_pin.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -36,46 +37,46 @@ func (m *MockPinRepository) EXPECT() *MockPinRepositoryMockRecorder {
 }
 
 // GetPinnedMessageByChannelID mocks base method.
-func (m *MockPinRepository) GetPinnedMessageByChannelID(channelID uuid.UUID) ([]*model.Pin, error) {
+func (m *MockPinRepository) GetPinnedMessageByChannelID(ctx context.Context, channelID uuid.UUID) ([]*model.Pin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPinnedMessageByChannelID", channelID)
+	ret := m.ctrl.Call(m, "GetPinnedMessageByChannelID", ctx, channelID)
 	ret0, _ := ret[0].([]*model.Pin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPinnedMessageByChannelID indicates an expected call of GetPinnedMessageByChannelID.
-func (mr *MockPinRepositoryMockRecorder) GetPinnedMessageByChannelID(channelID interface{}) *gomock.Call {
+func (mr *MockPinRepositoryMockRecorder) GetPinnedMessageByChannelID(ctx, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPinnedMessageByChannelID", reflect.TypeOf((*MockPinRepository)(nil).GetPinnedMessageByChannelID), channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPinnedMessageByChannelID", reflect.TypeOf((*MockPinRepository)(nil).GetPinnedMessageByChannelID), ctx, channelID)
 }
 
 // PinMessage mocks base method.
-func (m *MockPinRepository) PinMessage(messageID, userID uuid.UUID) (*model.Pin, error) {
+func (m *MockPinRepository) PinMessage(ctx context.Context, messageID, userID uuid.UUID) (*model.Pin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PinMessage", messageID, userID)
+	ret := m.ctrl.Call(m, "PinMessage", ctx, messageID, userID)
 	ret0, _ := ret[0].(*model.Pin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PinMessage indicates an expected call of PinMessage.
-func (mr *MockPinRepositoryMockRecorder) PinMessage(messageID, userID interface{}) *gomock.Call {
+func (mr *MockPinRepositoryMockRecorder) PinMessage(ctx, messageID, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinMessage", reflect.TypeOf((*MockPinRepository)(nil).PinMessage), messageID, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinMessage", reflect.TypeOf((*MockPinRepository)(nil).PinMessage), ctx, messageID, userID)
 }
 
 // UnpinMessage mocks base method.
-func (m *MockPinRepository) UnpinMessage(messageID uuid.UUID) (*model.Pin, error) {
+func (m *MockPinRepository) UnpinMessage(ctx context.Context, messageID uuid.UUID) (*model.Pin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnpinMessage", messageID)
+	ret := m.ctrl.Call(m, "UnpinMessage", ctx, messageID)
 	ret0, _ := ret[0].(*model.Pin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnpinMessage indicates an expected call of UnpinMessage.
-func (mr *MockPinRepositoryMockRecorder) UnpinMessage(messageID interface{}) *gomock.Call {
+func (mr *MockPinRepositoryMockRecorder) UnpinMessage(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinMessage", reflect.TypeOf((*MockPinRepository)(nil).UnpinMessage), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinMessage", reflect.TypeOf((*MockPinRepository)(nil).UnpinMessage), ctx, messageID)
 }

--- a/repository/mock_repository/mock_soundboard.go
+++ b/repository/mock_repository/mock_soundboard.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,73 +38,73 @@ func (m *MockSoundboardRepository) EXPECT() *MockSoundboardRepositoryMockRecorde
 }
 
 // CreateSoundboardItem mocks base method.
-func (m *MockSoundboardRepository) CreateSoundboardItem(args repository.CreateSoundboardItemArgs) error {
+func (m *MockSoundboardRepository) CreateSoundboardItem(ctx context.Context, args repository.CreateSoundboardItemArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSoundboardItem", args)
+	ret := m.ctrl.Call(m, "CreateSoundboardItem", ctx, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateSoundboardItem indicates an expected call of CreateSoundboardItem.
-func (mr *MockSoundboardRepositoryMockRecorder) CreateSoundboardItem(args interface{}) *gomock.Call {
+func (mr *MockSoundboardRepositoryMockRecorder) CreateSoundboardItem(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSoundboardItem", reflect.TypeOf((*MockSoundboardRepository)(nil).CreateSoundboardItem), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSoundboardItem", reflect.TypeOf((*MockSoundboardRepository)(nil).CreateSoundboardItem), ctx, args)
 }
 
 // DeleteSoundboardItem mocks base method.
-func (m *MockSoundboardRepository) DeleteSoundboardItem(soundID uuid.UUID) error {
+func (m *MockSoundboardRepository) DeleteSoundboardItem(ctx context.Context, soundID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSoundboardItem", soundID)
+	ret := m.ctrl.Call(m, "DeleteSoundboardItem", ctx, soundID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSoundboardItem indicates an expected call of DeleteSoundboardItem.
-func (mr *MockSoundboardRepositoryMockRecorder) DeleteSoundboardItem(soundID interface{}) *gomock.Call {
+func (mr *MockSoundboardRepositoryMockRecorder) DeleteSoundboardItem(ctx, soundID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSoundboardItem", reflect.TypeOf((*MockSoundboardRepository)(nil).DeleteSoundboardItem), soundID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSoundboardItem", reflect.TypeOf((*MockSoundboardRepository)(nil).DeleteSoundboardItem), ctx, soundID)
 }
 
 // GetAllSoundboardItems mocks base method.
-func (m *MockSoundboardRepository) GetAllSoundboardItems() ([]*model.SoundboardItem, error) {
+func (m *MockSoundboardRepository) GetAllSoundboardItems(ctx context.Context) ([]*model.SoundboardItem, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllSoundboardItems")
+	ret := m.ctrl.Call(m, "GetAllSoundboardItems", ctx)
 	ret0, _ := ret[0].([]*model.SoundboardItem)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllSoundboardItems indicates an expected call of GetAllSoundboardItems.
-func (mr *MockSoundboardRepositoryMockRecorder) GetAllSoundboardItems() *gomock.Call {
+func (mr *MockSoundboardRepositoryMockRecorder) GetAllSoundboardItems(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSoundboardItems", reflect.TypeOf((*MockSoundboardRepository)(nil).GetAllSoundboardItems))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSoundboardItems", reflect.TypeOf((*MockSoundboardRepository)(nil).GetAllSoundboardItems), ctx)
 }
 
 // GetSoundboardByCreatorID mocks base method.
-func (m *MockSoundboardRepository) GetSoundboardByCreatorID(creatorID uuid.UUID) ([]*model.SoundboardItem, error) {
+func (m *MockSoundboardRepository) GetSoundboardByCreatorID(ctx context.Context, creatorID uuid.UUID) ([]*model.SoundboardItem, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSoundboardByCreatorID", creatorID)
+	ret := m.ctrl.Call(m, "GetSoundboardByCreatorID", ctx, creatorID)
 	ret0, _ := ret[0].([]*model.SoundboardItem)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSoundboardByCreatorID indicates an expected call of GetSoundboardByCreatorID.
-func (mr *MockSoundboardRepositoryMockRecorder) GetSoundboardByCreatorID(creatorID interface{}) *gomock.Call {
+func (mr *MockSoundboardRepositoryMockRecorder) GetSoundboardByCreatorID(ctx, creatorID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoundboardByCreatorID", reflect.TypeOf((*MockSoundboardRepository)(nil).GetSoundboardByCreatorID), creatorID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoundboardByCreatorID", reflect.TypeOf((*MockSoundboardRepository)(nil).GetSoundboardByCreatorID), ctx, creatorID)
 }
 
 // UpdateSoundboardCreatorID mocks base method.
-func (m *MockSoundboardRepository) UpdateSoundboardCreatorID(soundID, creatorID uuid.UUID) error {
+func (m *MockSoundboardRepository) UpdateSoundboardCreatorID(ctx context.Context, soundID, creatorID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSoundboardCreatorID", soundID, creatorID)
+	ret := m.ctrl.Call(m, "UpdateSoundboardCreatorID", ctx, soundID, creatorID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSoundboardCreatorID indicates an expected call of UpdateSoundboardCreatorID.
-func (mr *MockSoundboardRepositoryMockRecorder) UpdateSoundboardCreatorID(soundID, creatorID interface{}) *gomock.Call {
+func (mr *MockSoundboardRepositoryMockRecorder) UpdateSoundboardCreatorID(ctx, soundID, creatorID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSoundboardCreatorID", reflect.TypeOf((*MockSoundboardRepository)(nil).UpdateSoundboardCreatorID), soundID, creatorID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSoundboardCreatorID", reflect.TypeOf((*MockSoundboardRepository)(nil).UpdateSoundboardCreatorID), ctx, soundID, creatorID)
 }

--- a/repository/mock_repository/mock_tag.go
+++ b/repository/mock_repository/mock_tag.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -36,118 +37,118 @@ func (m *MockTagRepository) EXPECT() *MockTagRepositoryMockRecorder {
 }
 
 // AddUserTag mocks base method.
-func (m *MockTagRepository) AddUserTag(userID, tagID uuid.UUID) error {
+func (m *MockTagRepository) AddUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUserTag", userID, tagID)
+	ret := m.ctrl.Call(m, "AddUserTag", ctx, userID, tagID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddUserTag indicates an expected call of AddUserTag.
-func (mr *MockTagRepositoryMockRecorder) AddUserTag(userID, tagID interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) AddUserTag(ctx, userID, tagID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserTag", reflect.TypeOf((*MockTagRepository)(nil).AddUserTag), userID, tagID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserTag", reflect.TypeOf((*MockTagRepository)(nil).AddUserTag), ctx, userID, tagID)
 }
 
 // ChangeUserTagLock mocks base method.
-func (m *MockTagRepository) ChangeUserTagLock(userID, tagID uuid.UUID, locked bool) error {
+func (m *MockTagRepository) ChangeUserTagLock(ctx context.Context, userID, tagID uuid.UUID, locked bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeUserTagLock", userID, tagID, locked)
+	ret := m.ctrl.Call(m, "ChangeUserTagLock", ctx, userID, tagID, locked)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ChangeUserTagLock indicates an expected call of ChangeUserTagLock.
-func (mr *MockTagRepositoryMockRecorder) ChangeUserTagLock(userID, tagID, locked interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) ChangeUserTagLock(ctx, userID, tagID, locked interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeUserTagLock", reflect.TypeOf((*MockTagRepository)(nil).ChangeUserTagLock), userID, tagID, locked)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeUserTagLock", reflect.TypeOf((*MockTagRepository)(nil).ChangeUserTagLock), ctx, userID, tagID, locked)
 }
 
 // DeleteUserTag mocks base method.
-func (m *MockTagRepository) DeleteUserTag(userID, tagID uuid.UUID) error {
+func (m *MockTagRepository) DeleteUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUserTag", userID, tagID)
+	ret := m.ctrl.Call(m, "DeleteUserTag", ctx, userID, tagID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteUserTag indicates an expected call of DeleteUserTag.
-func (mr *MockTagRepositoryMockRecorder) DeleteUserTag(userID, tagID interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) DeleteUserTag(ctx, userID, tagID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserTag", reflect.TypeOf((*MockTagRepository)(nil).DeleteUserTag), userID, tagID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserTag", reflect.TypeOf((*MockTagRepository)(nil).DeleteUserTag), ctx, userID, tagID)
 }
 
 // GetOrCreateTag mocks base method.
-func (m *MockTagRepository) GetOrCreateTag(name string) (*model.Tag, error) {
+func (m *MockTagRepository) GetOrCreateTag(ctx context.Context, name string) (*model.Tag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrCreateTag", name)
+	ret := m.ctrl.Call(m, "GetOrCreateTag", ctx, name)
 	ret0, _ := ret[0].(*model.Tag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrCreateTag indicates an expected call of GetOrCreateTag.
-func (mr *MockTagRepositoryMockRecorder) GetOrCreateTag(name interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) GetOrCreateTag(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateTag", reflect.TypeOf((*MockTagRepository)(nil).GetOrCreateTag), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateTag", reflect.TypeOf((*MockTagRepository)(nil).GetOrCreateTag), ctx, name)
 }
 
 // GetTagByID mocks base method.
-func (m *MockTagRepository) GetTagByID(id uuid.UUID) (*model.Tag, error) {
+func (m *MockTagRepository) GetTagByID(ctx context.Context, id uuid.UUID) (*model.Tag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTagByID", id)
+	ret := m.ctrl.Call(m, "GetTagByID", ctx, id)
 	ret0, _ := ret[0].(*model.Tag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTagByID indicates an expected call of GetTagByID.
-func (mr *MockTagRepositoryMockRecorder) GetTagByID(id interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) GetTagByID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagByID", reflect.TypeOf((*MockTagRepository)(nil).GetTagByID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagByID", reflect.TypeOf((*MockTagRepository)(nil).GetTagByID), ctx, id)
 }
 
 // GetUserIDsByTagID mocks base method.
-func (m *MockTagRepository) GetUserIDsByTagID(tagID uuid.UUID) ([]uuid.UUID, error) {
+func (m *MockTagRepository) GetUserIDsByTagID(ctx context.Context, tagID uuid.UUID) ([]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserIDsByTagID", tagID)
+	ret := m.ctrl.Call(m, "GetUserIDsByTagID", ctx, tagID)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserIDsByTagID indicates an expected call of GetUserIDsByTagID.
-func (mr *MockTagRepositoryMockRecorder) GetUserIDsByTagID(tagID interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) GetUserIDsByTagID(ctx, tagID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserIDsByTagID", reflect.TypeOf((*MockTagRepository)(nil).GetUserIDsByTagID), tagID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserIDsByTagID", reflect.TypeOf((*MockTagRepository)(nil).GetUserIDsByTagID), ctx, tagID)
 }
 
 // GetUserTag mocks base method.
-func (m *MockTagRepository) GetUserTag(userID, tagID uuid.UUID) (model.UserTag, error) {
+func (m *MockTagRepository) GetUserTag(ctx context.Context, userID, tagID uuid.UUID) (model.UserTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserTag", userID, tagID)
+	ret := m.ctrl.Call(m, "GetUserTag", ctx, userID, tagID)
 	ret0, _ := ret[0].(model.UserTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserTag indicates an expected call of GetUserTag.
-func (mr *MockTagRepositoryMockRecorder) GetUserTag(userID, tagID interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) GetUserTag(ctx, userID, tagID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTag", reflect.TypeOf((*MockTagRepository)(nil).GetUserTag), userID, tagID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTag", reflect.TypeOf((*MockTagRepository)(nil).GetUserTag), ctx, userID, tagID)
 }
 
 // GetUserTagsByUserID mocks base method.
-func (m *MockTagRepository) GetUserTagsByUserID(userID uuid.UUID) ([]model.UserTag, error) {
+func (m *MockTagRepository) GetUserTagsByUserID(ctx context.Context, userID uuid.UUID) ([]model.UserTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserTagsByUserID", userID)
+	ret := m.ctrl.Call(m, "GetUserTagsByUserID", ctx, userID)
 	ret0, _ := ret[0].([]model.UserTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserTagsByUserID indicates an expected call of GetUserTagsByUserID.
-func (mr *MockTagRepositoryMockRecorder) GetUserTagsByUserID(userID interface{}) *gomock.Call {
+func (mr *MockTagRepositoryMockRecorder) GetUserTagsByUserID(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTagsByUserID", reflect.TypeOf((*MockTagRepository)(nil).GetUserTagsByUserID), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTagsByUserID", reflect.TypeOf((*MockTagRepository)(nil).GetUserTagsByUserID), ctx, userID)
 }

--- a/repository/mock_repository/mock_user.go
+++ b/repository/mock_repository/mock_user.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,178 +38,178 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 }
 
 // CreateUser mocks base method.
-func (m *MockUserRepository) CreateUser(args repository.CreateUserArgs) (model.UserInfo, error) {
+func (m *MockUserRepository) CreateUser(ctx context.Context, args repository.CreateUserArgs) (model.UserInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUser", args)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, args)
 	ret0, _ := ret[0].(model.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockUserRepositoryMockRecorder) CreateUser(args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) CreateUser(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), ctx, args)
 }
 
 // GetLinkedExternalUserAccounts mocks base method.
-func (m *MockUserRepository) GetLinkedExternalUserAccounts(userID uuid.UUID) ([]*model.ExternalProviderUser, error) {
+func (m *MockUserRepository) GetLinkedExternalUserAccounts(ctx context.Context, userID uuid.UUID) ([]*model.ExternalProviderUser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLinkedExternalUserAccounts", userID)
+	ret := m.ctrl.Call(m, "GetLinkedExternalUserAccounts", ctx, userID)
 	ret0, _ := ret[0].([]*model.ExternalProviderUser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLinkedExternalUserAccounts indicates an expected call of GetLinkedExternalUserAccounts.
-func (mr *MockUserRepositoryMockRecorder) GetLinkedExternalUserAccounts(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetLinkedExternalUserAccounts(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkedExternalUserAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetLinkedExternalUserAccounts), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkedExternalUserAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetLinkedExternalUserAccounts), ctx, userID)
 }
 
 // GetUser mocks base method.
-func (m *MockUserRepository) GetUser(id uuid.UUID, withProfile bool) (model.UserInfo, error) {
+func (m *MockUserRepository) GetUser(ctx context.Context, id uuid.UUID, withProfile bool) (model.UserInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", id, withProfile)
+	ret := m.ctrl.Call(m, "GetUser", ctx, id, withProfile)
 	ret0, _ := ret[0].(model.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUser indicates an expected call of GetUser.
-func (mr *MockUserRepositoryMockRecorder) GetUser(id, withProfile interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUser(ctx, id, withProfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockUserRepository)(nil).GetUser), id, withProfile)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockUserRepository)(nil).GetUser), ctx, id, withProfile)
 }
 
 // GetUserByExternalID mocks base method.
-func (m *MockUserRepository) GetUserByExternalID(providerName, externalID string, withProfile bool) (model.UserInfo, error) {
+func (m *MockUserRepository) GetUserByExternalID(ctx context.Context, providerName, externalID string, withProfile bool) (model.UserInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserByExternalID", providerName, externalID, withProfile)
+	ret := m.ctrl.Call(m, "GetUserByExternalID", ctx, providerName, externalID, withProfile)
 	ret0, _ := ret[0].(model.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserByExternalID indicates an expected call of GetUserByExternalID.
-func (mr *MockUserRepositoryMockRecorder) GetUserByExternalID(providerName, externalID, withProfile interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUserByExternalID(ctx, providerName, externalID, withProfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByExternalID", reflect.TypeOf((*MockUserRepository)(nil).GetUserByExternalID), providerName, externalID, withProfile)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByExternalID", reflect.TypeOf((*MockUserRepository)(nil).GetUserByExternalID), ctx, providerName, externalID, withProfile)
 }
 
 // GetUserByName mocks base method.
-func (m *MockUserRepository) GetUserByName(name string, withProfile bool) (model.UserInfo, error) {
+func (m *MockUserRepository) GetUserByName(ctx context.Context, name string, withProfile bool) (model.UserInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserByName", name, withProfile)
+	ret := m.ctrl.Call(m, "GetUserByName", ctx, name, withProfile)
 	ret0, _ := ret[0].(model.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserByName indicates an expected call of GetUserByName.
-func (mr *MockUserRepositoryMockRecorder) GetUserByName(name, withProfile interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUserByName(ctx, name, withProfile interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByName", reflect.TypeOf((*MockUserRepository)(nil).GetUserByName), name, withProfile)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByName", reflect.TypeOf((*MockUserRepository)(nil).GetUserByName), ctx, name, withProfile)
 }
 
 // GetUserIDs mocks base method.
-func (m *MockUserRepository) GetUserIDs(query repository.UsersQuery) ([]uuid.UUID, error) {
+func (m *MockUserRepository) GetUserIDs(ctx context.Context, query repository.UsersQuery) ([]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserIDs", query)
+	ret := m.ctrl.Call(m, "GetUserIDs", ctx, query)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserIDs indicates an expected call of GetUserIDs.
-func (mr *MockUserRepositoryMockRecorder) GetUserIDs(query interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUserIDs(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserIDs", reflect.TypeOf((*MockUserRepository)(nil).GetUserIDs), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserIDs", reflect.TypeOf((*MockUserRepository)(nil).GetUserIDs), ctx, query)
 }
 
 // GetUserStats mocks base method.
-func (m *MockUserRepository) GetUserStats(userID uuid.UUID) (*repository.UserStats, error) {
+func (m *MockUserRepository) GetUserStats(ctx context.Context, userID uuid.UUID) (*repository.UserStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserStats", userID)
+	ret := m.ctrl.Call(m, "GetUserStats", ctx, userID)
 	ret0, _ := ret[0].(*repository.UserStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserStats indicates an expected call of GetUserStats.
-func (mr *MockUserRepositoryMockRecorder) GetUserStats(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUserStats(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStats", reflect.TypeOf((*MockUserRepository)(nil).GetUserStats), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStats", reflect.TypeOf((*MockUserRepository)(nil).GetUserStats), ctx, userID)
 }
 
 // GetUsers mocks base method.
-func (m *MockUserRepository) GetUsers(query repository.UsersQuery) ([]model.UserInfo, error) {
+func (m *MockUserRepository) GetUsers(ctx context.Context, query repository.UsersQuery) ([]model.UserInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUsers", query)
+	ret := m.ctrl.Call(m, "GetUsers", ctx, query)
 	ret0, _ := ret[0].([]model.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUsers indicates an expected call of GetUsers.
-func (mr *MockUserRepositoryMockRecorder) GetUsers(query interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUsers(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockUserRepository)(nil).GetUsers), query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockUserRepository)(nil).GetUsers), ctx, query)
 }
 
 // LinkExternalUserAccount mocks base method.
-func (m *MockUserRepository) LinkExternalUserAccount(userID uuid.UUID, args repository.LinkExternalUserAccountArgs) error {
+func (m *MockUserRepository) LinkExternalUserAccount(ctx context.Context, userID uuid.UUID, args repository.LinkExternalUserAccountArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkExternalUserAccount", userID, args)
+	ret := m.ctrl.Call(m, "LinkExternalUserAccount", ctx, userID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LinkExternalUserAccount indicates an expected call of LinkExternalUserAccount.
-func (mr *MockUserRepositoryMockRecorder) LinkExternalUserAccount(userID, args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) LinkExternalUserAccount(ctx, userID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkExternalUserAccount", reflect.TypeOf((*MockUserRepository)(nil).LinkExternalUserAccount), userID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkExternalUserAccount", reflect.TypeOf((*MockUserRepository)(nil).LinkExternalUserAccount), ctx, userID, args)
 }
 
 // UnlinkExternalUserAccount mocks base method.
-func (m *MockUserRepository) UnlinkExternalUserAccount(userID uuid.UUID, providerName string) error {
+func (m *MockUserRepository) UnlinkExternalUserAccount(ctx context.Context, userID uuid.UUID, providerName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkExternalUserAccount", userID, providerName)
+	ret := m.ctrl.Call(m, "UnlinkExternalUserAccount", ctx, userID, providerName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkExternalUserAccount indicates an expected call of UnlinkExternalUserAccount.
-func (mr *MockUserRepositoryMockRecorder) UnlinkExternalUserAccount(userID, providerName interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UnlinkExternalUserAccount(ctx, userID, providerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkExternalUserAccount", reflect.TypeOf((*MockUserRepository)(nil).UnlinkExternalUserAccount), userID, providerName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkExternalUserAccount", reflect.TypeOf((*MockUserRepository)(nil).UnlinkExternalUserAccount), ctx, userID, providerName)
 }
 
 // UpdateUser mocks base method.
-func (m *MockUserRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs) error {
+func (m *MockUserRepository) UpdateUser(ctx context.Context, id uuid.UUID, args repository.UpdateUserArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUser", id, args)
+	ret := m.ctrl.Call(m, "UpdateUser", ctx, id, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateUser indicates an expected call of UpdateUser.
-func (mr *MockUserRepositoryMockRecorder) UpdateUser(id, args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UpdateUser(ctx, id, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), id, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), ctx, id, args)
 }
 
 // UserExists mocks base method.
-func (m *MockUserRepository) UserExists(id uuid.UUID) (bool, error) {
+func (m *MockUserRepository) UserExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UserExists", id)
+	ret := m.ctrl.Call(m, "UserExists", ctx, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UserExists indicates an expected call of UserExists.
-func (mr *MockUserRepositoryMockRecorder) UserExists(id interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UserExists(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserExists", reflect.TypeOf((*MockUserRepository)(nil).UserExists), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserExists", reflect.TypeOf((*MockUserRepository)(nil).UserExists), ctx, id)
 }

--- a/repository/mock_repository/mock_user_role.go
+++ b/repository/mock_repository/mock_user_role.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,9 +36,9 @@ func (m *MockUserRoleRepository) EXPECT() *MockUserRoleRepositoryMockRecorder {
 }
 
 // CreateUserRoles mocks base method.
-func (m *MockUserRoleRepository) CreateUserRoles(roles ...*model.UserRole) error {
+func (m *MockUserRoleRepository) CreateUserRoles(ctx context.Context, roles ...*model.UserRole) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []interface{}{ctx}
 	for _, a := range roles {
 		varargs = append(varargs, a)
 	}
@@ -47,22 +48,23 @@ func (m *MockUserRoleRepository) CreateUserRoles(roles ...*model.UserRole) error
 }
 
 // CreateUserRoles indicates an expected call of CreateUserRoles.
-func (mr *MockUserRoleRepositoryMockRecorder) CreateUserRoles(roles ...interface{}) *gomock.Call {
+func (mr *MockUserRoleRepositoryMockRecorder) CreateUserRoles(ctx interface{}, roles ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserRoles", reflect.TypeOf((*MockUserRoleRepository)(nil).CreateUserRoles), roles...)
+	varargs := append([]interface{}{ctx}, roles...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserRoles", reflect.TypeOf((*MockUserRoleRepository)(nil).CreateUserRoles), varargs...)
 }
 
 // GetAllUserRoles mocks base method.
-func (m *MockUserRoleRepository) GetAllUserRoles() ([]*model.UserRole, error) {
+func (m *MockUserRoleRepository) GetAllUserRoles(ctx context.Context) ([]*model.UserRole, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUserRoles")
+	ret := m.ctrl.Call(m, "GetAllUserRoles", ctx)
 	ret0, _ := ret[0].([]*model.UserRole)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllUserRoles indicates an expected call of GetAllUserRoles.
-func (mr *MockUserRoleRepositoryMockRecorder) GetAllUserRoles() *gomock.Call {
+func (mr *MockUserRoleRepositoryMockRecorder) GetAllUserRoles(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUserRoles", reflect.TypeOf((*MockUserRoleRepository)(nil).GetAllUserRoles))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUserRoles", reflect.TypeOf((*MockUserRoleRepository)(nil).GetAllUserRoles), ctx)
 }

--- a/repository/oauth2.go
+++ b/repository/oauth2.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -33,17 +35,17 @@ type OAuth2Repository interface {
 	// 成功した場合、クライアントとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetClient(id string) (*model.OAuth2Client, error)
+	GetClient(ctx context.Context, id string) (*model.OAuth2Client, error)
 	// GetClients 指定したクライアントを全て取得します
 	//
 	// 成功した場合、クライアントの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetClients(query GetClientsQuery) ([]*model.OAuth2Client, error)
+	GetClients(ctx context.Context, query GetClientsQuery) ([]*model.OAuth2Client, error)
 	// SaveClient クライアントを保存します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	SaveClient(client *model.OAuth2Client) error
+	SaveClient(ctx context.Context, client *model.OAuth2Client) error
 	// UpdateClient クライアント情報を更新します
 	//
 	// 成功した場合、nilを返します。
@@ -51,85 +53,85 @@ type OAuth2Repository interface {
 	// clientIDに空文字を指定するとErrNilIDを返します。
 	// 更新内容に問題がある場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateClient(clientID string, args UpdateClientArgs) error
+	UpdateClient(ctx context.Context, clientID string, args UpdateClientArgs) error
 	// DeleteClient 指定したクライアントを削除します
 	//
 	// 成功した、或いは既に存在しない場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteClient(id string) error
+	DeleteClient(ctx context.Context, id string) error
 	// SaveAuthorize 認可データを保存します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	SaveAuthorize(data *model.OAuth2Authorize) error
+	SaveAuthorize(ctx context.Context, data *model.OAuth2Authorize) error
 	// GetAuthorize 指定したコードの認可データを取得します
 	//
 	// 成功した場合、認可データとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetAuthorize(code string) (*model.OAuth2Authorize, error)
+	GetAuthorize(ctx context.Context, code string) (*model.OAuth2Authorize, error)
 	// DeleteAuthorize 指定したコードの認可データを削除します
 	//
 	// 成功した、或いは既に存在しない場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteAuthorize(code string) error
+	DeleteAuthorize(ctx context.Context, code string) error
 	// IssueToken トークンを発行します
 	//
 	// 成功した場合、トークンとnilを返します。
 	// DBによるエラーを返すことがあります。
-	IssueToken(client *model.OAuth2Client, userID uuid.UUID, redirectURI string, scope model.AccessScopes, expire int, refresh bool) (*model.OAuth2Token, error)
+	IssueToken(ctx context.Context, client *model.OAuth2Client, userID uuid.UUID, redirectURI string, scope model.AccessScopes, expire int, refresh bool) (*model.OAuth2Token, error)
 	// GetTokenByID 指定したIDのトークンを取得します
 	//
 	// 成功した場合、トークンとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetTokenByID(id uuid.UUID) (*model.OAuth2Token, error)
+	GetTokenByID(ctx context.Context, id uuid.UUID) (*model.OAuth2Token, error)
 	// DeleteTokenByID 指定したIDのトークンを削除します
 	//
 	// 成功した、或いは既に存在しない場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteTokenByID(id uuid.UUID) error
+	DeleteTokenByID(ctx context.Context, id uuid.UUID) error
 	// GetTokenByAccess 指定したアクセストークンのトークンを取得します
 	//
 	// 成功した場合、トークンとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetTokenByAccess(access string) (*model.OAuth2Token, error)
+	GetTokenByAccess(ctx context.Context, access string) (*model.OAuth2Token, error)
 	// DeleteTokenByAccess 指定したアクセストークンのトークンを削除します
 	//
 	// 成功した、或いは既に存在しない場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteTokenByAccess(access string) error
+	DeleteTokenByAccess(ctx context.Context, access string) error
 	// GetTokenByRefresh 指定したリフレッシュトークンのトークンを取得します
 	//
 	// 成功した場合、トークンとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetTokenByRefresh(refresh string) (*model.OAuth2Token, error)
+	GetTokenByRefresh(ctx context.Context, refresh string) (*model.OAuth2Token, error)
 	// DeleteTokenByRefresh 指定したリフレッシュトークンのトークンを削除します
 	//
 	// 成功した、或いは既に存在しない場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteTokenByRefresh(refresh string) error
+	DeleteTokenByRefresh(ctx context.Context, refresh string) error
 	// GetTokensByUser 指定したユーザーのトークンを全て取得します
 	//
 	// 成功した場合、トークンの配列とnilを返します。
 	// 存在しないユーザーを指定した場合、空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetTokensByUser(userID uuid.UUID) ([]*model.OAuth2Token, error)
+	GetTokensByUser(ctx context.Context, userID uuid.UUID) ([]*model.OAuth2Token, error)
 	// DeleteTokenByUser 指定したユーザーのトークンを全て削除します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteTokenByUser(userID uuid.UUID) error
+	DeleteTokenByUser(ctx context.Context, userID uuid.UUID) error
 	// DeleteTokenByClient 指定したクライアントのトークンを全て削除します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteTokenByClient(clientID string) error
+	DeleteTokenByClient(ctx context.Context, clientID string) error
 	// DeleteUserTokensByClient 指定したユーザーの指定したクライアントのトークンをすべて削除します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteUserTokensByClient(userID uuid.UUID, clientID string) error
+	DeleteUserTokensByClient(ctx context.Context, userID uuid.UUID, clientID string) error
 }

--- a/repository/ogp_cache.go
+++ b/repository/ogp_cache.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/traPtitech/traQ/model"
@@ -13,25 +14,25 @@ type OgpCacheRepository interface {
 	//
 	// 成功した場合、作成されたOGPキャッシュとnilを返します。
 	// DBによるエラーを返すことがあります。
-	CreateOgpCache(url string, content *model.Ogp, cacheFor time.Duration) (c *model.OgpCache, err error)
+	CreateOgpCache(ctx context.Context, url string, content *model.Ogp, cacheFor time.Duration) (c *model.OgpCache, err error)
 
 	// GetOgpCache 指定したURLのOGPキャッシュを取得します
 	//
 	// 成功した場合、取得したOGPキャッシュとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetOgpCache(url string) (c *model.OgpCache, err error)
+	GetOgpCache(ctx context.Context, url string) (c *model.OgpCache, err error)
 
 	// DeleteOgpCache 指定したURLのOGPキャッシュを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteOgpCache(url string) error
+	DeleteOgpCache(ctx context.Context, url string) error
 
 	// DeleteStaleOgpCache 保存期間が経過したOGPキャッシュを削除します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteStaleOgpCache() error
+	DeleteStaleOgpCache(ctx context.Context) error
 }

--- a/repository/pin.go
+++ b/repository/pin.go
@@ -2,6 +2,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -10,9 +12,9 @@ import (
 // PinRepository ピンリポジトリ
 type PinRepository interface {
 	// PinMessage 指定したユーザーによって指定したメッセージをピン留めします
-	PinMessage(messageID, userID uuid.UUID) (*model.Pin, error)
+	PinMessage(ctx context.Context, messageID, userID uuid.UUID) (*model.Pin, error)
 	// UnpinMessage 指定したユーザーによって指定したピン留めを削除します
-	UnpinMessage(messageID uuid.UUID) (*model.Pin, error)
+	UnpinMessage(ctx context.Context, messageID uuid.UUID) (*model.Pin, error)
 	// GetPinnedMessageByChannelID 指定したチャンネルのピン留めを全て取得します
-	GetPinnedMessageByChannelID(channelID uuid.UUID) ([]*model.Pin, error)
+	GetPinnedMessageByChannelID(ctx context.Context, channelID uuid.UUID) ([]*model.Pin, error)
 }

--- a/repository/soundboard.go
+++ b/repository/soundboard.go
@@ -2,6 +2,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -22,28 +24,28 @@ type SoundboardRepository interface {
 	// 成功した場合、nilを返します。
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	CreateSoundboardItem(args CreateSoundboardItemArgs) error
+	CreateSoundboardItem(ctx context.Context, args CreateSoundboardItemArgs) error
 	// GetAllSoundboardItems すべてのサウンドボードアイテムを取得します
 	//
 	// 成功した場合、サウンドボードアイテムの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllSoundboardItems() ([]*model.SoundboardItem, error)
+	GetAllSoundboardItems(ctx context.Context) ([]*model.SoundboardItem, error)
 	// GetSoundboardItem 指定したIDのユーザーが作成したサウンドボードアイテムを取得します
 	//
 	// 成功した場合、サウンドボードアイテムとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetSoundboardByCreatorID(creatorID uuid.UUID) ([]*model.SoundboardItem, error)
+	GetSoundboardByCreatorID(ctx context.Context, creatorID uuid.UUID) ([]*model.SoundboardItem, error)
 	// UpdateSoundboardCreatorID サウンドボードアイテムの作成者を更新します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateSoundboardCreatorID(soundID uuid.UUID, creatorID uuid.UUID) error
+	UpdateSoundboardCreatorID(ctx context.Context, soundID uuid.UUID, creatorID uuid.UUID) error
 	// DeleteSoundboardItem サウンドボードアイテムを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteSoundboardItem(soundID uuid.UUID) error
+	DeleteSoundboardItem(ctx context.Context, soundID uuid.UUID) error
 }

--- a/repository/stamp.go
+++ b/repository/stamp.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -62,7 +63,7 @@ type StampRepository interface {
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// 既にNameが使われている場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	CreateStamp(args CreateStampArgs) (s *model.Stamp, err error)
+	CreateStamp(ctx context.Context, args CreateStampArgs) (s *model.Stamp, err error)
 	// UpdateStamp 指定したスタンプの情報を更新します
 	//
 	// 成功した場合、nilを返します。
@@ -71,60 +72,60 @@ type StampRepository interface {
 	// 更新内容に問題がある場合、ArgumentErrorを返します。
 	// 変更後のNameが既に使われている場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateStamp(id uuid.UUID, args UpdateStampArgs) error
+	UpdateStamp(ctx context.Context, id uuid.UUID, args UpdateStampArgs) error
 	// GetStamp 指定したIDのスタンプを取得します
 	//
 	// 成功した場合、スタンプとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetStamp(id uuid.UUID) (s *model.Stamp, err error)
+	GetStamp(ctx context.Context, id uuid.UUID) (s *model.Stamp, err error)
 	// GetStampByName 指定したnameのスタンプを取得します
 	//
 	// 成功した場合、スタンプとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetStampByName(name string) (s *model.Stamp, err error)
+	GetStampByName(ctx context.Context, name string) (s *model.Stamp, err error)
 	// DeleteStamp 指定したIDのスタンプを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 既に存在しない場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteStamp(id uuid.UUID) (err error)
+	DeleteStamp(ctx context.Context, id uuid.UUID) (err error)
 	// GetAllStampsWithThumbnail 全てのスタンプとサムネイルの有無を取得します
 	//
 	// 成功した場合、スタンプのIDでソートされた配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllStampsWithThumbnail(stampType StampType) (stamps []*model.StampWithThumbnail, err error)
+	GetAllStampsWithThumbnail(ctx context.Context, stampType StampType) (stamps []*model.StampWithThumbnail, err error)
 	// StampExists 指定したIDのスタンプが存在するかどうかを返します
 	//
 	// 存在する場合、trueとnilを返します。
 	// DBによるエラーを返すことがあります。
-	StampExists(id uuid.UUID) (bool, error)
+	StampExists(ctx context.Context, id uuid.UUID) (bool, error)
 	// GetUserStampHistory 指定したユーザーのスタンプ履歴を最大limit件取得します
 	//
 	// limitに負の値を指定した場合、全て取得します。
 	// 成功した場合、降順のスタンプ履歴の配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserStampHistory(userID uuid.UUID, limit int) (h []*UserStampHistory, err error)
+	GetUserStampHistory(ctx context.Context, userID uuid.UUID, limit int) (h []*UserStampHistory, err error)
 	// GetUserStampRecommendations 指定したユーザーのスタンプレコメンドを最大limit件取得します
 	//
 	// limitに負の値を指定した場合、全て取得します。
 	// 成功した場合、レコメンドスコアの高い順で並んだスタンプIDの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserStampRecommendations(userID uuid.UUID, limit int) (h []*UserStampRecommendation, err error)
+	GetUserStampRecommendations(ctx context.Context, userID uuid.UUID, limit int) (h []*UserStampRecommendation, err error)
 	// ExistStamps stampIDの配列から指定したスタンプが全て存在するか判定します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないスタンプがあった場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	ExistStamps(stampIDs []uuid.UUID) (err error)
+	ExistStamps(ctx context.Context, stampIDs []uuid.UUID) (err error)
 	// GetStampStats 成功した場合、(統計情報, nil)を返します。
 	//
 	// スタンプがない場合、(nil, ErrNotFound)を返します。
 	// stampIDにNILを渡した場合、(nil, ErrNilID)を返します。
 	// DBによるエラーを返すことがあります。
-	GetStampStats(stampID uuid.UUID) (*StampStats, error)
+	GetStampStats(ctx context.Context, stampID uuid.UUID) (*StampStats, error)
 }

--- a/repository/stamp_palette.go
+++ b/repository/stamp_palette.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -22,7 +24,7 @@ type StampPaletteRepository interface {
 	// userIDにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	CreateStampPalette(name, description string, stamps model.UUIDs, userID uuid.UUID) (sp *model.StampPalette, err error)
+	CreateStampPalette(ctx context.Context, name, description string, stamps model.UUIDs, userID uuid.UUID) (sp *model.StampPalette, err error)
 	// UpdateStampPalette 指定したスタンプパレットの情報を更新します
 	//
 	// 成功した場合、nilを返します。
@@ -30,23 +32,23 @@ type StampPaletteRepository interface {
 	// idにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 更新内容に問題がある場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateStampPalette(id uuid.UUID, args UpdateStampPaletteArgs) error
+	UpdateStampPalette(ctx context.Context, id uuid.UUID, args UpdateStampPaletteArgs) error
 	// GetStampPalette 指定したIDのスタンプパレットを取得します
 	//
 	// 成功した場合、スタンプパレットとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetStampPalette(id uuid.UUID) (sp *model.StampPalette, err error)
+	GetStampPalette(ctx context.Context, id uuid.UUID) (sp *model.StampPalette, err error)
 	// DeleteStampPalette 指定したIDのスタンプパレットを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 既に存在しない場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteStampPalette(id uuid.UUID) (err error)
+	DeleteStampPalette(ctx context.Context, id uuid.UUID) (err error)
 	// GetStampPalettes そのユーザーが作成したスタンプパレットを取得します
 	//
 	// 成功した場合、スタンプパレットの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetStampPalettes(userID uuid.UUID) (sps []*model.StampPalette, err error)
+	GetStampPalettes(ctx context.Context, userID uuid.UUID) (sps []*model.StampPalette, err error)
 }

--- a/repository/star.go
+++ b/repository/star.go
@@ -1,6 +1,10 @@
 package repository
 
-import "github.com/gofrs/uuid"
+import (
+	"context"
+
+	"github.com/gofrs/uuid"
+)
 
 // StarRepository チャンネルスターリポジトリ
 type StarRepository interface {
@@ -9,17 +13,17 @@ type StarRepository interface {
 	// 成功した、或いは既に登録されていた場合にnilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddStar(userID, channelID uuid.UUID) error
+	AddStar(ctx context.Context, userID, channelID uuid.UUID) error
 	// RemoveStar チャンネルのお気に入りを解除します
 	//
 	// 成功した、或いは既に解除されていた場合にnilを返します。
 	// 引数にuuid.Nilを指定するとErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveStar(userID, channelID uuid.UUID) error
+	RemoveStar(ctx context.Context, userID, channelID uuid.UUID) error
 	// GetStaredChannels ユーザーがお気に入りをしているチャンネルIDを取得します
 	//
 	// 成功した場合、チャンネルUUIDの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetStaredChannels(userID uuid.UUID) ([]uuid.UUID, error)
+	GetStaredChannels(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 }

--- a/repository/tag.go
+++ b/repository/tag.go
@@ -2,6 +2,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -14,50 +16,50 @@ type TagRepository interface {
 	// 成功した場合、タグとnilを返します。
 	// 存在しないタグの場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetTagByID(id uuid.UUID) (*model.Tag, error)
+	GetTagByID(ctx context.Context, id uuid.UUID) (*model.Tag, error)
 	// GetOrCreateTag 指定したタグを取得するか、生成したものを返します
 	//
 	// 成功した場合、タグとnilを返します。
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// 空文字を指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetOrCreateTag(name string) (*model.Tag, error)
+	GetOrCreateTag(ctx context.Context, name string) (*model.Tag, error)
 	// AddUserTag 指定したユーザーに指定したタグを付与します
 	//
 	// 成功した場合、nilを返します。
 	// 既に付与されている場合、ErrAlreadyExistsを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddUserTag(userID, tagID uuid.UUID) error
+	AddUserTag(ctx context.Context, userID, tagID uuid.UUID) error
 	// ChangeUserTagLock 指定したユーザーの指定したタグのロック状態を変更します
 	//
 	// 成功した場合、nilを返します。
 	// 存在しないユーザータグの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	ChangeUserTagLock(userID, tagID uuid.UUID, locked bool) error
+	ChangeUserTagLock(ctx context.Context, userID, tagID uuid.UUID, locked bool) error
 	// DeleteUserTag 指定したユーザーから指定したタグを削除します
 	//
 	// 成功した、或いは既に無い場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteUserTag(userID, tagID uuid.UUID) error
+	DeleteUserTag(ctx context.Context, userID, tagID uuid.UUID) error
 	// GetUserTag 指定したユーザーの指定したタグのユーザータグを取得します
 	//
 	// 成功した場合、ユーザータグとnilを返します。
 	// 存在しないユーザータグの場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserTag(userID, tagID uuid.UUID) (model.UserTag, error)
+	GetUserTag(ctx context.Context, userID, tagID uuid.UUID) (model.UserTag, error)
 	// GetUserTagsByUserID 指定したユーザーに付与されているタグを全て取得します
 	//
 	// 成功した場合、ユーザータグの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserTagsByUserID(userID uuid.UUID) ([]model.UserTag, error)
+	GetUserTagsByUserID(ctx context.Context, userID uuid.UUID) ([]model.UserTag, error)
 	// GetUserIDsByTagID 指定したタグを持った全ユーザーのUUIDを取得します
 	//
 	// 成功した場合、UUIDの配列とnilを返します。
 	// 存在しないタグを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserIDsByTagID(tagID uuid.UUID) ([]uuid.UUID, error)
+	GetUserIDsByTagID(ctx context.Context, tagID uuid.UUID) ([]uuid.UUID, error)
 }

--- a/repository/user.go
+++ b/repository/user.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -118,40 +119,40 @@ type UserRepository interface {
 	// 成功した場合、ユーザーとnilを返します。
 	// Nameが既に使われている場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	CreateUser(args CreateUserArgs) (model.UserInfo, error)
+	CreateUser(ctx context.Context, args CreateUserArgs) (model.UserInfo, error)
 	// GetUser 指定したIDのユーザーを取得します
 	//
 	// 成功した場合、ユーザーとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUser(id uuid.UUID, withProfile bool) (model.UserInfo, error)
+	GetUser(ctx context.Context, id uuid.UUID, withProfile bool) (model.UserInfo, error)
 	// GetUserByName 指定したNameのユーザーを取得する
 	//
 	// 成功した場合、ユーザーとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserByName(name string, withProfile bool) (model.UserInfo, error)
+	GetUserByName(ctx context.Context, name string, withProfile bool) (model.UserInfo, error)
 	// GetUserByExternalID 指定したproviderのexternalIDのユーザーを取得する
 	//
 	// 成功した場合、ユーザーとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserByExternalID(providerName, externalID string, withProfile bool) (model.UserInfo, error)
+	GetUserByExternalID(ctx context.Context, providerName, externalID string, withProfile bool) (model.UserInfo, error)
 	// GetUsers 指定した条件を満たすユーザーを取得します
 	//
 	// 成功した場合、ユーザーの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUsers(query UsersQuery) ([]model.UserInfo, error)
+	GetUsers(ctx context.Context, query UsersQuery) ([]model.UserInfo, error)
 	// GetUserIDs 指定した条件を満たすユーザーのUUIDの配列を取得します
 	//
 	// 成功した場合、UUIDの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserIDs(query UsersQuery) ([]uuid.UUID, error)
+	GetUserIDs(ctx context.Context, query UsersQuery) ([]uuid.UUID, error)
 	// UserExists 指定したIDのユーザーが存在するかどうかを返します
 	//
 	// 存在する場合、trueとnilを返します。
 	// DBによるエラーを返すことがあります。
-	UserExists(id uuid.UUID) (bool, error)
+	UserExists(ctx context.Context, id uuid.UUID) (bool, error)
 	// UpdateUser 指定したユーザーの情報を更新します
 	//
 	// 成功した場合、nilを返します。
@@ -159,7 +160,7 @@ type UserRepository interface {
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateUser(id uuid.UUID, args UpdateUserArgs) error
+	UpdateUser(ctx context.Context, id uuid.UUID, args UpdateUserArgs) error
 	// LinkExternalUserAccount 指定したユーザーに外部ログインアカウントを関連付けします
 	//
 	// 成功した場合、nilを返します。
@@ -168,23 +169,23 @@ type UserRepository interface {
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	LinkExternalUserAccount(userID uuid.UUID, args LinkExternalUserAccountArgs) error
+	LinkExternalUserAccount(ctx context.Context, userID uuid.UUID, args LinkExternalUserAccountArgs) error
 	// GetLinkedExternalUserAccounts 指定したユーザーに関連づけられている外部ログインアカウントの配列を返します
 	//
 	// 成功した場合、外部ログインアカウントの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetLinkedExternalUserAccounts(userID uuid.UUID) ([]*model.ExternalProviderUser, error)
+	GetLinkedExternalUserAccounts(ctx context.Context, userID uuid.UUID) ([]*model.ExternalProviderUser, error)
 	// UnlinkExternalUserAccount 指定したユーザーに関連づけられている指定した外部ログインアカウントの関連付けを解除します
 	//
 	// 成功した場合、nilを返します。
 	// 既に関連付けが無い場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	UnlinkExternalUserAccount(userID uuid.UUID, providerName string) error
+	UnlinkExternalUserAccount(ctx context.Context, userID uuid.UUID, providerName string) error
 	// GetUserStats 成功した場合、(統計情報, nil)を返します。
 	//
 	// ユーザーが存在しない場合、(nil, ErrNotFound)を返します。
 	// 引数にuuid.Nilを指定した場合、(nil, ErrNilID)を返します。
 	// DBによるエラーを返すことがあります。
-	GetUserStats(userID uuid.UUID) (*UserStats, error)
+	GetUserStats(ctx context.Context, userID uuid.UUID) (*UserStats, error)
 }

--- a/repository/user_group.go
+++ b/repository/user_group.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -22,7 +24,7 @@ type UserGroupRepository interface {
 	// 成功した場合、ユーザーグループとnilを返します。
 	// 既にNameが使われている場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	CreateUserGroup(name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error)
+	CreateUserGroup(ctx context.Context, name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error)
 	// UpdateUserGroup 指定したユーザーグループを更新します
 	//
 	// 成功した場合、nilを返します。
@@ -30,72 +32,72 @@ type UserGroupRepository interface {
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 既にNameが使われている場合、ErrAlreadyExistsを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateUserGroup(id uuid.UUID, args UpdateUserGroupArgs) error
+	UpdateUserGroup(ctx context.Context, id uuid.UUID, args UpdateUserGroupArgs) error
 	// DeleteUserGroup 指定したユーザーグループを削除します
 	//
 	// 成功した場合、nilを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteUserGroup(id uuid.UUID) error
+	DeleteUserGroup(ctx context.Context, id uuid.UUID) error
 	// GetUserGroup 指定したIDのユーザーグループを取得します
 	//
 	// 成功した場合、ユーザーグループとnilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserGroup(id uuid.UUID) (*model.UserGroup, error)
+	GetUserGroup(ctx context.Context, id uuid.UUID) (*model.UserGroup, error)
 	// GetUserGroupByName 指定した名前のユーザーグループを取得します
 	//
 	// 成功した場合、ユーザーグループとnilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserGroupByName(name string) (*model.UserGroup, error)
+	GetUserGroupByName(ctx context.Context, name string) (*model.UserGroup, error)
 	// GetUserBelongingGroupIDs 指定したユーザーが所属しているグループのUUIDを取得します
 	//
 	// 成功した場合、ユーザーグループのUUIDの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetUserBelongingGroupIDs(userID uuid.UUID) ([]uuid.UUID, error)
+	GetUserBelongingGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 	// GetAllUserGroups 全てのグループを取得します
 	//
 	// 成功した場合、ユーザーグループの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllUserGroups() ([]*model.UserGroup, error)
+	GetAllUserGroups(ctx context.Context) ([]*model.UserGroup, error)
 	// AddUserToGroup 指定したグループに指定したユーザーを追加します
 	//
 	// 成功した、或いは既に追加されている場合、nilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddUserToGroup(userID, groupID uuid.UUID, role string) error
+	AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID, role string) error
 	// AddUsersToGroup 指定したグループに指定した複数のユーザーを追加します
 	//
 	// 成功した、或いは既に追加されている場合、nilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddUsersToGroup(users []model.UserGroupMember, groupID uuid.UUID) error
+	AddUsersToGroup(ctx context.Context, users []model.UserGroupMember, groupID uuid.UUID) error
 	// RemoveUserFromGroup 指定したグループから指定したユーザーを削除します
 	//
 	// 全員の追加が成功した、或いは既に追加されている場合、nilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveUserFromGroup(userID, groupID uuid.UUID) error
+	RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID) error
 	// RemoveUsersFromGroup 指定したグループから指定した複数のユーザーを削除します
 	//
 	// 全員の削除が成功した、或いは既に削除されている場合、nilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveUsersFromGroup(groupID uuid.UUID) error
+	RemoveUsersFromGroup(ctx context.Context, groupID uuid.UUID) error
 	// AddUserToGroupAdmin 指定したグループの管理者に指定したユーザーを追加します
 	//
 	// 成功した、或いは既に追加されている場合、nilを返します。
 	// 存在しないグループの場合、ErrNotFoundを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	AddUserToGroupAdmin(userID, groupID uuid.UUID) error
+	AddUserToGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error
 	// RemoveUserFromGroupAdmin 指定したグループの管理者から指定したユーザーを削除します
 	//
 	// 成功した、或いは既に居ない場合、nilを返します。
@@ -103,5 +105,5 @@ type UserGroupRepository interface {
 	// グループから管理者が居なくなる場合、ErrForbiddenを返します。
 	// 引数にuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveUserFromGroupAdmin(userID, groupID uuid.UUID) error
+	RemoveUserFromGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error
 }

--- a/repository/user_role.go
+++ b/repository/user_role.go
@@ -1,17 +1,21 @@
 //go:generate mockgen -source=$GOFILE -destination=mock_$GOPACKAGE/mock_$GOFILE
 package repository
 
-import "github.com/traPtitech/traQ/model"
+import (
+	"context"
+
+	"github.com/traPtitech/traQ/model"
+)
 
 type UserRoleRepository interface {
 	// CreateUserRoles ユーザーロールを作成します
 	//
 	// 成功した場合、nilを返します。
 	// DBによるエラーを返すことがあります。
-	CreateUserRoles(roles ...*model.UserRole) error
+	CreateUserRoles(ctx context.Context, roles ...*model.UserRole) error
 	// GetAllUserRoles 全てのユーザーロールを返します
 	//
 	// 成功した場合、ユーザーロールの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllUserRoles() ([]*model.UserRole, error)
+	GetAllUserRoles(ctx context.Context) ([]*model.UserRole, error)
 }

--- a/repository/user_settings.go
+++ b/repository/user_settings.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -13,14 +15,14 @@ type UserSettingsRepository interface {
 	// isEnableがtrueの場合、メッセージ引用通知を有効にします
 	// isEnableがfalseの場合、メッセージ引用通知を無効にします
 	// DBによるエラーを返すことがあります
-	UpdateNotifyCitation(userID uuid.UUID, isEnable bool) error
+	UpdateNotifyCitation(ctx context.Context, userID uuid.UUID, isEnable bool) error
 	// GetNotifyCitation メッセージ引用通知の情報を取得します
 	//
 	// 返り値がtrueの場合、メッセージ引用通知が有効です
 	// 返り値がfalseの場合、メッセージ引用通知が無効です
 	// DBによるエラーを返すことがあります
-	GetNotifyCitation(userID uuid.UUID) (bool, error)
+	GetNotifyCitation(ctx context.Context, userID uuid.UUID) (bool, error)
 	// GetUserSettings ユーザー設定を返します
 	// DBによるエラーを返すことがあります
-	GetUserSettings(userID uuid.UUID) (*model.UserSettings, error)
+	GetUserSettings(ctx context.Context, userID uuid.UUID) (*model.UserSettings, error)
 }

--- a/repository/webhook.go
+++ b/repository/webhook.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -23,7 +25,7 @@ type WebhookRepository interface {
 	// 成功した場合、Webhookとnilを返します。
 	// 引数に問題がある場合、ArgumentErrorを返します。
 	// DBによるエラーを返すことがあります。
-	CreateWebhook(name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error)
+	CreateWebhook(ctx context.Context, name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error)
 	// UpdateWebhook Webhookを更新します
 	//
 	// 成功した場合、nilを返します。
@@ -31,35 +33,35 @@ type WebhookRepository interface {
 	// 更新内容に問題がある場合、ArgumentErrorを返します。
 	// idにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	UpdateWebhook(id uuid.UUID, args UpdateWebhookArgs) error
+	UpdateWebhook(ctx context.Context, id uuid.UUID, args UpdateWebhookArgs) error
 	// DeleteWebhook Webhookを削除します
 	//
 	// 成功した場合、nilを返します。WebhookのUserはstatusがdeactivatedになります。
 	// 既に存在しなかった場合、ErrNotFoundを返します。
 	// idにuuid.Nilを指定した場合、ErrNilIDを返します。
 	// DBによるエラーを返すことがあります。
-	DeleteWebhook(id uuid.UUID) error
+	DeleteWebhook(ctx context.Context, id uuid.UUID) error
 	// GetWebhook 指定したWebhookを取得します
 	//
 	// 成功した場合、Webhookとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetWebhook(id uuid.UUID) (model.Webhook, error)
+	GetWebhook(ctx context.Context, id uuid.UUID) (model.Webhook, error)
 	// GetWebhookByBotUserID 指定したユーザーUUIDをもつWebhookを取得します
 	//
 	// 成功した場合、Webhookとnilを返します。
 	// 存在しなかった場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	GetWebhookByBotUserID(id uuid.UUID) (model.Webhook, error)
+	GetWebhookByBotUserID(ctx context.Context, id uuid.UUID) (model.Webhook, error)
 	// GetAllWebhooks Webhookを全て取得します
 	//
 	// 成功した場合、Webhookの配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetAllWebhooks() ([]model.Webhook, error)
+	GetAllWebhooks(ctx context.Context) ([]model.Webhook, error)
 	// GetWebhooksByCreator 指定した制作者のWebhookを全て取得します
 	//
 	// 成功した場合、Webhookの配列とnilを返します。
 	// 存在しないユーザーを指定した場合は空配列とnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetWebhooksByCreator(creatorID uuid.UUID) ([]model.Webhook, error)
+	GetWebhooksByCreator(ctx context.Context, creatorID uuid.UUID) ([]model.Webhook, error)
 }

--- a/router/auth/provider.go
+++ b/router/auth/provider.go
@@ -139,7 +139,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// ユーザーアカウント状態を確認
-				user, err := repo.GetUser(sess.UserID(), false)
+				user, err := repo.GetUser(context.TODO(), sess.UserID(), false)
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
@@ -148,7 +148,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// アカウントにリンク
-				if err := repo.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+				if err := repo.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
 					ProviderName: tu.GetProviderName(),
 					ExternalID:   tu.GetID(),
 					Extra:        model.JSON{"externalName": tu.GetRawName()},
@@ -178,7 +178,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 			return herror.BadRequest("You have already logged in. Please logout once.")
 		}
 
-		user, err := repo.GetUserByExternalID(tu.GetProviderName(), tu.GetID(), false)
+		user, err := repo.GetUserByExternalID(context.TODO(), tu.GetProviderName(), tu.GetID(), false)
 		if err != nil {
 			if err != repository.ErrNotFound {
 				return herror.InternalServerError(err)
@@ -216,7 +216,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				args.IconFileID = fid
 			}
 
-			user, err = repo.CreateUser(args)
+			user, err = repo.CreateUser(context.TODO(), args)
 			if err != nil {
 				if err == repository.ErrAlreadyExists {
 					return herror.Conflict("name conflicts") // TODO 名前被りをどうするか

--- a/router/middlewares/no_login.go
+++ b/router/middlewares/no_login.go
@@ -1,6 +1,8 @@
 package middlewares
 
 import (
+	"context"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/traPtitech/traQ/repository"
@@ -21,7 +23,7 @@ func NoLogin(sessStore session.Store, repo repository.Repository) echo.Middlewar
 				return herror.InternalServerError(err)
 			}
 			if sess != nil && sess.LoggedIn() {
-				user, err := repo.GetUser(sess.UserID(), false)
+				user, err := repo.GetUser(context.TODO(), sess.UserID(), false)
 				if err != nil {
 					return herror.InternalServerError(err)
 				}

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -96,7 +96,7 @@ func (pr *ParamRetriever) error(err error) error {
 // GroupID リクエストURLの`groupID`パラメータからGroupを取り出す
 func (pr *ParamRetriever) GroupID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamGroupID, consts.KeyParamGroup, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetUserGroup(v)
+		return pr.repo.GetUserGroup(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -146,11 +146,11 @@ func (pr *ParamRetriever) WebhookID() echo.MiddlewareFunc {
 func (pr *ParamRetriever) StampID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
 		return pr.checkOnlyByUUID(consts.ParamStampID, func(_ echo.Context, v uuid.UUID) (bool, error) {
-			return pr.repo.StampExists(v)
+			return pr.repo.StampExists(context.TODO(), v)
 		})
 	}
 	return pr.byUUID(consts.ParamStampID, consts.KeyParamStamp, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetStamp(v)
+		return pr.repo.GetStamp(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -138,7 +138,7 @@ func (pr *ParamRetriever) FileID() echo.MiddlewareFunc {
 // WebhookID リクエストURLの`webhookID`パラメータからBotを取り出す
 func (pr *ParamRetriever) WebhookID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamWebhookID, consts.KeyParamWebhook, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetWebhook(v)
+		return pr.repo.GetWebhook(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -176,6 +176,6 @@ func (pr *ParamRetriever) UserID(checkOnly bool) echo.MiddlewareFunc {
 // ClipFolderID リクエストURLの`folderID`パラメータからClipFolderを取り出す
 func (pr *ParamRetriever) ClipFolderID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamClipFolderID, consts.KeyParamClipFolder, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetClipFolder(v)
+		return pr.repo.GetClipFolder(context.TODO(), v)
 	})
 }

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -1,6 +1,8 @@
 package middlewares
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 
@@ -155,7 +157,7 @@ func (pr *ParamRetriever) StampID(checkOnly bool) echo.MiddlewareFunc {
 // StampPalettesID リクエストURLの`paletteID`パラメータからStampPaletteを取り出す
 func (pr *ParamRetriever) StampPalettesID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamStampPaletteID, consts.KeyParamStampPalette, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetStampPalette(v)
+		return pr.repo.GetStampPalette(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -117,7 +117,7 @@ func (pr *ParamRetriever) ClientID() echo.MiddlewareFunc {
 // BotID リクエストURLの`botID`パラメータからBotを取り出す
 func (pr *ParamRetriever) BotID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamBotID, consts.KeyParamBot, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetBotByID(v)
+		return pr.repo.GetBotByID(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -110,7 +110,7 @@ func (pr *ParamRetriever) MessageID() echo.MiddlewareFunc {
 // ClientID リクエストURLの`clientID`パラメータからOAuth2Clientを取り出す
 func (pr *ParamRetriever) ClientID() echo.MiddlewareFunc {
 	return pr.byString(consts.ParamClientID, consts.KeyParamClient, func(_ echo.Context, v string) (interface{}, error) {
-		return pr.repo.GetClient(v)
+		return pr.repo.GetClient(context.TODO(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -165,11 +165,11 @@ func (pr *ParamRetriever) StampPalettesID() echo.MiddlewareFunc {
 func (pr *ParamRetriever) UserID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
 		return pr.checkOnlyByUUID(consts.ParamUserID, func(_ echo.Context, v uuid.UUID) (bool, error) {
-			return pr.repo.UserExists(v)
+			return pr.repo.UserExists(context.TODO(), v)
 		})
 	}
 	return pr.byUUID(consts.ParamUserID, consts.KeyParamUser, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetUser(v, true)
+		return pr.repo.GetUser(context.TODO(), v, true)
 	})
 }
 

--- a/router/middlewares/user_authenticate.go
+++ b/router/middlewares/user_authenticate.go
@@ -31,7 +31,7 @@ func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.
 				}
 
 				// OAuth2 Token検証
-				token, err := repo.GetTokenByAccess(ah[l+1:])
+				token, err := repo.GetTokenByAccess(context.TODO(), ah[l+1:])
 				if err != nil {
 					switch err {
 					case repository.ErrNotFound:

--- a/router/middlewares/user_authenticate.go
+++ b/router/middlewares/user_authenticate.go
@@ -68,7 +68,7 @@ func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.
 			}
 
 			// ユーザー取得
-			user, err := repo.GetUser(uid, true)
+			user, err := repo.GetUser(context.TODO(), uid, true)
 			if err != nil {
 				return herror.InternalServerError(err)
 			}

--- a/router/oauth2/authorization_endpoint.go
+++ b/router/oauth2/authorization_endpoint.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -168,7 +169,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 		return c.Redirect(http.StatusFound, redirectURI.String())
 	}
 	if se != nil {
-		u, err := h.Repo.GetUser(se.UserID(), false)
+		u, err := h.Repo.GetUser(context.TODO(), se.UserID(), false)
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)

--- a/router/oauth2/authorization_endpoint.go
+++ b/router/oauth2/authorization_endpoint.go
@@ -80,7 +80,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 	req.AccessTime = time.Now()
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(req.ClientID)
+	client, err := h.Repo.GetClient(context.TODO(), req.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -194,7 +194,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			redirectURI.RawQuery = q.Encode()
 			return c.Redirect(http.StatusFound, redirectURI.String())
 		}
-		tokens, err := h.Repo.GetTokensByUser(se.UserID())
+		tokens, err := h.Repo.GetTokensByUser(context.TODO(), se.UserID())
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
@@ -236,7 +236,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			CodeChallengeMethod: req.CodeChallengeMethod,
 			Nonce:               req.Nonce,
 		}
-		if err := h.Repo.SaveAuthorize(data); err != nil {
+		if err := h.Repo.SaveAuthorize(context.TODO(), data); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()
@@ -328,7 +328,7 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(reqAuth.ClientID)
+	client, err := h.Repo.GetClient(context.TODO(), reqAuth.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -376,7 +376,7 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 			CodeChallengeMethod: reqAuth.CodeChallengeMethod,
 			Nonce:               reqAuth.Nonce,
 		}
-		if err := h.Repo.SaveAuthorize(data); err != nil {
+		if err := h.Repo.SaveAuthorize(context.TODO(), data); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()

--- a/router/oauth2/authorization_endpoint_test.go
+++ b/router/oauth2/authorization_endpoint_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -530,7 +531,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 		t.Parallel()
 		assert := assert.New(t)
 		user := env.CreateUser(t, rand, useUUIDV4)
-		err := env.Repository.UpdateUser(user.GetID(), repository.UpdateUserArgs{UserState: optional.From(model.UserAccountStatusDeactivated)})
+		err := env.Repository.UpdateUser(context.TODO(), user.GetID(), repository.UpdateUserArgs{UserState: optional.From(model.UserAccountStatusDeactivated)})
 		require.NoError(t, err)
 
 		env.IssueToken(t, client, user.GetID(), false)

--- a/router/oauth2/authorization_endpoint_test.go
+++ b/router/oauth2/authorization_endpoint_test.go
@@ -78,7 +78,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesRead,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	t.Run("Success (prompt=none)", func(t *testing.T) {
 		t.Parallel()
@@ -105,7 +105,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 			assert.NotEmpty(loc.Query().Get("code"))
 		}
 
-		a, err := env.Repository.GetAuthorize(loc.Query().Get("code"))
+		a, err := env.Repository.GetAuthorize(context.TODO(), loc.Query().Get("code"))
 		if assert.NoError(err) {
 			assert.Equal("nonce", a.Nonce)
 		}
@@ -476,7 +476,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 		t.Parallel()
 		assert := assert.New(t)
 		user := env.CreateUser(t, rand, useUUIDV4)
-		_, err := env.Repository.IssueToken(client, user.GetID(), client.RedirectURI, scopesRead, 1000, false)
+		_, err := env.Repository.IssueToken(context.TODO(), client, user.GetID(), client.RedirectURI, scopesRead, 1000, false)
 		require.NoError(t, err)
 		e := env.R(t)
 		res := e.POST("/oauth2/authorize").
@@ -515,7 +515,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 			Secret:       random.AlphaNumeric(36),
 			Scopes:       scopes,
 		}
-		require.NoError(t, env.Repository.SaveClient(client))
+		require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 		e := env.R(t)
 		res := e.POST("/oauth2/authorize").
@@ -594,7 +594,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesRead,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	MakeDecideSession := func(t *testing.T, uid uuid.UUID, client *model.OAuth2Client) string {
 		s, err := env.SessStore.IssueSession(uid, map[string]interface{}{
@@ -633,7 +633,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 			assert.NotEmpty(loc.Query().Get("code"))
 		}
 
-		a, err := env.Repository.GetAuthorize(loc.Query().Get("code"))
+		a, err := env.Repository.GetAuthorize(context.TODO(), loc.Query().Get("code"))
 		if assert.NoError(err) {
 			assert.Equal("nonce", a.Nonce)
 		}
@@ -696,7 +696,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 			Secret:       random.AlphaNumeric(36),
 			Scopes:       scopesRead,
 		}
-		require.NoError(t, env.Repository.SaveClient(client))
+		require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 		e := env.R(t)
 		res := e.POST("/oauth2/authorize/decide").
 			WithFormField("submit", "approve").

--- a/router/oauth2/oauth2_test.go
+++ b/router/oauth2/oauth2_test.go
@@ -204,7 +204,7 @@ func (env *Env) CreateUser(t *testing.T, userName string, useUUIDV4 bool) model.
 
 func (env *Env) IssueToken(t *testing.T, client *model.OAuth2Client, userID uuid.UUID, refresh bool) *model.OAuth2Token {
 	t.Helper()
-	token, err := env.Repository.IssueToken(client, userID, client.RedirectURI, client.Scopes, 1000, refresh)
+	token, err := env.Repository.IssueToken(context.TODO(), client, userID, client.RedirectURI, client.Scopes, 1000, refresh)
 	require.NoError(t, err)
 	return token
 }
@@ -224,7 +224,7 @@ func (env *Env) MakeAuthorizeData(t *testing.T, clientID string, userID uuid.UUI
 		OriginalScopes: scopes,
 		Nonce:          "nonce",
 	}
-	require.NoError(t, env.Repository.SaveAuthorize(authorize))
+	require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 	return authorize
 }
 

--- a/router/oauth2/oauth2_test.go
+++ b/router/oauth2/oauth2_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -196,7 +197,7 @@ func (env *Env) CreateUser(t *testing.T, userName string, useUUIDV4 bool) model.
 		iconFileID = uuid.Must(uuid.NewV7())
 	}
 
-	u, err := env.Repository.CreateUser(repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.User, IconFileID: iconFileID})
+	u, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.User, IconFileID: iconFileID})
 	require.NoError(t, err)
 	return u
 }

--- a/router/oauth2/revoke_token_endpoint.go
+++ b/router/oauth2/revoke_token_endpoint.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -21,10 +22,10 @@ func (h *Handler) RevokeTokenEndpointHandler(c echo.Context) error {
 		return c.NoContent(http.StatusOK)
 	}
 
-	if err := h.Repo.DeleteTokenByAccess(req.Token); err != nil {
+	if err := h.Repo.DeleteTokenByAccess(context.TODO(), req.Token); err != nil {
 		return herror.InternalServerError(err)
 	}
-	if err := h.Repo.DeleteTokenByRefresh(req.Token); err != nil {
+	if err := h.Repo.DeleteTokenByRefresh(context.TODO(), req.Token); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/oauth2/revoke_token_endpoint_test.go
+++ b/router/oauth2/revoke_token_endpoint_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -39,7 +40,7 @@ func runRevokeTokenEndpointTests(t *testing.T, useUUIDv4 bool) {
 
 	t.Run("AccessToken", func(t *testing.T) {
 		t.Parallel()
-		token, err := env.Repository.IssueToken(nil, user.GetID(), "", model.AccessScopes{}, 10000, false)
+		token, err := env.Repository.IssueToken(context.TODO(), nil, user.GetID(), "", model.AccessScopes{}, 10000, false)
 		require.NoError(t, err)
 
 		e := env.R(t)
@@ -48,13 +49,13 @@ func runRevokeTokenEndpointTests(t *testing.T, useUUIDv4 bool) {
 			Expect().
 			Status(http.StatusOK)
 
-		_, err = env.Repository.GetTokenByID(token.ID)
+		_, err = env.Repository.GetTokenByID(context.TODO(), token.ID)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
 	t.Run("RefreshToken", func(t *testing.T) {
 		t.Parallel()
-		token, err := env.Repository.IssueToken(nil, user.GetID(), "", model.AccessScopes{}, 10000, true)
+		token, err := env.Repository.IssueToken(context.TODO(), nil, user.GetID(), "", model.AccessScopes{}, 10000, true)
 		require.NoError(t, err)
 
 		e := env.R(t)
@@ -63,7 +64,7 @@ func runRevokeTokenEndpointTests(t *testing.T, useUUIDv4 bool) {
 			Expect().
 			Status(http.StatusOK)
 
-		_, err = env.Repository.GetTokenByID(token.ID)
+		_, err = env.Repository.GetTokenByID(context.TODO(), token.ID)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 }

--- a/router/oauth2/token_endpoint.go
+++ b/router/oauth2/token_endpoint.go
@@ -77,7 +77,7 @@ func (h *Handler) issueToken(client *model.OAuth2Client, userID uuid.UUID, scope
 	isOIDC := scopes.Contains("openid")
 	// OIDCの場合は、Refresh TokenのScopeの管理（主にoffline_access周り）が面倒なので、一律で発行しないことにする
 	refresh := h.IsRefreshEnabled && grantTypeRefreshAllowed && !isOIDC
-	token, err := h.Repo.IssueToken(client, userID, client.RedirectURI, scopes, h.AccessTokenExp, refresh)
+	token, err := h.Repo.IssueToken(context.TODO(), client, userID, client.RedirectURI, scopes, h.AccessTokenExp, refresh)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 	}
 
 	// 認可コード確認
-	code, err := h.Repo.GetAuthorize(req.Code)
+	code, err := h.Repo.GetAuthorize(context.TODO(), req.Code)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -134,7 +134,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 		}
 	}
 	// 認可コードは２回使えない
-	if err := h.Repo.DeleteAuthorize(code.Code); err != nil {
+	if err := h.Repo.DeleteAuthorize(context.TODO(), code.Code); err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}
@@ -143,7 +143,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(code.ClientID)
+	client, err := h.Repo.GetClient(context.TODO(), code.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -215,7 +215,7 @@ func (h *Handler) tokenEndpointPasswordHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(cid)
+	client, err := h.Repo.GetClient(context.TODO(), cid)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -285,7 +285,7 @@ func (h *Handler) tokenEndpointClientCredentialsHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(id)
+	client, err := h.Repo.GetClient(context.TODO(), id)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -343,7 +343,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 	}
 
 	// リフレッシュトークン確認
-	token, err := h.Repo.GetTokenByRefresh(req.RefreshToken)
+	token, err := h.Repo.GetTokenByRefresh(context.TODO(), req.RefreshToken)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -355,7 +355,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(token.ClientID)
+	client, err := h.Repo.GetClient(context.TODO(), token.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -398,7 +398,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}
 	// 旧リフレッシュトークン削除
-	if err := h.Repo.DeleteTokenByRefresh(req.RefreshToken); err != nil {
+	if err := h.Repo.DeleteTokenByRefresh(context.TODO(), req.RefreshToken); err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}

--- a/router/oauth2/token_endpoint.go
+++ b/router/oauth2/token_endpoint.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 
 	vd "github.com/go-ozzo/ozzo-validation/v4"
@@ -229,7 +230,7 @@ func (h *Handler) tokenEndpointPasswordHandler(c echo.Context) error {
 	}
 
 	// ユーザー確認
-	user, err := h.Repo.GetUserByName(req.Username, false)
+	user, err := h.Repo.GetUserByName(context.TODO(), req.Username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/router/oauth2/token_endpoint_test.go
+++ b/router/oauth2/token_endpoint_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -67,7 +68,7 @@ func runTokenEndpointClientCredentialsTests(t *testing.T, uuidVersion int) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	t.Run("Success with Basic Auth", func(t *testing.T) {
 		t.Parallel()
@@ -212,7 +213,7 @@ func runTokenEndpointClientCredentialsTests(t *testing.T, uuidVersion int) {
 			RedirectURI:  "http://example.com",
 			Scopes:       scopesReadWrite,
 		}
-		require.NoError(t, env.Repository.SaveClient(client))
+		require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeClientCredentials).
@@ -292,7 +293,7 @@ func runTokenEndpointPasswordTests(t *testing.T, useUUIDV4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	t.Run("Success with Basic Auth", func(t *testing.T) {
 		t.Parallel()
@@ -404,7 +405,7 @@ func runTokenEndpointPasswordTests(t *testing.T, useUUIDV4 bool) {
 			RedirectURI:  "http://example.com",
 			Scopes:       scopesReadWrite,
 		}
-		require.NoError(t, env.Repository.SaveClient(client))
+		require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypePassword).
@@ -574,7 +575,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	var creatorIDConf uuid.UUID
 	if useUUIDv4 {
@@ -592,7 +593,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(clientConf))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), clientConf))
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
@@ -613,7 +614,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetTokenByRefresh(token.RefreshToken)
+		_, err := env.Repository.GetTokenByRefresh(context.TODO(), token.RefreshToken)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -637,7 +638,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.Value("scope").String().IsEqual("read")
 
-		_, err := env.Repository.GetTokenByRefresh(token.RefreshToken)
+		_, err := env.Repository.GetTokenByRefresh(context.TODO(), token.RefreshToken)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -661,7 +662,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.Value("scope").String().IsEqual("read")
 
-		_, err := env.Repository.GetTokenByRefresh(token.RefreshToken)
+		_, err := env.Repository.GetTokenByRefresh(context.TODO(), token.RefreshToken)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -685,7 +686,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetTokenByRefresh(token.RefreshToken)
+		_, err := env.Repository.GetTokenByRefresh(context.TODO(), token.RefreshToken)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -710,7 +711,7 @@ func runTokenEndpointRefreshTokenTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetTokenByRefresh(token.RefreshToken)
+		_, err := env.Repository.GetTokenByRefresh(context.TODO(), token.RefreshToken)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -845,7 +846,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	var creatorIDConf uuid.UUID
 	if useUUIDv4 {
@@ -863,7 +864,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		RedirectURI:  "http://example.com",
 		Scopes:       scopesReadWrite,
 	}
-	require.NoError(t, env.Repository.SaveClient(clientConf))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), clientConf))
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
@@ -887,7 +888,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -912,7 +913,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -938,7 +939,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -957,7 +958,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			CodeChallengeMethod: "plain",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -977,7 +978,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -996,7 +997,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			CodeChallengeMethod: "S256",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1016,7 +1017,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1033,7 +1034,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			OriginalScopes: scopesRead,
 			Nonce:          "nonce",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1052,7 +1053,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		obj.Value("refresh_token").String().NotEmpty()
 		obj.NotContainsKey("scope")
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1069,7 +1070,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			OriginalScopes: scopesReadManageBot,
 			Nonce:          "nonce",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1090,7 +1091,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		actual.FromString(obj.Value("scope").String().Raw())
 		assert.ElementsMatch(t, authorize.Scopes.StringArray(), actual.StringArray())
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1124,7 +1125,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidClient)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1144,7 +1145,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidClient)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1164,7 +1165,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidClient)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1197,7 +1198,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			OriginalScopes: scopesReadWrite,
 			Nonce:          "nonce",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1211,7 +1212,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidGrant)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1228,7 +1229,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			OriginalScopes: scopesReadWrite,
 			Nonce:          "nonce",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1242,7 +1243,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidClient)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1262,7 +1263,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidGrant)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1278,7 +1279,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			OriginalScopes: scopesReadWrite,
 			Nonce:          "nonce",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1292,7 +1293,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidGrant)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1311,7 +1312,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 			CodeChallengeMethod: "plain",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 		}
-		require.NoError(t, env.Repository.SaveAuthorize(authorize))
+		require.NoError(t, env.Repository.SaveAuthorize(context.TODO(), authorize))
 		e := env.R(t)
 		res := e.POST("/oauth2/token").
 			WithFormField("grant_type", grantTypeAuthorizationCode).
@@ -1325,7 +1326,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidRequest)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 
@@ -1346,7 +1347,7 @@ func runTokenEndpointAuthorizationCodeTests(t *testing.T, useUUIDv4 bool) {
 		res.Header("Pragma").IsEqual("no-cache")
 		res.JSON().Object().Value("error").IsEqual(errInvalidRequest)
 
-		_, err := env.Repository.GetAuthorize(authorize.Code)
+		_, err := env.Repository.GetAuthorize(context.TODO(), authorize.Code)
 		assert.EqualError(t, err, repository.ErrNotFound.Error())
 	})
 }

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,7 +32,7 @@ func ChangeUserIcon(p imaging2.Processor, c echo.Context, repo repository.Reposi
 	}
 
 	// アイコン変更
-	if err := repo.UpdateUser(userID, repository.UpdateUserArgs{IconFileID: optional.From(iconID)}); err != nil {
+	if err := repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{IconFileID: optional.From(iconID)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -64,7 +65,7 @@ func ServeUserIcon(c echo.Context, fm file.Manager, user model.UserInfo) error {
 
 // ChangeUserPassword userIDのユーザーのパスワードを変更する
 func ChangeUserPassword(c echo.Context, repo repository.Repository, seStore session.Store, userID uuid.UUID, newPassword string) error {
-	if err := repo.UpdateUser(userID, repository.UpdateUserArgs{Password: optional.From(newPassword)}); err != nil {
+	if err := repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{Password: optional.From(newPassword)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -96,7 +96,7 @@ func ServeFileThumbnail(c echo.Context, meta model.File, repo repository.Reposit
 		if errors.Is(err, storage.ErrFileNotFound) {
 			// サムネイルが実際には存在しないのでDBの情報を更新する
 			fileID := meta.GetID()
-			err := repo.DeleteFileThumbnail(fileID, thumbnailType)
+			err := repo.DeleteFileThumbnail(context.TODO(), fileID, thumbnailType)
 			if err != nil {
 				logger.Warn("failed to delete thumbnail from database", zap.Error(err))
 				return herror.InternalServerError(err)

--- a/router/utils/replace_mapper.go
+++ b/router/utils/replace_mapper.go
@@ -2,6 +2,8 @@
 package utils
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/repository"
@@ -28,7 +30,7 @@ func (m *replaceMapperImpl) Group(name string) (uuid.UUID, bool) {
 }
 
 func (m *replaceMapperImpl) User(name string) (uuid.UUID, bool) {
-	u, err := m.repo.GetUserByName(name, false)
+	u, err := m.repo.GetUserByName(context.TODO(), name, false)
 	if err != nil {
 		return uuid.Nil, false
 	}

--- a/router/utils/replace_mapper.go
+++ b/router/utils/replace_mapper.go
@@ -22,7 +22,7 @@ func (m *replaceMapperImpl) Channel(path string) (uuid.UUID, bool) {
 }
 
 func (m *replaceMapperImpl) Group(name string) (uuid.UUID, bool) {
-	g, err := m.repo.GetUserGroupByName(name)
+	g, err := m.repo.GetUserGroupByName(context.TODO(), name)
 	if err != nil {
 		return uuid.Nil, false
 	}

--- a/router/utils/validator.go
+++ b/router/utils/validator.go
@@ -79,16 +79,16 @@ var IsActiveHumanUserID = vd.WithContext(func(ctx context.Context, value interfa
 	case nil:
 		return nil
 	case uuid.UUID:
-		u, err = repo.GetUser(v, false)
+		u, err = repo.GetUser(context.TODO(), v, false)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		u, err = repo.GetUser(v.V, false)
+		u, err = repo.GetUser(context.TODO(), v.V, false)
 	case string:
-		u, err = repo.GetUser(uuid.FromStringOrNil(v), false)
+		u, err = repo.GetUser(context.TODO(), uuid.FromStringOrNil(v), false)
 	case []byte:
-		u, err = repo.GetUser(uuid.FromBytesOrNil(v), false)
+		u, err = repo.GetUser(context.TODO(), uuid.FromBytesOrNil(v), false)
 	default:
 		return errors.New(errMessage)
 	}
@@ -122,16 +122,16 @@ var IsUserID = vd.WithContext(func(ctx context.Context, value interface{}) error
 	case nil:
 		return nil
 	case uuid.UUID:
-		ok, err = repo.UserExists(v)
+		ok, err = repo.UserExists(context.TODO(), v)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		ok, err = repo.UserExists(v.V)
+		ok, err = repo.UserExists(context.TODO(), v.V)
 	case string:
-		ok, err = repo.UserExists(uuid.FromStringOrNil(v))
+		ok, err = repo.UserExists(context.TODO(), uuid.FromStringOrNil(v))
 	case []byte:
-		ok, err = repo.UserExists(uuid.FromBytesOrNil(v))
+		ok, err = repo.UserExists(context.TODO(), uuid.FromBytesOrNil(v))
 	default:
 		return errors.New(errMessage)
 	}
@@ -161,16 +161,16 @@ var IsNotWebhookUserID = vd.WithContext(func(ctx context.Context, value interfac
 	case nil:
 		return nil
 	case uuid.UUID:
-		user, err = repo.GetUser(v, false)
+		user, err = repo.GetUser(context.TODO(), v, false)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		user, err = repo.GetUser(v.V, false)
+		user, err = repo.GetUser(context.TODO(), v.V, false)
 	case string:
-		user, err = repo.GetUser(uuid.FromStringOrNil(v), false)
+		user, err = repo.GetUser(context.TODO(), uuid.FromStringOrNil(v), false)
 	case []byte:
-		user, err = repo.GetUser(uuid.FromBytesOrNil(v), false)
+		user, err = repo.GetUser(context.TODO(), uuid.FromBytesOrNil(v), false)
 	default:
 		return errors.New(errMessage)
 	}

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -23,7 +23,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	username := c.Param("username")
 
 	// ユーザー取得
-	user, err := h.Repo.GetUserByName(username, false)
+	user, err := h.Repo.GetUserByName(context.TODO(), username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -118,7 +118,7 @@ func (c *EmojiCache) Purge() {
 
 func emojiJSONGenerator(repo repository.Repository) func(_ context.Context, _ struct{}) ([]byte, error) {
 	return func(_ context.Context, _ struct{}) ([]byte, error) {
-		stamps, err := repo.GetAllStampsWithThumbnail(repository.StampTypeAll)
+		stamps, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func emojiJSONGenerator(repo repository.Repository) func(_ context.Context, _ st
 
 func emojiCSSGenerator(repo repository.Repository) func(_ context.Context, _ struct{}) ([]byte, error) {
 	return func(_ context.Context, _ struct{}) ([]byte, error) {
-		stamps, err := repo.GetAllStampsWithThumbnail(repository.StampTypeAll)
+		stamps, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
 		if err != nil {
 			return nil, err
 		}

--- a/router/v1/public_test.go
+++ b/router/v1/public_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"testing"
@@ -20,7 +21,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 	fid, err := file.GenerateIconFile(env.FileManager, "test")
 	require.NoError(err)
 
-	testUser, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	testUser, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:       random.AlphaNumeric(32),
 		Role:       role.User,
 		IconFileID: fid,

--- a/router/v1/router_test.go
+++ b/router/v1/router_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"image"
 	"net/http"
 	"net/http/httptest"
@@ -115,7 +116,7 @@ func setup(t *testing.T, server string) (*Env, *assert.Assertions, *require.Asse
 	assert, require := assertAndRequire(t)
 	repo := env.Repository
 	testUser := env.mustMakeUser(t, rand)
-	adminUser, err := repo.GetUserByName("traq", true)
+	adminUser, err := repo.GetUserByName(context.TODO(), "traq", true)
 	require.NoError(err)
 	return env, assert, require, env.generateSession(t, testUser.GetID()), env.generateSession(t, adminUser.GetID())
 }
@@ -156,7 +157,7 @@ func (env *Env) mustMakeUser(t *testing.T, userName string) model.UserInfo {
 		userName = random.AlphaNumeric(32)
 	}
 	// パスワード無し・アイコンファイルは実際には存在しないことに注意
-	u, err := env.Repository.CreateUser(repository.CreateUserArgs{Name: userName, Role: role.User, IconFileID: uuid.Must(uuid.NewV4())})
+	u, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{Name: userName, Role: role.User, IconFileID: uuid.Must(uuid.NewV4())})
 	require.NoError(t, err)
 	return u
 }

--- a/router/v3/activity.go
+++ b/router/v3/activity.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -74,7 +75,7 @@ func (h *Handlers) GetActivityTimeline(c echo.Context) error {
 	if !req.All {
 		query.SubscribedByUser = optional.From(userID)
 	}
-	messages, err := h.Repo.GetChannelLatestMessages(query)
+	messages, err := h.Repo.GetChannelLatestMessages(context.TODO(), query)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/activity_test.go
+++ b/router/v3/activity_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -71,7 +72,7 @@ func TestHandlers_GetActivityTimeline(t *testing.T) {
 
 	ch1 := env.CreateChannel(t, rand)
 	ch2 := env.CreateChannel(t, rand)
-	_, _, err := env.Repository.ChangeChannelSubscription(ch1.ID, repository.ChangeChannelSubscriptionArgs{
+	_, _, err := env.Repository.ChangeChannelSubscription(context.TODO(), ch1.ID, repository.ChangeChannelSubscriptionArgs{
 		Subscription: map[uuid.UUID]model.ChannelSubscribeLevel{
 			user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 		},

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -75,7 +75,7 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	if _, err := h.Repo.GetUserByName("BOT_"+req.Name, false); err == nil {
+	if _, err := h.Repo.GetUserByName(context.TODO(), "BOT_"+req.Name, false); err == nil {
 		return herror.Conflict("this name is already used")
 	} else if err != repository.ErrNotFound {
 		return herror.InternalServerError(err)
@@ -212,7 +212,7 @@ func (h *Handlers) GetBotIcon(c echo.Context) error {
 	w := getParamBot(c)
 
 	// ユーザー取得
-	user, err := h.Repo.GetUser(w.BotUserID, false)
+	user, err := h.Repo.GetUser(context.TODO(), w.BotUserID, false)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -94,7 +94,7 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	t, err := h.Repo.GetTokenByID(b.AccessTokenID)
+	t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -114,7 +114,7 @@ func (h *Handlers) GetBot(c echo.Context) error {
 			return herror.Forbidden()
 		}
 
-		t, err := h.Repo.GetTokenByID(b.AccessTokenID)
+		t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
 		if err != nil {
 			switch err {
 			case repository.ErrNotFound:
@@ -310,7 +310,7 @@ func (h *Handlers) ReissueBot(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	t, err := h.Repo.GetTokenByID(b.AccessTokenID)
+	t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -30,7 +30,7 @@ func (h *Handlers) GetBots(c echo.Context) error {
 		q = q.CreatedBy(getRequestUserID(c))
 	}
 
-	list, err := h.Repo.GetBots(q)
+	list, err := h.Repo.GetBots(context.TODO(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -89,7 +89,7 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		initialState = model.BotActive
 	}
 
-	b, err := h.Repo.CreateBot(req.Name, req.DisplayName, req.Description, iconFileID, getRequestUserID(c), model.BotMode(req.Mode), initialState, req.Endpoint)
+	b, err := h.Repo.CreateBot(context.TODO(), req.Name, req.DisplayName, req.Description, iconFileID, getRequestUserID(c), model.BotMode(req.Mode), initialState, req.Endpoint)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -124,7 +124,7 @@ func (h *Handlers) GetBot(c echo.Context) error {
 			}
 		}
 
-		ids, err := h.Repo.GetParticipatingChannelIDsByBot(b.ID)
+		ids, err := h.Repo.GetParticipatingChannelIDsByBot(context.TODO(), b.ID)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -189,7 +189,7 @@ func (h *Handlers) EditBot(c echo.Context) error {
 		Bio:             req.Bio,
 	}
 
-	if err := h.Repo.UpdateBot(b.ID, args); err != nil {
+	if err := h.Repo.UpdateBot(context.TODO(), b.ID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -200,7 +200,7 @@ func (h *Handlers) EditBot(c echo.Context) error {
 func (h *Handlers) DeleteBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	if err := h.Repo.DeleteBot(b.ID); err != nil {
+	if err := h.Repo.DeleteBot(context.TODO(), b.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -250,7 +250,7 @@ func (h *Handlers) GetBotLogs(c echo.Context) error {
 		return err
 	}
 
-	logs, err := h.Repo.GetBotEventLogs(b.ID, req.Limit, req.Offset)
+	logs, err := h.Repo.GetBotEventLogs(context.TODO(), b.ID, req.Limit, req.Offset)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -262,7 +262,7 @@ func (h *Handlers) GetBotLogs(c echo.Context) error {
 func (h *Handlers) GetChannelBots(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	bots, err := h.Repo.GetBots(repository.BotsQuery{}.CMemberOf(channelID))
+	bots, err := h.Repo.GetBots(context.TODO(), repository.BotsQuery{}.CMemberOf(channelID))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -295,7 +295,7 @@ func (h *Handlers) ActivateBot(c echo.Context) error {
 func (h *Handlers) InactivateBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	if err := h.Repo.ChangeBotState(b.ID, model.BotInactive); err != nil {
+	if err := h.Repo.ChangeBotState(context.TODO(), b.ID, model.BotInactive); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -305,7 +305,7 @@ func (h *Handlers) InactivateBot(c echo.Context) error {
 func (h *Handlers) ReissueBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	b, err := h.Repo.ReissueBotTokens(b.ID)
+	b, err := h.Repo.ReissueBotTokens(context.TODO(), b.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -342,7 +342,7 @@ func (h *Handlers) LetBotJoinChannel(c echo.Context) error {
 	b := getParamBot(c)
 
 	// 参加
-	if err := h.Repo.AddBotToChannel(b.ID, req.ChannelID); err != nil {
+	if err := h.Repo.AddBotToChannel(context.TODO(), b.ID, req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -370,7 +370,7 @@ func (h *Handlers) LetBotLeaveChannel(c echo.Context) error {
 	b := getParamBot(c)
 
 	// 退出
-	if err := h.Repo.RemoveBotFromChannel(b.ID, req.ChannelID); err != nil {
+	if err := h.Repo.RemoveBotFromChannel(context.TODO(), b.ID, req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/bots_test.go
+++ b/router/v3/bots_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -369,9 +370,9 @@ func TestHandlers_EditBot(t *testing.T) {
 	bot1 := env.CreateBot(t, rand, user1.GetID())
 	bot2 := env.CreateBot(t, rand, user1.GetID())
 	bot3 := env.CreateBot(t, rand, user2.GetID())
-	wsBotWithEndpoint, err := env.Repository.CreateBot(random.AlphaNumeric(16), "po", "po", uuid.Nil, user1.GetID(), model.BotModeWebSocket, model.BotActive, "https://example.com")
+	wsBotWithEndpoint, err := env.Repository.CreateBot(context.TODO(), random.AlphaNumeric(16), "po", "po", uuid.Nil, user1.GetID(), model.BotModeWebSocket, model.BotActive, "https://example.com")
 	require.NoError(t, err)
-	wsBotWithoutEndpoint, err := env.Repository.CreateBot(random.AlphaNumeric(16), "po", "po", uuid.Nil, user1.GetID(), model.BotModeWebSocket, model.BotActive, "")
+	wsBotWithoutEndpoint, err := env.Repository.CreateBot(context.TODO(), random.AlphaNumeric(16), "po", "po", uuid.Nil, user1.GetID(), model.BotModeWebSocket, model.BotActive, "")
 	require.NoError(t, err)
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -697,7 +698,7 @@ func TestHandlers_GetBotLogs(t *testing.T) {
 		Code:      400,
 		DateTime:  time.Now(),
 	}
-	require.NoError(t, env.Repository.WriteBotEventLog(log))
+	require.NoError(t, env.Repository.WriteBotEventLog(context.TODO(), log))
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -768,7 +769,7 @@ func TestHandlers_GetChannelBots(t *testing.T) {
 	channel := env.CreateChannel(t, rand)
 	commonSession := env.S(t, user.GetID())
 	bot := env.CreateBot(t, rand, user.GetID())
-	require.NoError(t, env.Repository.AddBotToChannel(bot.ID, channel.ID))
+	require.NoError(t, env.Repository.AddBotToChannel(context.TODO(), bot.ID, channel.ID))
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -1031,7 +1032,7 @@ func TestHandlers_LetBotLeaveChannel(t *testing.T) {
 	bot2 := env.CreateBot(t, rand, user2.GetID())
 	channel1 := env.CreateChannel(t, rand)
 	channel2 := env.CreateChannel(t, rand)
-	require.NoError(t, env.Repository.AddBotToChannel(bot1.ID, channel1.ID))
+	require.NoError(t, env.Repository.AddBotToChannel(context.TODO(), bot1.ID, channel1.ID))
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -188,7 +188,7 @@ func (h *Handlers) GetChannelViewers(c echo.Context) error {
 func (h *Handlers) GetChannelStats(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 	excludeDeletedMessages := isTrue(c.QueryParam("exclude-deleted-messages"))
-	stats, err := h.Repo.GetChannelStats(channelID, excludeDeletedMessages)
+	stats, err := h.Repo.GetChannelStats(context.TODO(), channelID, excludeDeletedMessages)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -287,7 +287,7 @@ func (h *Handlers) GetChannelEvents(c echo.Context) error {
 		return err
 	}
 
-	events, more, err := h.Repo.GetChannelEvents(req.convert(channelID))
+	events, more, err := h.Repo.GetChannelEvents(context.TODO(), req.convert(channelID))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -304,7 +304,7 @@ func (h *Handlers) GetChannelSubscribers(c echo.Context) error {
 		return herror.Forbidden()
 	}
 
-	subscriptions, err := h.Repo.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -330,7 +330,7 @@ func (h *Handlers) SetChannelSubscribers(c echo.Context) error {
 		return err
 	}
 
-	subscriptions, err := h.Repo.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -238,7 +239,7 @@ func (h *Handlers) EditChannelTopic(c echo.Context) error {
 func (h *Handlers) GetChannelPins(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	pins, err := h.Repo.GetPinnedMessageByChannelID(channelID)
+	pins, err := h.Repo.GetPinnedMessageByChannelID(context.TODO(), channelID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"slices"
 	"strings"
@@ -1050,7 +1051,7 @@ func TestHandlers_SetChannelSubscribers(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.From(channel.ID)})
+		subs, err := env.Repository.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{ChannelID: optional.From(channel.ID)})
 		require.NoError(t, err)
 
 		if assert.Len(t, subs, 1) {
@@ -1150,7 +1151,7 @@ func TestHandlers_EditChannelSubscribers(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.From(channel.ID)})
+		subs, err := env.Repository.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{ChannelID: optional.From(channel.ID)})
 		require.NoError(t, err)
 
 		if assert.Len(t, subs, 4) {

--- a/router/v3/clients.go
+++ b/router/v3/clients.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 
 	vd "github.com/go-ozzo/ozzo-validation/v4"
@@ -25,7 +26,7 @@ func (h *Handlers) GetClients(c echo.Context) error {
 		q = q.IsDevelopedBy(getRequestUserID(c))
 	}
 
-	ocs, err := h.Repo.GetClients(q)
+	ocs, err := h.Repo.GetClients(context.TODO(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -69,7 +70,7 @@ func (h *Handlers) CreateClient(c echo.Context) error {
 		Secret:       random.SecureAlphaNumeric(36),
 		Scopes:       req.Scopes,
 	}
-	if err := h.Repo.SaveClient(client); err != nil {
+	if err := h.Repo.SaveClient(context.TODO(), client); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -125,7 +126,7 @@ func (h *Handlers) EditClient(c echo.Context) error {
 		CallbackURL:  req.CallbackURL,
 		Confidential: req.Confidential,
 	}
-	if err := h.Repo.UpdateClient(oc.ID, args); err != nil {
+	if err := h.Repo.UpdateClient(context.TODO(), oc.ID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -137,7 +138,7 @@ func (h *Handlers) DeleteClient(c echo.Context) error {
 	oc := getParamClient(c)
 
 	// delete client
-	if err := h.Repo.DeleteClient(oc.ID); err != nil {
+	if err := h.Repo.DeleteClient(context.TODO(), oc.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -149,7 +150,7 @@ func (h *Handlers) RevokeClientTokens(c echo.Context) error {
 	oc := getParamClient(c)
 	userID := getRequestUserID(c)
 
-	err := h.Repo.DeleteUserTokensByClient(userID, oc.ID)
+	err := h.Repo.DeleteUserTokensByClient(context.TODO(), userID, oc.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/clients_test.go
+++ b/router/v3/clients_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -257,7 +258,7 @@ func TestHandlers_CreateClient(t *testing.T) {
 		obj.Value("secret").String().NotEmpty()
 		obj.Value("confidential").Boolean().IsFalse()
 
-		c, err := env.Repository.GetClient(obj.Value("id").String().Raw())
+		c, err := env.Repository.GetClient(context.TODO(), obj.Value("id").String().Raw())
 		assert.NoError(t, err)
 		oAuth2ClientEquals(t, c, obj)
 	})
@@ -284,7 +285,7 @@ func TestHandlers_CreateClient(t *testing.T) {
 		obj.Value("secret").String().NotEmpty()
 		obj.Value("confidential").Boolean().IsTrue()
 
-		c, err := env.Repository.GetClient(obj.Value("id").String().Raw())
+		c, err := env.Repository.GetClient(context.TODO(), obj.Value("id").String().Raw())
 		assert.NoError(t, err)
 		oAuth2ClientEquals(t, c, obj)
 	})
@@ -546,7 +547,7 @@ func TestHandlers_EditClient(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		c, err := env.Repository.GetClient(c1.ID)
+		c, err := env.Repository.GetClient(context.TODO(), c1.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, c.Name, "po")
 	})
@@ -560,7 +561,7 @@ func TestHandlers_EditClient(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		c, err := env.Repository.GetClient(c2.ID)
+		c, err := env.Repository.GetClient(context.TODO(), c2.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, c.Name, "po2")
 	})
@@ -574,7 +575,7 @@ func TestHandlers_EditClient(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		c, err := env.Repository.GetClient(c3.ID)
+		c, err := env.Repository.GetClient(context.TODO(), c3.ID)
 		require.NoError(t, err)
 		assert.True(t, c.Confidential)
 	})
@@ -629,7 +630,7 @@ func TestHandlers_DeleteClient(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetClient(c1.ID)
+		_, err := env.Repository.GetClient(context.TODO(), c1.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 
@@ -641,7 +642,7 @@ func TestHandlers_DeleteClient(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetClient(c2.ID)
+		_, err := env.Repository.GetClient(context.TODO(), c2.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }
@@ -743,7 +744,7 @@ func TestHandlers_RevokeClientTokens(t *testing.T) {
 
 			for userID, userTokens := range tokens {
 				for _, userToken := range userTokens {
-					_, err := env.Repository.GetTokenByID(userToken.ID)
+					_, err := env.Repository.GetTokenByID(context.TODO(), userToken.ID)
 					if userToken.ClientID == tt.clientID && userID == tt.user.GetID() && tt.statusCode == http.StatusNoContent {
 						assert.ErrorIs(t, err, repository.ErrNotFound)
 					} else {

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,7 +54,7 @@ func (h *Handlers) CreateClipFolder(c echo.Context) error {
 		return err
 	}
 
-	cf, err := h.Repo.CreateClipFolder(userID, req.Name, req.Description)
+	cf, err := h.Repo.CreateClipFolder(context.TODO(), userID, req.Name, req.Description)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -65,7 +66,7 @@ func (h *Handlers) CreateClipFolder(c echo.Context) error {
 func (h *Handlers) GetClipFolders(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	cfs, err := h.Repo.GetClipFoldersByUserID(userID)
+	cfs, err := h.Repo.GetClipFoldersByUserID(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -82,7 +83,7 @@ func (h *Handlers) GetClipFolder(c echo.Context) error {
 func (h *Handlers) DeleteClipFolder(c echo.Context) error {
 	folderID := getParamAsUUID(c, consts.ParamClipFolderID)
 
-	if err := h.Repo.DeleteClipFolder(folderID); err != nil {
+	if err := h.Repo.DeleteClipFolder(context.TODO(), folderID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -97,7 +98,7 @@ func (h *Handlers) EditClipFolder(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateClipFolder(cf.ID, req.Name, req.Description); err != nil {
+	if err := h.Repo.UpdateClipFolder(context.TODO(), cf.ID, req.Name, req.Description); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -135,7 +136,7 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 	}
 
 	var cfm *model.ClipFolderMessage
-	cfm, err = h.Repo.AddClipFolderMessage(cf.ID, req.MessageID)
+	cfm, err = h.Repo.AddClipFolderMessage(context.TODO(), cf.ID, req.MessageID)
 	if err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
@@ -181,7 +182,7 @@ func (h *Handlers) GetClipFolderMessages(c echo.Context) error {
 		return err
 	}
 
-	messages, more, err := h.Repo.GetClipFolderMessages(cf.ID, req.convert())
+	messages, more, err := h.Repo.GetClipFolderMessages(context.TODO(), cf.ID, req.convert())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -196,7 +197,7 @@ func (h *Handlers) DeleteClipFolderMessages(c echo.Context) error {
 	messageID := getParamAsUUID(c, consts.ParamMessageID)
 
 	cf := getParamClipFolder(c)
-	if err := h.Repo.DeleteClipFolderMessage(cf.ID, messageID); err != nil {
+	if err := h.Repo.DeleteClipFolderMessage(context.TODO(), cf.ID, messageID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/clips_test.go
+++ b/router/v3/clips_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -304,7 +305,7 @@ func TestHandlers_DeleteClipFolder(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetClipFolder(cf1.ID)
+		_, err := env.Repository.GetClipFolder(context.TODO(), cf1.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }
@@ -373,7 +374,7 @@ func TestHandlers_EditClipFolder(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		cf, err := env.Repository.GetClipFolder(cf1.ID)
+		cf, err := env.Repository.GetClipFolder(context.TODO(), cf1.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, "nya", cf.Name)
 		assert.EqualValues(t, "foo", cf.Description)
@@ -394,7 +395,7 @@ func TestHandlers_PostClipFolderMessage(t *testing.T) {
 	m := env.CreateMessage(t, user2.GetID(), c.ID, rand)
 	user1Session := env.S(t, user1.GetID())
 
-	_, err := env.Repository.AddClipFolderMessage(cf3.ID, m.GetID())
+	_, err := env.Repository.AddClipFolderMessage(context.TODO(), cf3.ID, m.GetID())
 	require.NoError(t, err)
 
 	req := &PostClipFolderMessageRequest{
@@ -542,7 +543,7 @@ func TestHandlers_GetClipFolderMessages(t *testing.T) {
 	m := env.CreateMessage(t, user2.GetID(), c.ID, rand)
 	user1Session := env.S(t, user1.GetID())
 
-	_, err := env.Repository.AddClipFolderMessage(cf1.ID, m.GetID())
+	_, err := env.Repository.AddClipFolderMessage(context.TODO(), cf1.ID, m.GetID())
 	require.NoError(t, err)
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -613,7 +614,7 @@ func TestHandlers_DeleteClipFolderMessages(t *testing.T) {
 	m2 := env.CreateMessage(t, user1.GetID(), c.ID, rand)
 	user1Session := env.S(t, user1.GetID())
 
-	_, err := env.Repository.AddClipFolderMessage(cf1.ID, m.GetID())
+	_, err := env.Repository.AddClipFolderMessage(context.TODO(), cf1.ID, m.GetID())
 	require.NoError(t, err)
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -659,7 +660,7 @@ func TestHandlers_DeleteClipFolderMessages(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		messages, more, err := env.Repository.GetClipFolderMessages(cf1.ID, repository.ClipFolderMessageQuery{
+		messages, more, err := env.Repository.GetClipFolderMessages(context.TODO(), cf1.ID, repository.ClipFolderMessageQuery{
 			Limit:  50,
 			Offset: 0,
 			Asc:    false,
@@ -674,7 +675,7 @@ func TestHandlers_DeleteClipFolderMessages(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		messages, more, err = env.Repository.GetClipFolderMessages(cf1.ID, repository.ClipFolderMessageQuery{
+		messages, more, err = env.Repository.GetClipFolderMessages(context.TODO(), cf1.ID, repository.ClipFolderMessageQuery{
 			Limit:  50,
 			Offset: 0,
 			Asc:    false,

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -302,7 +302,7 @@ func (h *Handlers) GetMessageClips(c echo.Context) error {
 	userID := getRequestUserID(c)
 	messageID := getParamAsUUID(c, consts.ParamMessageID)
 
-	clips, err := h.Repo.GetMessageClips(userID, messageID)
+	clips, err := h.Repo.GetMessageClips(context.TODO(), userID, messageID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -20,7 +20,7 @@ import (
 func (h *Handlers) GetMyUnreadChannels(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	list, err := h.Repo.GetUserUnreadChannels(userID)
+	list, err := h.Repo.GetUserUnreadChannels(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -33,7 +33,7 @@ func (h *Handlers) ReadChannel(c echo.Context) error {
 	userID := getRequestUserID(c)
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	if err := h.Repo.DeleteUnreadsByChannelID(channelID, userID); err != nil {
+	if err := h.Repo.DeleteUnreadsByChannelID(context.TODO(), channelID, userID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -149,7 +149,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			return herror.Forbidden("you are not allowed to delete this message")
 		case model.UserTypeBot:
 			// BOTのメッセージの削除権限の確認
-			wh, err := h.Repo.GetBotByBotUserID(mUser.GetID())
+			wh, err := h.Repo.GetBotByBotUserID(context.TODO(), mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted bot

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -163,7 +164,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			}
 		case model.UserTypeWebhook:
 			// Webhookのメッセージの削除権限の確認
-			wh, err := h.Repo.GetWebhookByBotUserID(mUser.GetID())
+			wh, err := h.Repo.GetWebhookByBotUserID(context.TODO(), mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted webhook

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -139,7 +139,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 	m := getParamMessage(c)
 
 	if muid := m.GetUserID(); muid != userID {
-		mUser, err := h.Repo.GetUser(muid, false)
+		mUser, err := h.Repo.GetUser(context.TODO(), muid, false)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -213,7 +214,7 @@ func TestHandlers_EditMessage(t *testing.T) {
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
 	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
-	require.NoError(t, env.Repository.DeleteWebhook(w3.GetID()))
+	require.NoError(t, env.Repository.DeleteWebhook(context.TODO(), w3.GetID()))
 
 	s := env.S(t, user.GetID())
 
@@ -363,7 +364,7 @@ func TestHandlers_DeleteMessage(t *testing.T) {
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
 	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
-	require.NoError(t, env.Repository.DeleteWebhook(w3.GetID()))
+	require.NoError(t, env.Repository.DeleteWebhook(context.TODO(), w3.GetID()))
 
 	s := env.S(t, user.GetID())
 

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -82,7 +82,7 @@ func TestHandlers_ReadChannel(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		chs, err := env.Repository.GetUserUnreadChannels(user.GetID())
+		chs, err := env.Repository.GetUserUnreadChannels(context.TODO(), user.GetID())
 		require.NoError(t, err)
 		assert.Len(t, chs, 0)
 	})

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -912,7 +912,7 @@ func TestHandlers_GetMessageClips(t *testing.T) {
 	ch := env.CreateChannel(t, rand)
 	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	cf := env.CreateClipFolder(t, rand, rand, user.GetID())
-	_, err := env.Repository.AddClipFolderMessage(cf.ID, m.GetID())
+	_, err := env.Repository.AddClipFolderMessage(context.TODO(), cf.ID, m.GetID())
 	require.NoError(t, err)
 	s := env.S(t, user.GetID())
 

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -213,7 +213,7 @@ func TestHandlers_EditMessage(t *testing.T) {
 
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
-	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
+	require.NoError(t, env.Repository.DeleteBot(context.TODO(), bot3.ID))
 	require.NoError(t, env.Repository.DeleteWebhook(context.TODO(), w3.GetID()))
 
 	s := env.S(t, user.GetID())
@@ -363,7 +363,7 @@ func TestHandlers_DeleteMessage(t *testing.T) {
 
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
-	require.NoError(t, env.Repository.DeleteBot(bot3.ID))
+	require.NoError(t, env.Repository.DeleteBot(context.TODO(), bot3.ID))
 	require.NoError(t, env.Repository.DeleteWebhook(context.TODO(), w3.GetID()))
 
 	s := env.S(t, user.GetID())

--- a/router/v3/public.go
+++ b/router/v3/public.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -43,7 +44,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	username := c.Param("username")
 
 	// ユーザー取得
-	user, err := h.Repo.GetUserByName(username, false)
+	user, err := h.Repo.GetUserByName(context.TODO(), username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/router/v3/public_test.go
+++ b/router/v3/public_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 	env := Setup(t, common1)
 	iconFileID, err := file2.GenerateIconFile(env.FM, "test")
 	require.NoError(t, err)
-	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:       random.AlphaNumeric(20),
 		Password:   "totallyASecurePassword",
 		Role:       role.User,

--- a/router/v3/qall.go
+++ b/router/v3/qall.go
@@ -28,7 +28,7 @@ func (h *Handlers) GetQallEndpoints(c echo.Context) error {
 
 // GetSoundboardItems GET /qall/soundboard
 func (h *Handlers) GetSoundboardItems(c echo.Context) error {
-	items, err := h.Repo.GetAllSoundboardItems()
+	items, err := h.Repo.GetAllSoundboardItems(context.TODO())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 		}
 		if init {
 			// システムユーザーロール投入
-			if err := repo.CreateUserRoles(role.SystemRoleModels()...); err != nil {
+			if err := repo.CreateUserRoles(context.TODO(), role.SystemRoleModels()...); err != nil {
 				panic(err)
 			}
 		}

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -367,7 +367,7 @@ func (env *Env) CreateStampPalette(t *testing.T, creator uuid.UUID, name string,
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	sp, err := env.Repository.CreateStampPalette(name, "desc", stamps, creator)
+	sp, err := env.Repository.CreateStampPalette(context.TODO(), name, "desc", stamps, creator)
 	require.NoError(t, err)
 	return sp
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -424,7 +424,7 @@ func (env *Env) CreateBot(t *testing.T, name string, creatorID uuid.UUID) *model
 		name = random.AlphaNumeric(20)
 	}
 	f := env.CreateFile(t, creatorID, uuid.Nil)
-	b, err := env.Repository.CreateBot(name, "po", "totally a desc", f.GetID(), creatorID, model.BotModeHTTP, model.BotInactive, "https://example.com")
+	b, err := env.Repository.CreateBot(context.TODO(), name, "po", "totally a desc", f.GetID(), creatorID, model.BotModeHTTP, model.BotInactive, "https://example.com")
 	require.NoError(t, err)
 	return b
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -491,7 +491,7 @@ func (env *Env) CreateClipFolder(t *testing.T, name, desc string, creatorID uuid
 	if desc == rand {
 		desc = random.AlphaNumeric(20)
 	}
-	cf, err := env.Repository.CreateClipFolder(creatorID, name, desc)
+	cf, err := env.Repository.CreateClipFolder(context.TODO(), creatorID, name, desc)
 	require.NoError(t, err)
 	return cf
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -342,7 +342,7 @@ func (env *Env) DeleteMessage(t *testing.T, messageID uuid.UUID) {
 // MakeMessageUnread 指定したメッセージを未読にします
 func (env *Env) MakeMessageUnread(t *testing.T, userID, messageID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, env.Repository.SetMessageUnreads(map[uuid.UUID]bool{userID: false}, messageID))
+	require.NoError(t, env.Repository.SetMessageUnreads(context.TODO(), map[uuid.UUID]bool{userID: false}, messageID))
 }
 
 // CreateStamp スタンプを必ず作成します

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -255,12 +255,12 @@ func (env *Env) AddTag(t *testing.T, name string, userID uuid.UUID) model.UserTa
 		name = random.AlphaNumeric(20)
 	}
 
-	tag, err := env.Repository.GetOrCreateTag(name)
+	tag, err := env.Repository.GetOrCreateTag(context.TODO(), name)
 	require.NoError(t, err)
 
-	require.NoError(t, env.Repository.AddUserTag(userID, tag.ID))
+	require.NoError(t, env.Repository.AddUserTag(context.TODO(), userID, tag.ID))
 
-	ut, err := env.Repository.GetUserTag(userID, tag.ID)
+	ut, err := env.Repository.GetUserTag(context.TODO(), userID, tag.ID)
 	require.NoError(t, err)
 	return ut
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -352,7 +352,7 @@ func (env *Env) CreateStamp(t *testing.T, creator uuid.UUID, name string) *model
 		name = random.AlphaNumeric(20)
 	}
 	f := env.CreateFile(t, creator, uuid.Nil)
-	s, err := env.Repository.CreateStamp(repository.CreateStampArgs{
+	s, err := env.Repository.CreateStamp(context.TODO(), repository.CreateStampArgs{
 		Name:      name,
 		FileID:    f.GetID(),
 		CreatorID: creator,

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -232,7 +232,7 @@ func (env *Env) CreateUser(t *testing.T, userName string) model.UserInfo {
 	if userName == rand {
 		userName = random.AlphaNumeric(32)
 	}
-	u, err := env.Repository.CreateUser(repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.User, IconFileID: uuid.Must(uuid.NewV7())})
+	u, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.User, IconFileID: uuid.Must(uuid.NewV7())})
 	require.NoError(t, err)
 	return u
 }
@@ -243,7 +243,7 @@ func (env *Env) CreateAdmin(t *testing.T, userName string) model.UserInfo {
 	if userName == rand {
 		userName = random.AlphaNumeric(32)
 	}
-	u, err := env.Repository.CreateUser(repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.Admin, IconFileID: uuid.Must(uuid.NewV4())})
+	u, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{Name: userName, Password: "!test_test@test-", Role: role.Admin, IconFileID: uuid.Must(uuid.NewV4())})
 	require.NoError(t, err)
 	return u
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image"
 	"net/http"
@@ -311,7 +312,7 @@ func (env *Env) CreateSubchannel(t *testing.T, parent *model.Channel, name strin
 // AddStar 指定したチャンネルをスターします
 func (env *Env) AddStar(t *testing.T, userID, channelID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, env.Repository.AddStar(userID, channelID))
+	require.NoError(t, env.Repository.AddStar(context.TODO(), userID, channelID))
 }
 
 // CreateDMChannel DMチャンネルを必ず作成します

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -436,7 +436,7 @@ func (env *Env) CreateWebhook(t *testing.T, name string, creatorID, channelID uu
 		name = random.AlphaNumeric(20)
 	}
 	f := env.CreateFile(t, creatorID, uuid.Nil)
-	w, err := env.Repository.CreateWebhook(name, "po", channelID, f.GetID(), creatorID, random.SecureAlphaNumeric(20))
+	w, err := env.Repository.CreateWebhook(context.TODO(), name, "po", channelID, f.GetID(), creatorID, random.SecureAlphaNumeric(20))
 	require.NoError(t, err)
 	return w
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -272,7 +272,7 @@ func (env *Env) CreateUserGroup(t *testing.T, name, description, groupType strin
 		name = random.AlphaNumeric(20)
 	}
 	icon := env.CreateFile(t, uuid.Nil, uuid.Nil)
-	ug, err := env.Repository.CreateUserGroup(name, description, groupType, adminID, icon.GetID())
+	ug, err := env.Repository.CreateUserGroup(context.TODO(), name, description, groupType, adminID, icon.GetID())
 	require.NoError(t, err)
 	return ug
 }
@@ -280,7 +280,7 @@ func (env *Env) CreateUserGroup(t *testing.T, name, description, groupType strin
 // AddUserToUserGroup ユーザーをユーザーグループに必ず追加します
 func (env *Env) AddUserToUserGroup(t *testing.T, userID, groupID uuid.UUID, role string) {
 	t.Helper()
-	require.NoError(t, env.Repository.AddUserToGroup(userID, groupID, role))
+	require.NoError(t, env.Repository.AddUserToGroup(context.TODO(), userID, groupID, role))
 }
 
 // CreateChannel チャンネルを必ず作成します

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -470,14 +470,14 @@ func (env *Env) CreateOAuth2Client(t *testing.T, name string, creatorID uuid.UUI
 	for _, opt := range opts {
 		opt(client)
 	}
-	require.NoError(t, env.Repository.SaveClient(client))
+	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 	return client
 }
 
 // IssueToken OAuth2トークンを必ず発行します
 func (env *Env) IssueToken(t *testing.T, client *model.OAuth2Client, userID uuid.UUID) *model.OAuth2Token {
 	t.Helper()
-	tok, err := env.Repository.IssueToken(client, userID, "https://example.com", model.AccessScopes{"read": {}}, 86400, false)
+	tok, err := env.Repository.IssueToken(context.TODO(), client, userID, "https://example.com", model.AccessScopes{"read": {}}, 86400, false)
 	require.NoError(t, err)
 	return tok
 }

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -38,7 +39,7 @@ func (h *Handlers) Login(c echo.Context) error {
 		return err
 	}
 
-	user, err := h.Repo.GetUserByName(req.Name, false)
+	user, err := h.Repo.GetUserByName(context.TODO(), req.Name, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -186,7 +187,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 
 // GetMyExternalAccounts GET /users/me/ex-accounts
 func (h *Handlers) GetMyExternalAccounts(c echo.Context) error {
-	links, err := h.Repo.GetLinkedExternalUserAccounts(getRequestUserID(c))
+	links, err := h.Repo.GetLinkedExternalUserAccounts(context.TODO(), getRequestUserID(c))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -234,7 +235,7 @@ func (h *Handlers) LinkExternalAccount(c echo.Context) error {
 		return herror.BadRequest("invalid provider name")
 	}
 
-	links, err := h.Repo.GetLinkedExternalUserAccounts(getRequestUserID(c))
+	links, err := h.Repo.GetLinkedExternalUserAccounts(context.TODO(), getRequestUserID(c))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -265,7 +266,7 @@ func (h *Handlers) UnlinkExternalAccount(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UnlinkExternalUserAccount(getRequestUserID(c), req.ProviderName); err != nil {
+	if err := h.Repo.UnlinkExternalUserAccount(context.TODO(), getRequestUserID(c), req.ProviderName); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.BadRequest("invalid provider name")

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -135,7 +135,7 @@ func (h *Handlers) RevokeMySession(c echo.Context) error {
 func (h *Handlers) GetMyTokens(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	ot, err := h.Repo.GetTokensByUser(userID)
+	ot, err := h.Repo.GetTokensByUser(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -165,7 +165,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 	tokenID := getParamAsUUID(c, consts.ParamTokenID)
 	userID := getRequestUserID(c)
 
-	ot, err := h.Repo.GetTokenByID(tokenID)
+	ot, err := h.Repo.GetTokenByID(context.TODO(), tokenID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -178,7 +178,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 		return herror.NotFound()
 	}
 
-	if err := h.Repo.DeleteTokenByAccess(ot.AccessToken); err != nil {
+	if err := h.Repo.DeleteTokenByAccess(context.TODO(), ot.AccessToken); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/sessions_test.go
+++ b/router/v3/sessions_test.go
@@ -414,7 +414,7 @@ func TestHandlers_RevokeMyToken(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetTokenByID(tok.ID)
+		_, err := env.Repository.GetTokenByID(context.TODO(), tok.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }

--- a/router/v3/sessions_test.go
+++ b/router/v3/sessions_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestHandlers_Login(t *testing.T) {
 
 	path := "/api/v3/login"
 	env := Setup(t, common1)
-	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:        random.AlphaNumeric(20),
 		DisplayName: "po",
 		Role:        role.User,
@@ -71,7 +72,7 @@ func TestHandlers_Login(t *testing.T) {
 		Password:    "testTestTest",
 	})
 	require.NoError(t, err)
-	deactivated, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	deactivated, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:        random.AlphaNumeric(20),
 		DisplayName: "po",
 		Role:        role.User,
@@ -79,11 +80,11 @@ func TestHandlers_Login(t *testing.T) {
 		Password:    "testTestTest",
 	})
 	require.NoError(t, err)
-	err = env.Repository.UpdateUser(deactivated.GetID(), repository.UpdateUserArgs{
+	err = env.Repository.UpdateUser(context.TODO(), deactivated.GetID(), repository.UpdateUserArgs{
 		UserState: optional.From(model.UserAccountStatusDeactivated),
 	})
 	require.NoError(t, err)
-	suspended, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	suspended, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:        random.AlphaNumeric(20),
 		DisplayName: "po",
 		Role:        role.User,
@@ -91,7 +92,7 @@ func TestHandlers_Login(t *testing.T) {
 		Password:    "testTestTest",
 	})
 	require.NoError(t, err)
-	err = env.Repository.UpdateUser(suspended.GetID(), repository.UpdateUserArgs{
+	err = env.Repository.UpdateUser(context.TODO(), suspended.GetID(), repository.UpdateUserArgs{
 		UserState: optional.From(model.UserAccountStatusSuspended),
 	})
 	require.NoError(t, err)
@@ -435,7 +436,7 @@ func TestHandlers_GetMyExternalAccounts(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 			Name:        random.AlphaNumeric(20),
 			DisplayName: "po",
 			Role:        role.User,
@@ -443,7 +444,7 @@ func TestHandlers_GetMyExternalAccounts(t *testing.T) {
 			Password:    "!test_test@test-",
 		})
 		require.NoError(t, err)
-		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+		err = env.Repository.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
 			ProviderName: "traq",
 			ExternalID:   "sappi_red",
 			Extra:        map[string]interface{}{},
@@ -470,7 +471,7 @@ func TestHandlers_GetMyExternalAccounts(t *testing.T) {
 	t.Run("success with external name", func(t *testing.T) {
 		t.Parallel()
 
-		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 			Name:        random.AlphaNumeric(20),
 			DisplayName: "po",
 			Role:        role.User,
@@ -478,7 +479,7 @@ func TestHandlers_GetMyExternalAccounts(t *testing.T) {
 			Password:    "!test_test@test-",
 		})
 		require.NoError(t, err)
-		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+		err = env.Repository.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
 			ProviderName: "traq",
 			ExternalID:   "motoki317",
 			Extra: map[string]interface{}{
@@ -525,7 +526,7 @@ func TestHandlers_LinkExternalAccount(t *testing.T) {
 	t.Run("already linked", func(t *testing.T) {
 		t.Parallel()
 
-		user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+		user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 			Name:        random.AlphaNumeric(20),
 			DisplayName: "po",
 			Role:        role.User,
@@ -533,7 +534,7 @@ func TestHandlers_LinkExternalAccount(t *testing.T) {
 			Password:    "!test_test@test-",
 		})
 		require.NoError(t, err)
-		err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+		err = env.Repository.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
 			ProviderName: "traq",
 			ExternalID:   "takashi_trap",
 			Extra:        map[string]interface{}{},
@@ -577,7 +578,7 @@ func TestHandlers_UnlinkExternalAccount(t *testing.T) {
 	path := "/api/v3/users/me/ex-accounts/unlink"
 	env := Setup(t, common1)
 
-	user, err := env.Repository.CreateUser(repository.CreateUserArgs{
+	user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:        random.AlphaNumeric(20),
 		DisplayName: "po",
 		Role:        role.User,
@@ -585,7 +586,7 @@ func TestHandlers_UnlinkExternalAccount(t *testing.T) {
 		Password:    "!test_test@test-",
 	})
 	require.NoError(t, err)
-	err = env.Repository.LinkExternalUserAccount(user.GetID(), repository.LinkExternalUserAccountArgs{
+	err = env.Repository.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
 		ProviderName: "traq",
 		ExternalID:   "xxpoxx",
 		Extra:        map[string]interface{}{},
@@ -621,7 +622,7 @@ func TestHandlers_UnlinkExternalAccount(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		externals, err := env.Repository.GetLinkedExternalUserAccounts(user.GetID())
+		externals, err := env.Repository.GetLinkedExternalUserAccounts(context.TODO(), user.GetID())
 		require.NoError(t, err)
 		assert.Len(t, externals, 0)
 	})

--- a/router/v3/stamp_palettes.go
+++ b/router/v3/stamp_palettes.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/traPtitech/traQ/router/extension"
@@ -19,7 +20,7 @@ import (
 func (h *Handlers) GetStampPalettes(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	palettes, err := h.Repo.GetStampPalettes(userID)
+	palettes, err := h.Repo.GetStampPalettes(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -56,7 +57,7 @@ func (h *Handlers) CreateStampPalette(c echo.Context) error {
 	}
 
 	// スタンプパレット作成
-	sp, err := h.Repo.CreateStampPalette(req.Name, req.Description, req.Stamps, userID)
+	sp, err := h.Repo.CreateStampPalette(context.TODO(), req.Name, req.Description, req.Stamps, userID)
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -108,7 +109,7 @@ func (h *Handlers) EditStampPalette(c echo.Context) error {
 	}
 
 	// スタンプパレット更新
-	if err := h.Repo.UpdateStampPalette(stampPalette.ID, args); err != nil {
+	if err := h.Repo.UpdateStampPalette(context.TODO(), stampPalette.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -134,7 +135,7 @@ func (h *Handlers) DeleteStampPalette(c echo.Context) error {
 		return herror.Forbidden("you are not permitted to delete stamp-palette created by others")
 	}
 
-	if err := h.Repo.DeleteStampPalette(stampPalette.ID); err != nil {
+	if err := h.Repo.DeleteStampPalette(context.TODO(), stampPalette.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/stamp_palettes_test.go
+++ b/router/v3/stamp_palettes_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -292,7 +293,7 @@ func TestHandlers_EditStampPalette(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		updated, err := env.Repository.GetStampPalette(sp.ID)
+		updated, err := env.Repository.GetStampPalette(context.TODO(), sp.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, sp.ID.String(), updated.ID.String())
 		assert.EqualValues(t, "test", updated.Name)
@@ -386,7 +387,7 @@ func TestHandlers_DeleteStampPalette(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetStampPalette(sp.ID)
+		_, err := env.Repository.GetStampPalette(context.TODO(), sp.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -66,7 +66,7 @@ func (h *Handlers) GetStamps(c echo.Context) error {
 		stampType = repository.StampTypeOriginal
 	}
 
-	stamps, err := h.Repo.GetAllStampsWithThumbnail(stampType)
+	stamps, err := h.Repo.GetAllStampsWithThumbnail(context.TODO(), stampType)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -85,7 +85,7 @@ func (h *Handlers) CreateStamp(c echo.Context) error {
 	}
 
 	// スタンプ作成
-	s, err := h.Repo.CreateStamp(repository.CreateStampArgs{Name: c.FormValue("name"), FileID: fileID, CreatorID: userID})
+	s, err := h.Repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: c.FormValue("name"), FileID: fileID, CreatorID: userID})
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -138,7 +138,7 @@ func (h *Handlers) EditStamp(c echo.Context) error {
 	}
 
 	// 更新
-	if err := h.Repo.UpdateStamp(stamp.ID, args); err != nil {
+	if err := h.Repo.UpdateStamp(context.TODO(), stamp.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -155,7 +155,7 @@ func (h *Handlers) EditStamp(c echo.Context) error {
 func (h *Handlers) DeleteStamp(c echo.Context) error {
 	stampID := getParamAsUUID(c, consts.ParamStampID)
 
-	if err := h.Repo.DeleteStamp(stampID); err != nil {
+	if err := h.Repo.DeleteStamp(context.TODO(), stampID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -203,7 +203,7 @@ func (h *Handlers) ChangeStampImage(c echo.Context) error {
 
 	args := repository.UpdateStampArgs{FileID: optional.From(fileID)}
 	// 更新
-	if err := h.Repo.UpdateStamp(stamp.ID, args); err != nil {
+	if err := h.Repo.UpdateStamp(context.TODO(), stamp.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -217,7 +217,7 @@ func (h *Handlers) ChangeStampImage(c echo.Context) error {
 // GetStampStats GET /stamps/:stampID/stats
 func (h *Handlers) GetStampStats(c echo.Context) error {
 	stampID := getParamAsUUID(c, consts.ParamStampID)
-	stats, err := h.Repo.GetStampStats(stampID)
+	stats, err := h.Repo.GetStampStats(context.TODO(), stampID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/stamps_test.go
+++ b/router/v3/stamps_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -283,7 +284,7 @@ func TestHandlers_EditStamp(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		stamp, err := env.Repository.GetStamp(stamp.ID)
+		stamp, err := env.Repository.GetStamp(context.TODO(), stamp.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, user2.GetID().String(), stamp.CreatorID.String())
 		assert.EqualValues(t, "test123123", stamp.Name)
@@ -347,7 +348,7 @@ func TestHandlers_DeleteStamp(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetStamp(stamp.ID)
+		_, err := env.Repository.GetStamp(context.TODO(), stamp.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }

--- a/router/v3/star.go
+++ b/router/v3/star.go
@@ -20,7 +20,7 @@ import (
 func (h *Handlers) GetMyStars(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	stars, err := h.Repo.GetStaredChannels(userID)
+	stars, err := h.Repo.GetStaredChannels(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -47,7 +47,7 @@ func (h *Handlers) PostStar(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.AddStar(getRequestUserID(c), req.ChannelID); err != nil {
+	if err := h.Repo.AddStar(context.TODO(), getRequestUserID(c), req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -59,7 +59,7 @@ func (h *Handlers) RemoveMyStar(c echo.Context) error {
 	userID := getRequestUserID(c)
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	if err := h.Repo.RemoveStar(userID, channelID); err != nil {
+	if err := h.Repo.RemoveStar(context.TODO(), userID, channelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/star_test.go
+++ b/router/v3/star_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -86,7 +87,7 @@ func TestHandlers_PostStar(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		stars, err := env.Repository.GetStaredChannels(user.GetID())
+		stars, err := env.Repository.GetStaredChannels(context.TODO(), user.GetID())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, stars, []uuid.UUID{ch.ID})
 	})
@@ -130,7 +131,7 @@ func TestHandlers_RemoveMyStar(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		stars, err := env.Repository.GetStaredChannels(user.GetID())
+		stars, err := env.Repository.GetStaredChannels(context.TODO(), user.GetID())
 		require.NoError(t, err)
 		assert.Len(t, stars, 0)
 	})

--- a/router/v3/tags.go
+++ b/router/v3/tags.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -26,7 +27,7 @@ func (h *Handlers) GetMyUserTags(c echo.Context) error {
 
 // serveUserTags 指定したユーザーのタグ一覧をレスポンスとして返す
 func serveUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) error {
-	tags, err := repo.GetUserTagsByUserID(userID)
+	tags, err := repo.GetUserTagsByUserID(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -65,13 +66,13 @@ func addUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) e
 	}
 
 	// タグの確認
-	t, err := repo.GetOrCreateTag(req.Tag)
+	t, err := repo.GetOrCreateTag(context.TODO(), req.Tag)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
 	// ユーザーにタグを付与
-	if err := repo.AddUserTag(userID, t.ID); err != nil {
+	if err := repo.AddUserTag(context.TODO(), userID, t.ID); err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
 			return c.NoContent(http.StatusConflict)
@@ -80,7 +81,7 @@ func addUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) e
 		}
 	}
 
-	ut, err := repo.GetUserTag(userID, t.ID)
+	ut, err := repo.GetUserTag(context.TODO(), userID, t.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -111,7 +112,7 @@ func (h *Handlers) EditUserTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// 更新
-	if err := h.Repo.ChangeUserTagLock(userID, tagID, req.IsLocked); err != nil {
+	if err := h.Repo.ChangeUserTagLock(context.TODO(), userID, tagID, req.IsLocked); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.NotFound()
@@ -134,7 +135,7 @@ func (h *Handlers) EditMyUserTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// 更新
-	if err := h.Repo.ChangeUserTagLock(userID, tagID, req.IsLocked); err != nil {
+	if err := h.Repo.ChangeUserTagLock(context.TODO(), userID, tagID, req.IsLocked); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.NotFound()
@@ -161,7 +162,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// タグがつけられているかを見る
-	ut, err := repo.GetUserTag(userID, tagID)
+	ut, err := repo.GetUserTag(context.TODO(), userID, tagID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound: // 既にない
@@ -176,7 +177,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 	}
 
 	// 削除
-	if err := repo.DeleteUserTag(userID, ut.GetTagID()); err != nil {
+	if err := repo.DeleteUserTag(context.TODO(), userID, ut.GetTagID()); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -187,7 +188,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 func (h *Handlers) GetTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
-	t, err := h.Repo.GetTagByID(tagID)
+	t, err := h.Repo.GetTagByID(context.TODO(), tagID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -197,7 +198,7 @@ func (h *Handlers) GetTag(c echo.Context) error {
 		}
 	}
 
-	users, err := h.Repo.GetUserIDsByTagID(t.ID)
+	users, err := h.Repo.GetUserIDsByTagID(context.TODO(), t.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/tags_test.go
+++ b/router/v3/tags_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -372,7 +373,7 @@ func TestHandlers_EditUserTag(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ut, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		ut, err := env.Repository.GetUserTag(context.TODO(), user.GetID(), ut.GetTagID())
 		require.NoError(t, err)
 		assert.True(t, ut.GetIsLocked())
 	})
@@ -427,7 +428,7 @@ func TestHandlers_EditMyUserTag(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ut, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		ut, err := env.Repository.GetUserTag(context.TODO(), user.GetID(), ut.GetTagID())
 		require.NoError(t, err)
 		assert.True(t, ut.GetIsLocked())
 	})
@@ -444,7 +445,7 @@ func TestHandlers_RemoveUserTag(t *testing.T) {
 	ut := env.AddTag(t, "test", user2.GetID())
 	ut2 := env.AddTag(t, "test2", user2.GetID())
 	locked := env.AddTag(t, "test3", user2.GetID())
-	require.NoError(t, env.Repository.ChangeUserTagLock(user2.GetID(), locked.GetTagID(), true))
+	require.NoError(t, env.Repository.ChangeUserTagLock(context.TODO(), user2.GetID(), locked.GetTagID(), true))
 
 	s := env.S(t, user.GetID())
 
@@ -473,7 +474,7 @@ func TestHandlers_RemoveUserTag(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetUserTag(user2.GetID(), ut.GetTagID())
+		_, err := env.Repository.GetUserTag(context.TODO(), user2.GetID(), ut.GetTagID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 
 		// already removed
@@ -494,7 +495,7 @@ func TestHandlers_RemoveMyUserTag(t *testing.T) {
 	ut := env.AddTag(t, "test", user.GetID())
 	ut2 := env.AddTag(t, "test2", user.GetID())
 	locked := env.AddTag(t, "test3", user.GetID())
-	require.NoError(t, env.Repository.ChangeUserTagLock(user.GetID(), locked.GetTagID(), true))
+	require.NoError(t, env.Repository.ChangeUserTagLock(context.TODO(), user.GetID(), locked.GetTagID(), true))
 
 	s := env.S(t, user.GetID())
 
@@ -523,7 +524,7 @@ func TestHandlers_RemoveMyUserTag(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetUserTag(user.GetID(), ut.GetTagID())
+		_, err := env.Repository.GetUserTag(context.TODO(), user.GetID(), ut.GetTagID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 
 		// already removed

--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -25,7 +25,7 @@ import (
 
 // GetUserGroups GET /groups
 func (h *Handlers) GetUserGroups(c echo.Context) error {
-	gs, err := h.Repo.GetAllUserGroups()
+	gs, err := h.Repo.GetAllUserGroups(context.TODO())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -66,7 +66,7 @@ func (h *Handlers) PostUserGroups(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	g, err := h.Repo.CreateUserGroup(req.Name, req.Description, req.Type, reqUserID, iconFileID)
+	g, err := h.Repo.CreateUserGroup(context.TODO(), req.Name, req.Description, req.Type, reqUserID, iconFileID)
 	if err != nil {
 		if err == repository.ErrAlreadyExists {
 			return herror.Conflict("group with the name already exists")
@@ -116,7 +116,7 @@ func (h *Handlers) EditUserGroup(c echo.Context) error {
 		Description: req.Description,
 		Type:        req.Type,
 	}
-	if err := h.Repo.UpdateUserGroup(g.ID, args); err != nil {
+	if err := h.Repo.UpdateUserGroup(context.TODO(), g.ID, args); err != nil {
 		if err == repository.ErrAlreadyExists {
 			return herror.Conflict("group with the name already exists")
 		}
@@ -135,7 +135,7 @@ func (h *Handlers) PutUserGroupIcon(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateUserGroup(g.ID, repository.UpdateUserGroupArgs{Icon: optional.From(fileID)}); err != nil {
+	if err := h.Repo.UpdateUserGroup(context.TODO(), g.ID, repository.UpdateUserGroupArgs{Icon: optional.From(fileID)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -146,7 +146,7 @@ func (h *Handlers) PutUserGroupIcon(c echo.Context) error {
 func (h *Handlers) DeleteUserGroup(c echo.Context) error {
 	g := getParamGroup(c)
 
-	if err := h.Repo.DeleteUserGroup(g.ID); err != nil {
+	if err := h.Repo.DeleteUserGroup(context.TODO(), g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -182,7 +182,7 @@ func (h *Handlers) AddUserGroupMember(c echo.Context) error {
 	var singleReq PostUserGroupMemberRequest
 	c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	if err := bindAndValidate(c, &singleReq); err == nil {
-		if err := h.Repo.AddUserToGroup(singleReq.ID, g.ID, singleReq.Role); err != nil {
+		if err := h.Repo.AddUserToGroup(context.TODO(), singleReq.ID, g.ID, singleReq.Role); err != nil {
 			return herror.InternalServerError(err)
 		}
 		return c.NoContent(http.StatusNoContent)
@@ -199,7 +199,7 @@ func (h *Handlers) AddUserGroupMember(c echo.Context) error {
 	for i, req := range reqs {
 		users[i] = model.UserGroupMember{UserID: req.ID, Role: req.Role, GroupID: g.ID}
 	}
-	if err := h.Repo.AddUsersToGroup(users, g.ID); err != nil {
+	if err := h.Repo.AddUsersToGroup(context.TODO(), users, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -231,7 +231,7 @@ func (h *Handlers) EditUserGroupMember(c echo.Context) error {
 		return herror.BadRequest("this user is not this group's member")
 	}
 
-	if err := h.Repo.AddUserToGroup(uid, g.ID, req.Role); err != nil {
+	if err := h.Repo.AddUserToGroup(context.TODO(), uid, g.ID, req.Role); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -242,7 +242,7 @@ func (h *Handlers) EditUserGroupMember(c echo.Context) error {
 func (h *Handlers) RemoveUserGroupMember(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
 	g := getParamGroup(c)
-	if err := h.Repo.RemoveUserFromGroup(userID, g.ID); err != nil {
+	if err := h.Repo.RemoveUserFromGroup(context.TODO(), userID, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -252,7 +252,7 @@ func (h *Handlers) RemoveUserGroupMember(c echo.Context) error {
 // RemoveUserGroupMembers DELETE /groups/:groupID/members
 func (h *Handlers) RemoveUserGroupMembers(c echo.Context) error {
 	g := getParamGroup(c)
-	if err := h.Repo.RemoveUsersFromGroup(g.ID); err != nil {
+	if err := h.Repo.RemoveUsersFromGroup(context.TODO(), g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -283,7 +283,7 @@ func (h *Handlers) AddUserGroupAdmin(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.AddUserToGroupAdmin(req.ID, g.ID); err != nil {
+	if err := h.Repo.AddUserToGroupAdmin(context.TODO(), req.ID, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -295,7 +295,7 @@ func (h *Handlers) RemoveUserGroupAdmin(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
 	g := getParamGroup(c)
 
-	if err := h.Repo.RemoveUserFromGroupAdmin(userID, g.ID); err != nil {
+	if err := h.Repo.RemoveUserFromGroupAdmin(context.TODO(), userID, g.ID); err != nil {
 		if err == repository.ErrForbidden {
 			return herror.BadRequest()
 		}

--- a/router/v3/user_groups_test.go
+++ b/router/v3/user_groups_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -51,7 +52,7 @@ func TestHandlers_GetUserGroups(t *testing.T) {
 
 	ug := env.CreateUserGroup(t, "SysAd", "po", "", user.GetID())
 	env.AddUserToUserGroup(t, user2.GetID(), ug.ID, "")
-	ug, err := env.Repository.GetUserGroup(ug.ID)
+	ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 	require.NoError(t, err)
 
 	s := env.S(t, user.GetID())
@@ -249,7 +250,7 @@ func TestHandlers_GetUserGroup(t *testing.T) {
 
 	ug := env.CreateUserGroup(t, rand, "po", "", user.GetID())
 	env.AddUserToUserGroup(t, user2.GetID(), ug.ID, "")
-	ug, err := env.Repository.GetUserGroup(ug.ID)
+	ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 	require.NoError(t, err)
 
 	s := env.S(t, user.GetID())
@@ -419,7 +420,7 @@ func TestHandlers_EditUserGroup(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, "testGroup456", ug.Name)
 	})
@@ -472,7 +473,7 @@ func TestHandlers_DeleteUserGroup(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetUserGroup(ug.ID)
+		_, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }
@@ -585,7 +586,7 @@ func TestHandlers_AddUserGroupMember(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		if assert.Len(t, ug.Members, 1) {
 			m := ug.Members[0]
@@ -656,7 +657,7 @@ func TestHandlers_AddUsersGroupMember(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		if assert.Len(t, ug.Members, 2) {
 			m := ug.Members[0]
@@ -782,7 +783,7 @@ func TestHandlers_EditUserGroupMember(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		if assert.Len(t, ug.Members, 1) {
 			m := ug.Members[0]
@@ -850,7 +851,7 @@ func TestHandlers_RemoveUserGroupMember(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		assert.Len(t, ug.Members, 0)
 
@@ -920,7 +921,7 @@ func TestHandlers_RemoveUserGroupMembers(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		assert.Len(t, ug.Members, 0)
 
@@ -1050,7 +1051,7 @@ func TestHandlers_AddUserGroupAdmin(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 
 		admins := make([]uuid.UUID, len(ug.Admins))
@@ -1073,8 +1074,8 @@ func TestHandlers_RemoveUserGroupAdmin(t *testing.T) {
 	ug := env.CreateUserGroup(t, rand, "", "", user.GetID())
 	ug2 := env.CreateUserGroup(t, rand, "", "", user.GetID())
 	ug3 := env.CreateUserGroup(t, rand, "", "", user2.GetID())
-	require.NoError(t, env.Repository.AddUserToGroupAdmin(user3.GetID(), ug.ID))
-	require.NoError(t, env.Repository.AddUserToGroupAdmin(user3.GetID(), ug3.ID))
+	require.NoError(t, env.Repository.AddUserToGroupAdmin(context.TODO(), user3.GetID(), ug.ID))
+	require.NoError(t, env.Repository.AddUserToGroupAdmin(context.TODO(), user3.GetID(), ug3.ID))
 
 	s := env.S(t, user.GetID())
 
@@ -1112,7 +1113,7 @@ func TestHandlers_RemoveUserGroupAdmin(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ug, err := env.Repository.GetUserGroup(ug.ID)
+		ug, err := env.Repository.GetUserGroup(context.TODO(), ug.ID)
 		require.NoError(t, err)
 		if assert.Len(t, ug.Admins, 1) {
 			admin := ug.Admins[0]

--- a/router/v3/user_settings.go
+++ b/router/v3/user_settings.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -22,7 +23,7 @@ func (h *Handlers) PutMyNotifyCitation(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateNotifyCitation(id, us.NotifyCitation); err != nil {
+	if err := h.Repo.UpdateNotifyCitation(context.TODO(), id, us.NotifyCitation); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -33,7 +34,7 @@ func (h *Handlers) PutMyNotifyCitation(c echo.Context) error {
 func (h *Handlers) GetMySettings(c echo.Context) error {
 	id := getRequestUserID(c)
 
-	us, err := h.Repo.GetUserSettings(id)
+	us, err := h.Repo.GetUserSettings(context.TODO(), id)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -45,7 +46,7 @@ func (h *Handlers) GetMySettings(c echo.Context) error {
 func (h *Handlers) GetMyNotifyCitation(c echo.Context) error {
 	id := getRequestUserID(c)
 
-	nc, err := h.Repo.GetNotifyCitation(id)
+	nc, err := h.Repo.GetNotifyCitation(context.TODO(), id)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/user_settings_test.go
+++ b/router/v3/user_settings_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestHandlers_PutMyNotifyCitation(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		nc, err := env.Repository.GetNotifyCitation(user.GetID())
+		nc, err := env.Repository.GetNotifyCitation(context.TODO(), user.GetID())
 		require.NoError(t, err)
 		assert.True(t, nc)
 	})

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -91,7 +91,7 @@ func (h *Handlers) CreateUser(c echo.Context) error {
 func (h *Handlers) GetMe(c echo.Context) error {
 	me := getRequestUser(c)
 
-	tags, err := h.Repo.GetUserTagsByUserID(me.GetID())
+	tags, err := h.Repo.GetUserTagsByUserID(context.TODO(), me.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -379,7 +379,7 @@ func (h *Handlers) ChangeUserPassword(c echo.Context) error {
 func (h *Handlers) GetUser(c echo.Context) error {
 	user := getParamUser(c)
 
-	tags, err := h.Repo.GetUserTagsByUserID(user.GetID())
+	tags, err := h.Repo.GetUserTagsByUserID(context.TODO(), user.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -450,7 +450,7 @@ func (h *Handlers) EditUser(c echo.Context) error {
 
 // GetMyChannelSubscriptions GET /users/me/subscriptions
 func (h *Handlers) GetMyChannelSubscriptions(c echo.Context) error {
-	subscriptions, err := h.Repo.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{}.SetUser(getRequestUserID(c)))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetUser(getRequestUserID(c)))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -42,7 +42,7 @@ func (h *Handlers) GetUsers(c echo.Context) error {
 		q = q.Active()
 	}
 
-	users, err := h.Repo.GetUsers(q)
+	users, err := h.Repo.GetUsers(context.TODO(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -74,7 +74,7 @@ func (h *Handlers) CreateUser(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	user, err := h.Repo.CreateUser(repository.CreateUserArgs{Name: req.Name, Password: req.Password.ValueOrZero(), Role: role.User, IconFileID: iconFileID})
+	user, err := h.Repo.CreateUser(context.TODO(), repository.CreateUserArgs{Name: req.Name, Password: req.Password.ValueOrZero(), Role: role.User, IconFileID: iconFileID})
 	if err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
@@ -176,7 +176,7 @@ func (h *Handlers) EditMe(c echo.Context) error {
 		Bio:         req.Bio,
 		HomeChannel: req.HomeChannel,
 	}
-	if err := h.Repo.UpdateUser(userID, args); err != nil {
+	if err := h.Repo.UpdateUser(context.TODO(), userID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -429,7 +429,7 @@ func (h *Handlers) EditUser(c echo.Context) error {
 		deactivate = req.State.V == model.UserAccountStatusDeactivated.Int()
 	}
 
-	if err := h.Repo.UpdateUser(userID, args); err != nil {
+	if err := h.Repo.UpdateUser(context.TODO(), userID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 	// 凍結の際
@@ -512,7 +512,7 @@ func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
 // GetUserStats GET /users/me/:userID/stats
 func (h *Handlers) GetUserStats(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
-	stats, err := h.Repo.GetUserStats(userID)
+	stats, err := h.Repo.GetUserStats(context.TODO(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -286,7 +286,7 @@ func (h *Handlers) GetMyStampHistory(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	history, err := h.Repo.GetUserStampHistory(userID, req.Limit)
+	history, err := h.Repo.GetUserStampHistory(context.TODO(), userID, req.Limit)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -316,7 +316,7 @@ func (h *Handlers) GetMyStampRecommendations(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	recommendations, err := h.Repo.GetUserStampRecommendations(userID, *req.Limit)
+	recommendations, err := h.Repo.GetUserStampRecommendations(context.TODO(), userID, *req.Limit)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -343,7 +343,7 @@ func (h *Handlers) PostMyFCMDevice(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	if err := h.Repo.RegisterDevice(userID, req.Token); err != nil {
+	if err := h.Repo.RegisterDevice(context.TODO(), userID, req.Token); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -96,7 +96,7 @@ func (h *Handlers) GetMe(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	groups, err := h.Repo.GetUserBelongingGroupIDs(me.GetID())
+	groups, err := h.Repo.GetUserBelongingGroupIDs(context.TODO(), me.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -384,7 +384,7 @@ func (h *Handlers) GetUser(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	groups, err := h.Repo.GetUserBelongingGroupIDs(user.GetID())
+	groups, err := h.Repo.GetUserBelongingGroupIDs(context.TODO(), user.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -1155,7 +1155,7 @@ func TestHandlers_SetChannelSubscribeLevel(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		subs, err := env.Repository.GetChannelSubscriptions(repository.ChannelSubscriptionQuery{ChannelID: optional.From(ch.ID)})
+		subs, err := env.Repository.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{ChannelID: optional.From(ch.ID)})
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
 			sub := subs[0]

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -728,7 +729,7 @@ func TestHandlers_PostMyFCMDevice(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		tokens, err := env.Repository.GetDeviceTokens(set.UUID{user.GetID(): {}})
+		tokens, err := env.Repository.GetDeviceTokens(context.TODO(), set.UUID{user.GetID(): {}})
 		require.NoError(t, err)
 		if assert.Len(t, tokens, 1) {
 			assert.ElementsMatch(t, tokens[user.GetID()], []string{"dummy:token"})

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -42,11 +42,11 @@ func TestHandlers_GetUsers(t *testing.T) {
 	user2 := env.CreateUser(t, "sappi_red")
 	deactivated := env.CreateUser(t, "deactivated")
 	suspended := env.CreateUser(t, "suspended")
-	err := env.Repository.UpdateUser(deactivated.GetID(), repository.UpdateUserArgs{
+	err := env.Repository.UpdateUser(context.TODO(), deactivated.GetID(), repository.UpdateUserArgs{
 		UserState: optional.From(model.UserAccountStatusDeactivated),
 	})
 	require.NoError(t, err)
-	err = env.Repository.UpdateUser(suspended.GetID(), repository.UpdateUserArgs{
+	err = env.Repository.UpdateUser(context.TODO(), suspended.GetID(), repository.UpdateUserArgs{
 		UserState: optional.From(model.UserAccountStatusSuspended),
 	})
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestHandlers_EditMe(t *testing.T) {
 				Expect().
 				Status(http.StatusNoContent)
 
-			profile, err := env.Repository.GetUser(user.GetID(), true)
+			profile, err := env.Repository.GetUser(context.TODO(), user.GetID(), true)
 			require.NoError(t, err)
 			assert.EqualValues(t, strings.Repeat("a", 32), profile.GetDisplayName())
 		})
@@ -350,7 +350,7 @@ func TestHandlers_EditMe(t *testing.T) {
 				Expect().
 				Status(http.StatusNoContent)
 
-			profile, err := env.Repository.GetUser(user.GetID(), true)
+			profile, err := env.Repository.GetUser(context.TODO(), user.GetID(), true)
 			require.NoError(t, err)
 			assert.EqualValues(t, "po", profile.GetDisplayName())
 			if assert.True(t, profile.GetHomeChannel().Valid) {
@@ -478,7 +478,7 @@ func TestHandlers_PutMyPassword(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		u, err := env.Repository.GetUser(user.GetID(), false)
+		u, err := env.Repository.GetUser(context.TODO(), user.GetID(), false)
 		require.NoError(t, err)
 		assert.NoError(t, u.Authenticate(newPass))
 	})
@@ -986,7 +986,7 @@ func TestHandlers_EditUser(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		profile, err := env.Repository.GetUser(user2.GetID(), true)
+		profile, err := env.Repository.GetUser(context.TODO(), user2.GetID(), true)
 		require.NoError(t, err)
 		assert.EqualValues(t, model.UserAccountStatusDeactivated, profile.GetState())
 	})
@@ -1000,7 +1000,7 @@ func TestHandlers_EditUser(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		profile, err := env.Repository.GetUser(user.GetID(), true)
+		profile, err := env.Repository.GetUser(context.TODO(), user.GetID(), true)
 		require.NoError(t, err)
 		assert.EqualValues(t, "po", profile.GetDisplayName())
 	})

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -35,9 +35,9 @@ func (h *Handlers) GetWebhooks(c echo.Context) error {
 		err  error
 	)
 	if isTrue(c.QueryParam("all")) && h.RBAC.IsGranted(user.GetRole(), permission.AccessOthersWebhook) {
-		list, err = h.Repo.GetAllWebhooks()
+		list, err = h.Repo.GetAllWebhooks(context.TODO())
 	} else {
-		list, err = h.Repo.GetWebhooksByCreator(user.GetID())
+		list, err = h.Repo.GetWebhooksByCreator(context.TODO(), user.GetID())
 	}
 	if err != nil {
 		return herror.InternalServerError(err)
@@ -95,7 +95,7 @@ func (h *Handlers) CreateWebhook(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	w, err := h.Repo.CreateWebhook(req.Name, req.Description, req.ChannelID, iconFileID, userID, req.Secret)
+	w, err := h.Repo.CreateWebhook(context.TODO(), req.Name, req.Description, req.ChannelID, iconFileID, userID, req.Secret)
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -149,7 +149,7 @@ func (h *Handlers) EditWebhook(c echo.Context) error {
 		Secret:      req.Secret,
 		CreatorID:   req.OwnerID,
 	}
-	if err := h.Repo.UpdateWebhook(w.GetID(), args); err != nil {
+	if err := h.Repo.UpdateWebhook(context.TODO(), w.GetID(), args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -228,7 +228,7 @@ func (h *Handlers) PostWebhook(c echo.Context) error {
 func (h *Handlers) DeleteWebhook(c echo.Context) error {
 	w := getParamWebhook(c)
 
-	if err := h.Repo.DeleteWebhook(w.GetID()); err != nil {
+	if err := h.Repo.DeleteWebhook(context.TODO(), w.GetID()); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -256,7 +256,7 @@ func (h *Handlers) DeleteWebhookMessage(c echo.Context) error {
 	messageUserID := m.GetUserID()
 
 	if botUserID == messageUserID {
-		if err := h.Repo.DeleteMessage(messageID); err != nil {
+		if err := h.Repo.DeleteMessage(context.TODO(), messageID); err != nil {
 			return herror.InternalServerError(err)
 		}
 	} else {

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -51,7 +51,7 @@ func (h *Handlers) GetWebhookIcon(c echo.Context) error {
 	w := getParamWebhook(c)
 
 	// ユーザー取得
-	user, err := h.Repo.GetUser(w.GetBotUserID(), false)
+	user, err := h.Repo.GetUser(context.TODO(), w.GetBotUserID(), false)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/webhooks_test.go
+++ b/router/v3/webhooks_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -120,7 +121,7 @@ func TestHandlers_GetWebhookIcon(t *testing.T) {
 
 	file, err := file2.GenerateIconFile(env.FM, "wh")
 	require.NoError(t, err)
-	wh, err := env.Repository.CreateWebhook(random2.AlphaNumeric(20), "", ch.ID, file, user.GetID(), "")
+	wh, err := env.Repository.CreateWebhook(context.TODO(), random2.AlphaNumeric(20), "", ch.ID, file, user.GetID(), "")
 	require.NoError(t, err)
 
 	s := env.S(t, user.GetID())
@@ -299,7 +300,7 @@ func TestHandlers_EditWebhook(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		wh, err := env.Repository.GetWebhook(wh.GetID())
+		wh, err := env.Repository.GetWebhook(context.TODO(), wh.GetID())
 		require.NoError(t, err)
 		assert.EqualValues(t, "po", wh.GetName())
 	})
@@ -484,7 +485,7 @@ func TestHandlers_DeleteWebhook(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetWebhook(wh.GetID())
+		_, err := env.Repository.GetWebhook(context.TODO(), wh.GetID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }

--- a/router/v3/webhooks_test.go
+++ b/router/v3/webhooks_test.go
@@ -597,7 +597,7 @@ func TestHandlers_DeleteWebhookMessage(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.Repository.GetMessageByID(message.GetID())
+		_, err := env.Repository.GetMessageByID(context.TODO(), message.GetID())
 		assert.ErrorIs(t, err, repository.ErrNotFound)
 	})
 }

--- a/service/bot/event/dispatcher_impl.go
+++ b/service/bot/event/dispatcher_impl.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -57,7 +59,7 @@ func (d *dispatcherImpl) Send(b *model.Bot, event model.BotEventType, body []byt
 }
 
 func (d *dispatcherImpl) writeLog(log *model.BotEventLog) {
-	if err := d.repo.WriteBotEventLog(log); err != nil {
+	if err := d.repo.WriteBotEventLog(context.TODO(), log); err != nil {
 		d.l.Warn("failed to write log", zap.Error(err), zap.Any("eventLog", log))
 	}
 }

--- a/service/bot/handler/ev_bot_joined.go
+++ b/service/bot/handler/ev_bot_joined.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,7 @@ func BotJoined(ctx Context, datetime time.Time, _ string, fields hub.Fields) err
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
-	user, err := ctx.R().GetUser(ch.CreatorID, false)
+	user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_bot_left.go
+++ b/service/bot/handler/ev_bot_left.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,7 @@ func BotLeft(ctx Context, datetime time.Time, _ string, fields hub.Fields) error
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
-	user, err := ctx.R().GetUser(ch.CreatorID, false)
+	user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_bot_ping_request.go
+++ b/service/bot/handler/ev_bot_ping_request.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -22,12 +23,12 @@ func BotPingRequest(ctx Context, datetime time.Time, _ string, fields hub.Fields
 
 	if ctx.D().Send(bot, event.Ping, buf) {
 		// OK
-		if err := ctx.R().ChangeBotState(bot.ID, model.BotActive); err != nil {
+		if err := ctx.R().ChangeBotState(context.TODO(), bot.ID, model.BotActive); err != nil {
 			return fmt.Errorf("failed to ChangeBotState: %w", err)
 		}
 	} else {
 		// NG
-		if err := ctx.R().ChangeBotState(bot.ID, model.BotPaused); err != nil {
+		if err := ctx.R().ChangeBotState(context.TODO(), bot.ID, model.BotPaused); err != nil {
 			return fmt.Errorf("failed to ChangeBotState: %w", err)
 		}
 	}

--- a/service/bot/handler/ev_bot_ping_request_test.go
+++ b/service/bot/handler/ev_bot_ping_request_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -40,7 +41,7 @@ func TestBotPingRequest(t *testing.T) {
 		buf, err := jsonIter.ConfigFastest.Marshal(payload.MakePing(et))
 		require.NoError(t, err)
 
-		repo.MockBotRepository.EXPECT().ChangeBotState(b.ID, model.BotActive).Return(nil).Times(1)
+		repo.MockBotRepository.EXPECT().ChangeBotState(context.TODO(), b.ID, model.BotActive).Return(nil).Times(1)
 		d.EXPECT().Send(b, event.Ping, buf).Return(true).Times(1)
 
 		assert.NoError(t, BotPingRequest(handlerCtx, et, intevent.BotPingRequest, hub.Fields{
@@ -60,7 +61,7 @@ func TestBotPingRequest(t *testing.T) {
 		buf, err := jsonIter.ConfigFastest.Marshal(payload.MakePing(et))
 		require.NoError(t, err)
 
-		repo.MockBotRepository.EXPECT().ChangeBotState(b.ID, model.BotPaused).Return(nil).Times(1)
+		repo.MockBotRepository.EXPECT().ChangeBotState(context.TODO(), b.ID, model.BotPaused).Return(nil).Times(1)
 		d.EXPECT().Send(b, event.Ping, buf).Return(false).Times(1)
 
 		assert.NoError(t, BotPingRequest(handlerCtx, et, intevent.BotPingRequest, hub.Fields{

--- a/service/bot/handler/ev_channel_created.go
+++ b/service/bot/handler/ev_channel_created.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -22,7 +23,7 @@ func ChannelCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 			return nil
 		}
 
-		user, err := ctx.R().GetUser(ch.CreatorID, false)
+		user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
 		if err != nil {
 			return fmt.Errorf("failed to GetUser: %w", err)
 		}

--- a/service/bot/handler/ev_channel_topic_updated.go
+++ b/service/bot/handler/ev_channel_topic_updated.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -30,12 +31,12 @@ func ChannelTopicUpdated(ctx Context, datetime time.Time, _ string, fields hub.F
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	chCreator, err := ctx.R().GetUser(ch.CreatorID, false)
+	chCreator, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(updaterID, false)
+	user, err := ctx.R().GetUser(context.TODO(), updaterID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_message_created.go
+++ b/service/bot/handler/ev_message_created.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,7 +24,7 @@ func MessageCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(m.UserID, false)
+	user, err := ctx.R().GetUser(context.TODO(), m.UserID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_message_updated.go
+++ b/service/bot/handler/ev_message_updated.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -22,7 +23,7 @@ func MessageUpdated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(m.UserID, false)
+	user, err := ctx.R().GetUser(context.TODO(), m.UserID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_stamp_created.go
+++ b/service/bot/handler/ev_stamp_created.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -24,7 +25,7 @@ func StampCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields) 
 
 	var user model.UserInfo
 	if !stamp.IsSystemStamp() {
-		user, err = ctx.R().GetUser(stamp.CreatorID, false)
+		user, err = ctx.R().GetUser(context.TODO(), stamp.CreatorID, false)
 		if err != nil {
 			return fmt.Errorf("failed to GetUser: %w", err)
 		}

--- a/service/bot/handler/ev_user_group_admin_added.go
+++ b/service/bot/handler/ev_user_group_admin_added.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/gofrs/uuid"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/leandro-lugaresi/hub"
 

--- a/service/bot/handler/ev_user_group_admin_removed.go
+++ b/service/bot/handler/ev_user_group_admin_removed.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/gofrs/uuid"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/leandro-lugaresi/hub"
 

--- a/service/bot/handler/ev_user_group_member_added.go
+++ b/service/bot/handler/ev_user_group_member_added.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/gofrs/uuid"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/leandro-lugaresi/hub"
 

--- a/service/bot/handler/ev_user_group_member_removed.go
+++ b/service/bot/handler/ev_user_group_member_removed.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/gofrs/uuid"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/leandro-lugaresi/hub"
 

--- a/service/bot/handler/ev_user_group_member_updated.go
+++ b/service/bot/handler/ev_user_group_member_updated.go
@@ -2,8 +2,9 @@ package handler
 
 import (
 	"fmt"
-	"github.com/gofrs/uuid"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/leandro-lugaresi/hub"
 

--- a/service/bot/handler/ev_user_tag_added.go
+++ b/service/bot/handler/ev_user_tag_added.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,7 +24,7 @@ func UserTagAdded(ctx Context, datetime time.Time, _ string, fields hub.Fields) 
 		return nil
 	}
 
-	t, err := ctx.R().GetTagByID(tagID)
+	t, err := ctx.R().GetTagByID(context.TODO(), tagID)
 	if err != nil {
 		return fmt.Errorf("failed to GetTagByID: %w", err)
 	}

--- a/service/bot/handler/ev_user_tag_removed.go
+++ b/service/bot/handler/ev_user_tag_removed.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,7 +24,7 @@ func UserTagRemoved(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return nil
 	}
 
-	t, err := ctx.R().GetTagByID(tagID)
+	t, err := ctx.R().GetTagByID(context.TODO(), tagID)
 	if err != nil {
 		return fmt.Errorf("failed to GetTagByID: %w", err)
 	}

--- a/service/bot/handler/handler_test.go
+++ b/service/bot/handler/handler_test.go
@@ -81,7 +81,7 @@ func registerChannel(cm *mock_channel.MockManager, ch *model.Channel) {
 
 func registerTag(repo *Repo, t *model.Tag) {
 	repo.MockTagRepository.EXPECT().
-		GetTagByID(t.ID).
+		GetTagByID(context.TODO(), t.ID).
 		Return(t, nil).
 		AnyTimes()
 }

--- a/service/bot/handler/handler_test.go
+++ b/service/bot/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -66,7 +67,7 @@ func registerBot(_ *testing.T, handlerCtx *mock_handler.MockContext, b *model.Bo
 
 func registerUser(repo *Repo, u *model.User) {
 	repo.MockUserRepository.EXPECT().
-		GetUser(u.ID, gomock.Any()).
+		GetUser(context.TODO(), u.ID, gomock.Any()).
 		Return(u, nil).
 		AnyTimes()
 }

--- a/service/bot/service_impl.go
+++ b/service/bot/service_impl.go
@@ -91,7 +91,7 @@ func (p *serviceImpl) start() {
 				if !ok {
 					return
 				}
-				if err := p.repo.PurgeBotEventLogs(time.Now().Add(-botEventLogPurgeBefore)); err != nil {
+				if err := p.repo.PurgeBotEventLogs(context.TODO(), time.Now().Add(-botEventLogPurgeBefore)); err != nil {
 					p.logger.Error("an error occurred while purging old bot event logs", zap.Error(err))
 				}
 			case <-p.serviceDone:
@@ -137,7 +137,7 @@ func (p *serviceImpl) Multicast(ev model.BotEventType, payload interface{}, targ
 }
 
 func (p *serviceImpl) GetBot(id uuid.UUID) (*model.Bot, error) {
-	bots, err := p.repo.GetBots(repository.BotsQuery{}.Active().BotID(id))
+	bots, err := p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().BotID(id))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (p *serviceImpl) GetBot(id uuid.UUID) (*model.Bot, error) {
 }
 
 func (p *serviceImpl) GetBotByBotUserID(uid uuid.UUID) (*model.Bot, error) {
-	bots, err := p.repo.GetBots(repository.BotsQuery{}.Active().BotUserID(uid))
+	bots, err := p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().BotUserID(uid))
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +159,9 @@ func (p *serviceImpl) GetBotByBotUserID(uid uuid.UUID) (*model.Bot, error) {
 }
 
 func (p *serviceImpl) GetBots(event model.BotEventType) ([]*model.Bot, error) {
-	return p.repo.GetBots(repository.BotsQuery{}.Active().Subscribe(event))
+	return p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().Subscribe(event))
 }
 
 func (p *serviceImpl) GetChannelBots(cid uuid.UUID, event model.BotEventType) ([]*model.Bot, error) {
-	return p.repo.GetBots(repository.BotsQuery{}.Active().Subscribe(event).CMemberOf(cid))
+	return p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().Subscribe(event).CMemberOf(cid))
 }

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -31,7 +32,7 @@ type managerImpl struct {
 }
 
 func InitChannelManager(repo repository.ChannelRepository, logger *zap.Logger) (Manager, error) {
-	channels, err := repo.GetPublicChannels()
+	channels, err := repo.GetPublicChannels(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to init channel.Manager: %w", err)
 	}
@@ -55,7 +56,7 @@ func (m *managerImpl) GetChannel(id uuid.UUID) (*model.Channel, error) {
 		return ch, nil
 	}
 
-	ch, err = m.R.GetChannel(id)
+	ch, err = m.R.GetChannel(context.TODO(), id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil, ErrChannelNotFound
@@ -108,7 +109,7 @@ func (m *managerImpl) CreatePublicChannel(name string, parent, creatorID uuid.UU
 	}
 
 	// チャンネル作成
-	ch, err := m.R.CreateChannel(model.Channel{
+	ch, err := m.R.CreateChannel(context.TODO(), model.Channel{
 		Name:      name,
 		ParentID:  parent,
 		CreatorID: creatorID,
@@ -235,7 +236,7 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 		}
 	}
 
-	ch, err = m.R.UpdateChannel(id, args)
+	ch, err = m.R.UpdateChannel(context.TODO(), id, args)
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -284,7 +285,7 @@ func (m *managerImpl) ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
 		queue = append(queue, m.T.getChildrenIDs(id)...)
 	}
 
-	chs, err := m.R.ArchiveChannels(targets)
+	chs, err := m.R.ArchiveChannels(context.TODO(), targets)
 	if err != nil {
 		return fmt.Errorf("failed to ArchiveChannels: %w", err)
 	}
@@ -317,7 +318,7 @@ func (m *managerImpl) UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error 
 		return ErrInvalidParentChannel // 親チャンネルがアーカイブされている
 	}
 
-	ch, err = m.R.UpdateChannel(id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
+	ch, err = m.R.UpdateChannel(context.TODO(), id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -343,7 +344,7 @@ func (m *managerImpl) ChangeChannelSubscriptions(channelID uuid.UUID, subscripti
 		return ErrForcedNotification
 	}
 
-	on, off, err := m.R.ChangeChannelSubscription(channelID, repository.ChangeChannelSubscriptionArgs{
+	on, off, err := m.R.ChangeChannelSubscription(context.TODO(), channelID, repository.ChangeChannelSubscriptionArgs{
 		Subscription: subscriptions,
 		KeepOffLevel: keepOffLevel,
 	})
@@ -365,7 +366,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 		return nil, ErrChannelNotFound
 	}
 
-	ch, err := m.R.GetDirectMessageChannel(user1, user2)
+	ch, err := m.R.GetDirectMessageChannel(context.TODO(), user1, user2)
 	if err == nil {
 		return ch, nil
 	} else if err != repository.ErrNotFound {
@@ -373,14 +374,12 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 	}
 
 	// 存在しなかったので作成
-	ch, err = m.R.CreateChannel(
-		model.Channel{
-			Name:      "dm_" + random.AlphaNumeric(17),
-			IsVisible: true,
-		},
+	ch, err = m.R.CreateChannel(context.TODO(), model.Channel{
+		Name:      "dm_" + random.AlphaNumeric(17),
+		IsVisible: true,
+	},
 		set.UUIDSetFromArray([]uuid.UUID{user1, user2}),
-		true,
-	)
+		true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
@@ -389,7 +388,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 }
 
 func (m *managerImpl) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
-	members, err := m.R.GetPrivateChannelMemberIDs(id)
+	members, err := m.R.GetPrivateChannelMemberIDs(context.TODO(), id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMCHannelMembers: %w", err)
 	}
@@ -397,7 +396,7 @@ func (m *managerImpl) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
 }
 
 func (m *managerImpl) GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
-	mappings, err := m.R.GetDirectMessageChannelMapping(userID)
+	mappings, err := m.R.GetDirectMessageChannelMapping(context.TODO(), userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMChannelMapping: %w", err)
 	}
@@ -419,7 +418,7 @@ func (m *managerImpl) IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bo
 	}
 
 	// DMチャンネル
-	members, err := m.R.GetPrivateChannelMemberIDs(channelID)
+	members, err := m.R.GetPrivateChannelMemberIDs(context.TODO(), channelID)
 	if err != nil {
 		return false, fmt.Errorf("failed to IsChannelAccessibleToUser: %w", err)
 	}
@@ -444,7 +443,7 @@ func (m *managerImpl) recordChannelEvent(channelID uuid.UUID, eventType model.Ch
 	go func() {
 		defer m.P.Done()
 
-		err := m.R.RecordChannelEvent(channelID, eventType, detail, datetime)
+		err := m.R.RecordChannelEvent(context.TODO(), channelID, eventType, detail, datetime)
 		if err != nil {
 			m.L.Warn("failed to record channel event", zap.Error(err), zap.Stringer("channelID", channelID), zap.Stringer("type", eventType), zap.Any("detail", detail), zap.Time("datetime", datetime))
 		}

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -58,7 +59,7 @@ func TestInitChannelManager(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetPublicChannels().
+			GetPublicChannels(context.TODO()).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -74,7 +75,7 @@ func TestInitChannelManager(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 
 		repo.EXPECT().
-			GetPublicChannels().
+			GetPublicChannels(context.TODO()).
 			Return([]*model.Channel{
 				{ID: cABC, Name: "c", ParentID: cAB, Topic: "", IsForced: false, IsPublic: true, IsVisible: true},
 				{ID: cABCD, Name: "d", ParentID: cABC, Topic: "", IsForced: false, IsPublic: true, IsVisible: true},
@@ -92,7 +93,7 @@ func TestInitChannelManager(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 
 		repo.EXPECT().
-			GetPublicChannels().
+			GetPublicChannels(context.TODO()).
 			Return([]*model.Channel{}, nil).
 			Times(1)
 
@@ -124,7 +125,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(dm1.ID).
+			GetChannel(context.TODO(), dm1.ID).
 			Return(dm1, nil).
 			Times(1)
 
@@ -153,7 +154,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(cNotFound).
+			GetChannel(context.TODO(), cNotFound).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -169,7 +170,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetChannel(cNotFound).
+			GetChannel(context.TODO(), cNotFound).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -285,7 +286,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			CreateChannel(gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
@@ -336,12 +337,12 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any()).
+							CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {
 							repo.EXPECT().
-								RecordChannelEvent(c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
 									"userId":    c.Creator,
 									"channelId": cid,
 								}), createdAt).
@@ -372,7 +373,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(gomock.Any()).
+			GetChannel(context.TODO(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -448,7 +449,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			UpdateChannel(gomock.Any(), gomock.Any()).
+			UpdateChannel(context.TODO(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
@@ -549,7 +550,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Topic.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(c.ID, model.ChannelEventTopicChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventTopicChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.Topic,
 									"after":  args.Topic.V,
@@ -560,7 +561,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Visibility.Valid && ch.IsVisible != args.Visibility.V {
 							repo.EXPECT().
-								RecordChannelEvent(c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
 									"userId":     args.UpdaterID,
 									"visibility": args.Visibility.V,
 								}, gomock.Any()).
@@ -570,7 +571,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.ForcedNotification.Valid && ch.IsForced != args.ForcedNotification.V {
 							repo.EXPECT().
-								RecordChannelEvent(c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"force":  args.ForcedNotification.V,
 								}, gomock.Any()).
@@ -580,7 +581,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Name.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.Name,
 									"after":  args.Name.V,
@@ -591,7 +592,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Parent.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.ParentID,
 									"after":  args.Parent.V,
@@ -602,7 +603,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							UpdateChannel(c.ID, args).
+							UpdateChannel(context.TODO(), c.ID, args).
 							Return(&newChan, nil).
 							Times(1)
 
@@ -660,7 +661,7 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			ChangeChannelSubscription(gomock.Any(), gomock.Any()).
+			ChangeChannelSubscription(context.TODO(), gomock.Any(), gomock.Any()).
 			Return(nil, nil, mockErr).
 			AnyTimes()
 
@@ -698,11 +699,11 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 				}
 
 				repo.EXPECT().
-					ChangeChannelSubscription(c.ID, gomock.Any()).
+					ChangeChannelSubscription(context.TODO(), c.ID, gomock.Any()).
 					Return(on, off, nil).
 					AnyTimes()
 				repo.EXPECT().
-					RecordChannelEvent(c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
+					RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
 						"userId": uid1,
 						"on":     on,
 						"off":    off,
@@ -728,7 +729,7 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(gomock.Any()).
+			GetChannel(context.TODO(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -752,7 +753,7 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(dm1.ID).
+			GetChannel(context.TODO(), dm1.ID).
 			Return(dm1, nil).
 			AnyTimes()
 
@@ -787,11 +788,11 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 			{ID: cAD, Name: "d", ParentID: cA, Topic: "", IsForced: false, IsPublic: true, IsVisible: false},
 		}
 		repo.EXPECT().
-			ArchiveChannels(gomock.Len(len(expects))).
+			ArchiveChannels(context.TODO(), gomock.Len(len(expects))).
 			Return(expects, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(context.TODO(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(len(expects))
 
@@ -816,7 +817,7 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(gomock.Any()).
+			GetChannel(context.TODO(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -851,11 +852,11 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			UpdateChannel(cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
+			UpdateChannel(context.TODO(), cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
 			Return(&model.Channel{ID: cABB, Name: "b", ParentID: cAB, Topic: "", IsForced: false, IsPublic: true, IsVisible: true}, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(context.TODO(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -896,7 +897,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(context.TODO(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					AnyTimes()
 
@@ -914,11 +915,11 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(context.TODO(), gomock.Any(), gomock.Any()).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 				repo.EXPECT().
-					CreateChannel(gomock.Any(), gomock.Any(), gomock.Any()).
+					CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
@@ -945,7 +946,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 					IsVisible: true,
 				}
 				repo.EXPECT().
-					GetDirectMessageChannel(uid1, uid2).
+					GetDirectMessageChannel(context.TODO(), uid1, uid2).
 					Return(dm1, nil).
 					Times(1)
 
@@ -964,12 +965,12 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 				uid1 := uuid.NewV3(uuid.Nil, "u1")
 				uid2 := uuid.NewV3(uuid.Nil, "u2")
 				repo.EXPECT().
-					GetDirectMessageChannel(uid1, uid2).
+					GetDirectMessageChannel(context.TODO(), uid1, uid2).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 
 				repo.EXPECT().
-					CreateChannel(gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
+					CreateChannel(context.TODO(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
 					Return(&model.Channel{
 						ID:        uuid.NewV3(uuid.Nil, "c 1-1"),
 						Name:      "dm_" + random.AlphaNumeric(17),
@@ -1002,12 +1003,12 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 				id := mustGenerateUUID(uuidVersion)
 				expected := []uuid.UUID{cA, cE}
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(id).
+					GetPrivateChannelMemberIDs(context.TODO(), id).
 					Return(expected, nil).
 					Times(1)
 
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(cNotFound).
+					GetPrivateChannelMemberIDs(context.TODO(), cNotFound).
 					Return([]uuid.UUID{}, nil).
 					Times(1)
 
@@ -1028,7 +1029,7 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(gomock.Any()).
+					GetPrivateChannelMemberIDs(context.TODO(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
@@ -1059,7 +1060,7 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(uid1).
+			GetDirectMessageChannelMapping(context.TODO(), uid1).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid1, User1: uid1, User2: uid1},
 				{ChannelID: cid2, User1: uid1, User2: uid2},
@@ -1068,14 +1069,14 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(uid2).
+			GetDirectMessageChannelMapping(context.TODO(), uid2).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid2, User1: uid1, User2: uid2},
 			}, nil).
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(uid4).
+			GetDirectMessageChannelMapping(context.TODO(), uid4).
 			Return([]*model.DMChannelMapping{}, nil).
 			Times(1)
 
@@ -1106,7 +1107,7 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(uid1).
+			GetDirectMessageChannelMapping(context.TODO(), uid1).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -1134,22 +1135,22 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(cNotFound).
+			GetPrivateChannelMemberIDs(context.TODO(), cNotFound).
 			Return([]uuid.UUID{}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(cid1).
+			GetPrivateChannelMemberIDs(context.TODO(), cid1).
 			Return([]uuid.UUID{uid1}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(cid2).
+			GetPrivateChannelMemberIDs(context.TODO(), cid2).
 			Return([]uuid.UUID{uid1, uid2}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(cid3).
+			GetPrivateChannelMemberIDs(context.TODO(), cid3).
 			Return([]uuid.UUID{uid1, uid3}, nil).
 			AnyTimes()
 
@@ -1185,7 +1186,7 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(gomock.Any()).
+			GetPrivateChannelMemberIDs(context.TODO(), gomock.Any()).
 			Return(nil, mockErr).
 			Times(1)
 

--- a/service/fcm/impl.go
+++ b/service/fcm/impl.go
@@ -83,7 +83,7 @@ func (c *clientImpl) send(targetUserIDs set.UUID, p *Payload, withUnreadCount bo
 
 	logger := c.logger.With(zap.Reflect("payload", p))
 
-	tokensMap, err := c.repo.GetDeviceTokens(targetUserIDs)
+	tokensMap, err := c.repo.GetDeviceTokens(context.TODO(), targetUserIDs)
 	if err != nil {
 		logger.Error("failed to GetDeviceTokens", zap.Error(err), zap.Strings("target_user_ids", targetUserIDs.StringArray()))
 		return err
@@ -222,7 +222,7 @@ func (c *clientImpl) sendMessages(messages []*messaging.Message) {
 		}
 	}
 	if len(invalidTokens) > 0 {
-		err := c.repo.DeleteDeviceTokens(invalidTokens)
+		err := c.repo.DeleteDeviceTokens(context.TODO(), invalidTokens)
 		if err != nil {
 			c.logger.Error("failed to DeleteDeviceTokens", zap.Error(err), zap.Strings("invalid_tokens", invalidTokens))
 			return

--- a/service/file/manager_impl.go
+++ b/service/file/manager_impl.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -203,7 +204,7 @@ func (m *managerImpl) Save(args SaveArgs) (model.File, error) {
 		})
 	}
 
-	err := m.repo.SaveFileMeta(f, acl)
+	err := m.repo.SaveFileMeta(context.TODO(), f, acl)
 	if err != nil {
 		if err := m.fs.DeleteByKey(f.ID.String(), f.Type); err != nil {
 			m.l.Warn("failed to delete file from storage during rollback", zap.Error(err), zap.Stringer("fid", f.ID))
@@ -219,7 +220,7 @@ func (m *managerImpl) Save(args SaveArgs) (model.File, error) {
 }
 
 func (m *managerImpl) Get(id uuid.UUID) (model.File, error) {
-	meta, err := m.repo.GetFileMeta(id)
+	meta, err := m.repo.GetFileMeta(context.TODO(), id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil, ErrNotFound
@@ -230,7 +231,7 @@ func (m *managerImpl) Get(id uuid.UUID) (model.File, error) {
 }
 
 func (m *managerImpl) List(q repository.FilesQuery) ([]model.File, bool, error) {
-	r, more, err := m.repo.GetFileMetas(q)
+	r, more, err := m.repo.GetFileMetas(context.TODO(), q)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to GetFileMetas: %w", err)
 	}
@@ -238,7 +239,7 @@ func (m *managerImpl) List(q repository.FilesQuery) ([]model.File, bool, error) 
 }
 
 func (m *managerImpl) Delete(id uuid.UUID) error {
-	meta, err := m.repo.GetFileMeta(id)
+	meta, err := m.repo.GetFileMeta(context.TODO(), id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return ErrNotFound
@@ -246,7 +247,7 @@ func (m *managerImpl) Delete(id uuid.UUID) error {
 		return fmt.Errorf("failed to GetFileMeta: %w", err)
 	}
 
-	if err := m.repo.DeleteFileMeta(id); err != nil {
+	if err := m.repo.DeleteFileMeta(context.TODO(), id); err != nil {
 		return fmt.Errorf("failed to DeleteFileMeta: %w", err)
 	}
 	if err := m.fs.DeleteByKey(meta.ID.String(), meta.Type); err != nil {
@@ -261,7 +262,7 @@ func (m *managerImpl) Delete(id uuid.UUID) error {
 }
 
 func (m *managerImpl) Accessible(fileID, userID uuid.UUID) (bool, error) {
-	ok, err := m.repo.IsFileAccessible(fileID, userID)
+	ok, err := m.repo.IsFileAccessible(context.TODO(), fileID, userID)
 	if err != nil {
 		return false, fmt.Errorf("failed to IsFileAccessible: %w", err)
 	}

--- a/service/file/manager_impl_test.go
+++ b/service/file/manager_impl_test.go
@@ -2,12 +2,14 @@ package file
 
 import (
 	"bytes"
+	"context"
 	"errors"
-	"github.com/stretchr/testify/require"
 	"image/png"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
@@ -65,8 +67,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			DoAndReturn(func(meta *model.FileMeta, _ []*model.FileACLEntry) error {
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			DoAndReturn(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
 			}).
@@ -124,8 +126,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			DoAndReturn(func(meta *model.FileMeta, _ []*model.FileACLEntry) error {
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			DoAndReturn(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
 			}).
@@ -188,8 +190,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -255,8 +257,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -321,8 +323,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -385,8 +387,8 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
-			Do(func(meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
+			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
 		ip.EXPECT().
@@ -439,7 +441,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		}}
 
 		repo.EXPECT().
-			GetFileMeta(meta.ID).
+			GetFileMeta(context.TODO(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 
@@ -456,7 +458,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(uuid.Nil).
+			GetFileMeta(context.TODO(), uuid.Nil).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -473,7 +475,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(uuid.Nil).
+			GetFileMeta(context.TODO(), uuid.Nil).
 			Return(nil, errMock).
 			Times(1)
 
@@ -508,7 +510,7 @@ func TestManagerImpl_List(t *testing.T) {
 		}}
 
 		repo.EXPECT().
-			GetFileMetas(gomock.Any()).
+			GetFileMetas(context.TODO(), gomock.Any()).
 			Return([]*model.FileMeta{meta, meta, meta}, true, nil).
 			Times(1)
 
@@ -526,7 +528,7 @@ func TestManagerImpl_List(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMetas(gomock.Any()).
+			GetFileMetas(context.TODO(), gomock.Any()).
 			Return(nil, false, errMock).
 			Times(1)
 
@@ -569,11 +571,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 			},
 		}
 		repo.EXPECT().
-			GetFileMeta(meta.ID).
+			GetFileMeta(context.TODO(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(meta.ID).
+			DeleteFileMeta(context.TODO(), meta.ID).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
@@ -610,11 +612,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetFileMeta(meta.ID).
+			GetFileMeta(context.TODO(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(meta.ID).
+			DeleteFileMeta(context.TODO(), meta.ID).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
@@ -632,7 +634,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(uuid.Nil).
+			GetFileMeta(context.TODO(), uuid.Nil).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -646,7 +648,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(uuid.Nil).
+			GetFileMeta(context.TODO(), uuid.Nil).
 			Return(nil, errMock).
 			Times(1)
 
@@ -673,11 +675,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetFileMeta(meta.ID).
+			GetFileMeta(context.TODO(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(meta.ID).
+			DeleteFileMeta(context.TODO(), meta.ID).
 			Return(errMock).
 			Times(1)
 
@@ -699,7 +701,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(fid, uid).Return(false, errMock).Times(1)
+		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, errMock).Times(1)
 
 		ok, err := fm.Accessible(fid, uid)
 		if assert.Error(t, err) {
@@ -716,7 +718,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(fid, uid).Return(true, nil).Times(1)
+		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(true, nil).Times(1)
 
 		ok, err := fm.Accessible(fid, uid)
 		if assert.NoError(t, err) {
@@ -732,7 +734,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(fid, uid).Return(false, nil).Times(1)
+		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, nil).Times(1)
 
 		ok, err := fm.Accessible(fid, uid)
 		if assert.NoError(t, err) {

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -202,7 +202,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// チャンネルに上限数以上のメッセージがピン留めされていないか確認
-	pins, err := m.R.GetPinnedMessageByChannelID(msg.GetChannelID())
+	pins, err := m.R.GetPinnedMessageByChannelID(context.TODO(), msg.GetChannelID())
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// ピン
-	pin, err := m.R.PinMessage(id, userID)
+	pin, err := m.R.PinMessage(context.TODO(), id, userID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -250,7 +250,7 @@ func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
 	}
 
 	// ピン外し
-	pin, err := m.R.UnpinMessage(id)
+	pin, err := m.R.UnpinMessage(context.TODO(), id)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -39,7 +39,7 @@ func NewMessageManager(repo repository.Repository, cm channel.Manager, logger *z
 		R:  repo,
 		L:  logger.Named("message_manager"),
 		cache: sc.NewMust(func(_ context.Context, key uuid.UUID) (*message, error) {
-			m, err := repo.GetMessageByID(key)
+			m, err := repo.GetMessageByID(context.TODO(), key)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return nil, ErrNotFound
@@ -65,7 +65,7 @@ func (m *manager) get(id uuid.UUID) (*message, error) {
 }
 
 func (m *manager) GetIn(ids []uuid.UUID) ([]Message, error) {
-	messages, _, err := m.R.GetMessages(repository.MessagesQuery{IDIn: optional.From(ids)})
+	messages, _, err := m.R.GetMessages(context.TODO(), repository.MessagesQuery{IDIn: optional.From(ids)})
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
 		ExcludeDMs:               query.ExcludeDMs,
 		DisablePreload:           query.DisablePreload,
 	}
-	messages, more, err := m.R.GetMessages(q)
+	messages, more, err := m.R.GetMessages(context.TODO(), q)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetMessages: %w", err)
 	}
@@ -125,7 +125,7 @@ func (m *manager) Create(channelID, userID uuid.UUID, content string) (Message, 
 
 func (m *manager) create(channelID, userID uuid.UUID, content string) (Message, error) {
 	// 作成
-	msg, err := m.R.CreateMessage(userID, channelID, content)
+	msg, err := m.R.CreateMessage(context.TODO(), userID, channelID, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateMessage: %w", err)
 	}
@@ -145,7 +145,7 @@ func (m *manager) Edit(id uuid.UUID, content string) error {
 	}
 
 	// 更新
-	if err := m.R.UpdateMessage(id, content); err != nil {
+	if err := m.R.UpdateMessage(context.TODO(), id, content); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -171,7 +171,7 @@ func (m *manager) Delete(id uuid.UUID) error {
 	}
 
 	// 削除
-	if err := m.R.DeleteMessage(id); err != nil {
+	if err := m.R.DeleteMessage(context.TODO(), id); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -282,7 +282,7 @@ func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.Messag
 	}
 
 	// スタンプを押す
-	ms, err := m.R.AddStampToMessage(id, stampID, userID, n)
+	ms, err := m.R.AddStampToMessage(context.TODO(), id, stampID, userID, n)
 	if err != nil {
 		return nil, fmt.Errorf("failed to AddStampToMessage: %w", err)
 	}
@@ -306,7 +306,7 @@ func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
 	}
 
 	// スタンプを消す
-	if err := m.R.RemoveStampFromMessage(id, stampID, userID); err != nil {
+	if err := m.R.RemoveStampFromMessage(context.TODO(), id, stampID, userID); err != nil {
 		return fmt.Errorf("failed to RemoveStampFromMessage: %w", err)
 	}
 

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -326,7 +326,7 @@ func (m *manager) recordChannelEvent(channelID uuid.UUID, eventType model.Channe
 	go func() {
 		defer m.P.Done()
 
-		err := m.R.RecordChannelEvent(channelID, eventType, detail, datetime)
+		err := m.R.RecordChannelEvent(context.TODO(), channelID, eventType, detail, datetime)
 		if err != nil {
 			m.L.Warn("failed to record channel event", zap.Error(err), zap.Stringer("channelID", channelID), zap.Stringer("type", eventType), zap.Any("detail", detail), zap.Time("datetime", datetime))
 		}

--- a/service/message/manager_impl_test.go
+++ b/service/message/manager_impl_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestManager_Get(t *testing.T) {
 		}
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(msg.ID).
+			GetMessageByID(context.TODO(), msg.ID).
 			Return(msg, nil).
 			Times(1)
 
@@ -90,7 +91,7 @@ func TestManager_Get(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -127,7 +128,7 @@ func TestManager_Create(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(uid, cid, content).
+			CreateMessage(context.TODO(), uid, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: uid, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
@@ -141,7 +142,7 @@ func TestManager_Create(t *testing.T) {
 		// キャッシュに取得
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(msg.GetID()).
+			GetMessageByID(context.TODO(), msg.GetID()).
 			Return(msg.(*message).Model, nil).
 			Times(1)
 		result, err := m.Get(msg.GetID())
@@ -178,7 +179,7 @@ func TestManager_CreateDM(t *testing.T) {
 		cm.EXPECT().GetDMChannel(from, to).Return(&model.Channel{ID: cid}, nil).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(from, cid, content).
+			CreateMessage(context.TODO(), from, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: from, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
@@ -192,7 +193,7 @@ func TestManager_CreateDM(t *testing.T) {
 		// キャッシュに取得
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(msg.GetID()).
+			GetMessageByID(context.TODO(), msg.GetID()).
 			Return(msg.(*message).Model, nil).
 			Times(1)
 		result, err := m.Get(msg.GetID())
@@ -226,7 +227,7 @@ func TestManager_Edit(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -243,7 +244,7 @@ func TestManager_Edit(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
@@ -262,14 +263,14 @@ func TestManager_Edit(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			UpdateMessage(id, newContent).
+			UpdateMessage(context.TODO(), id, newContent).
 			Return(nil).
 			Times(1)
 
@@ -289,7 +290,7 @@ func TestManager_Delete(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -306,7 +307,7 @@ func TestManager_Delete(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
@@ -325,14 +326,14 @@ func TestManager_Delete(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			DeleteMessage(id).
+			DeleteMessage(context.TODO(), id).
 			Return(nil).
 			Times(1)
 
@@ -352,7 +353,7 @@ func TestManager_AddStamps(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -369,7 +370,7 @@ func TestManager_AddStamps(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
@@ -391,7 +392,7 @@ func TestManager_AddStamps(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{{
 				MessageID: id,
 				StampID:   sid2,
@@ -401,7 +402,7 @@ func TestManager_AddStamps(t *testing.T) {
 			Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -421,7 +422,7 @@ func TestManager_AddStamps(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			AddStampToMessage(id, sid, uid, 1).
+			AddStampToMessage(context.TODO(), id, sid, uid, 1).
 			Return(&model.MessageStamp{
 				MessageID: id,
 				StampID:   sid,
@@ -464,7 +465,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -481,7 +482,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
 		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
@@ -503,7 +504,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -521,7 +522,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 			Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(id).
+			GetMessageByID(context.TODO(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -535,7 +536,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			RemoveStampFromMessage(id, sid, uid).
+			RemoveStampFromMessage(context.TODO(), id, sid, uid).
 			Return(nil).
 			Times(1)
 

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -86,7 +86,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	forceNotify := chTree.IsForceChannel(chID)
 
 	// 投稿ユーザー情報を取得
-	mUser, err := ns.repo.GetUser(m.UserID, false)
+	mUser, err := ns.repo.GetUser(context.TODO(), m.UserID, false)
 	if err != nil {
 		logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", m.UserID)) // 失敗
 		return
@@ -140,7 +140,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	q := repository.UsersQuery{}.Active().NotBot()
 	switch {
 	case forceNotify: // 強制通知チャンネル
-		users, err := ns.repo.GetUserIDs(q)
+		users, err := ns.repo.GetUserIDs(context.TODO(), q)
 		if err != nil {
 			logger.Error("failed to GetUsers", zap.Error(err)) // 失敗
 			return
@@ -150,7 +150,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		noticeable.Add(users...)
 
 	case isDM: // DM
-		users, err := ns.repo.GetUserIDs(q.CMemberOf(chID))
+		users, err := ns.repo.GetUserIDs(context.TODO(), q.CMemberOf(chID))
 		if err != nil {
 			logger.Error("failed to GetPrivateChannelMemberIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -161,7 +161,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 
 	default: // 通常チャンネルメッセージ
 		// チャンネル通知購読者取得
-		notify, err := ns.repo.GetUserIDs(q.SubscriberAtNotifyLevelOf(chID))
+		notify, err := ns.repo.GetUserIDs(context.TODO(), q.SubscriberAtNotifyLevelOf(chID))
 		if err != nil {
 			logger.Error("failed to GetUserIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -169,7 +169,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		notifiedUsers.Add(notify...)
 
 		// チャンネル未読管理購読者取得
-		mark, err := ns.repo.GetUserIDs(q.SubscriberAtMarkLevelOf(chID))
+		mark, err := ns.repo.GetUserIDs(context.TODO(), q.SubscriberAtMarkLevelOf(chID))
 		if err != nil {
 			logger.Error("failed to GetUserIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -178,7 +178,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 
 		// ユーザーグループ・メンションユーザー取得
 		for _, uid := range parsed.Mentions {
-			user, err := ns.repo.GetUser(uid, false)
+			user, err := ns.repo.GetUser(context.TODO(), uid, false)
 			if err != nil {
 				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue
@@ -193,7 +193,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 			noticeable.Add(uid)
 		}
 		for _, gid := range parsed.GroupMentions {
-			gs, err := ns.repo.GetUserIDs(q.GMemberOf(gid))
+			gs, err := ns.repo.GetUserIDs(context.TODO(), q.GMemberOf(gid))
 			if err != nil {
 				logger.Error("failed to GetUserGroupMemberIDs", zap.Error(err), zap.Stringer("groupId", gid)) // 失敗
 				return
@@ -211,7 +211,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 			}
 			uid := m.UserID
 
-			user, err := ns.repo.GetUser(uid, false)
+			user, err := ns.repo.GetUser(context.TODO(), uid, false)
 			if err != nil {
 				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -220,7 +221,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 				continue
 			}
 
-			us, err := ns.repo.GetNotifyCitation(uid)
+			us, err := ns.repo.GetNotifyCitation(context.TODO(), uid)
 			if err != nil {
 				logger.Error("failed to GetNotifyCitation", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -204,7 +204,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		}
 		// メッセージを引用されたユーザーへの通知
 		for _, mid := range parsed.Citation {
-			m, err := ns.repo.GetMessageByID(mid)
+			m, err := ns.repo.GetMessageByID(context.TODO(), mid)
 			if err != nil {
 				logger.Error("failed to GetMessageByID", zap.Error(err), zap.Stringer("citedMessageId", mid)) // 失敗
 				continue
@@ -253,7 +253,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	for uid := range markedUsers {
 		userNoticeableMap[uid] = noticeable.Contains(uid)
 	}
-	if err := ns.repo.SetMessageUnreads(userNoticeableMap, m.ID); err != nil {
+	if err := ns.repo.SetMessageUnreads(context.TODO(), userNoticeableMap, m.ID); err != nil {
 		logger.Error("failed to SetMessageUnreads", zap.Error(err), zap.Stringer("message_id", m.ID)) // 失敗
 	}
 

--- a/service/ogp/service_impl.go
+++ b/service/ogp/service_impl.go
@@ -64,7 +64,7 @@ func (s *ServiceImpl) start() error {
 				if !ok {
 					return
 				}
-				if err := s.repo.DeleteStaleOgpCache(); err != nil {
+				if err := s.repo.DeleteStaleOgpCache(context.TODO()); err != nil {
 					s.logger.Error("an error occurred while deleting stale ogp caches", zap.Error(err))
 				}
 			case <-s.serviceDone:
@@ -94,7 +94,7 @@ func (s *ServiceImpl) GetMeta(url *url.URL) (ogp *model.Ogp, expiresAt time.Time
 
 // getMetaOrCreate OGP情報をDBのキャッシュから取得し、存在しなかった場合はリクエストを飛ばし新たに作成します。
 func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fetchResult, err error) {
-	cache, err := s.repo.GetOgpCache(urlStr)
+	cache, err := s.repo.GetOgpCache(context.TODO(), urlStr)
 	if err != nil && err != repository.ErrNotFound {
 		return fetchResult{}, err
 	}
@@ -112,7 +112,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 		return fetchResult{nil, cache.ExpiresAt}, nil
 	}
 	if isCacheExpired {
-		if err := s.repo.DeleteOgpCache(urlStr); err != nil && err != repository.ErrNotFound {
+		if err := s.repo.DeleteOgpCache(context.TODO(), urlStr); err != nil && err != repository.ErrNotFound {
 			return fetchResult{}, err
 		}
 	}
@@ -128,7 +128,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 		switch err {
 		case parser.ErrClient, parser.ErrParse, parser.ErrNetwork, parser.ErrContentTypeNotSupported:
 			// 4xxエラー、パースエラー、名前解決などのネットワークエラーの場合はネガティブキャッシュを作成
-			cache, createErr := s.repo.CreateOgpCache(urlStr, nil, DefaultCacheDuration)
+			cache, createErr := s.repo.CreateOgpCache(context.TODO(), urlStr, nil, DefaultCacheDuration)
 			if createErr != nil {
 				return fetchResult{}, createErr
 			}
@@ -141,7 +141,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 
 	// リクエストが成功した場合はキャッシュを作成
 	content := parser.MergeDefaultPageMetaAndOpenGraph(og, meta)
-	cache, err = s.repo.CreateOgpCache(urlStr, content, DefaultCacheDuration)
+	cache, err = s.repo.CreateOgpCache(context.TODO(), urlStr, content, DefaultCacheDuration)
 	if err != nil {
 		return fetchResult{}, err
 	}
@@ -150,7 +150,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 }
 
 func (s *ServiceImpl) DeleteCache(url *url.URL) error {
-	err := s.repo.DeleteOgpCache(url.String())
+	err := s.repo.DeleteOgpCache(context.TODO(), url.String())
 	// キャッシュが見つからなかった場合でも、削除されてはいるので正常とみなす
 	if err != nil && err != repository.ErrNotFound {
 		return err

--- a/service/oidc/userinfo.go
+++ b/service/oidc/userinfo.go
@@ -1,6 +1,8 @@
 package oidc
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/traPtitech/traQ/model"
@@ -32,7 +34,7 @@ type ScopeChecker interface {
 }
 
 func (s *Service) GetUserInfo(userID uuid.UUID, scopes ScopeChecker) (map[string]any, error) {
-	user, err := s.repo.GetUser(userID, true)
+	user, err := s.repo.GetUser(context.TODO(), userID, true)
 	if err != nil {
 		return nil, err
 	}

--- a/service/oidc/userinfo.go
+++ b/service/oidc/userinfo.go
@@ -38,7 +38,7 @@ func (s *Service) GetUserInfo(userID uuid.UUID, scopes ScopeChecker) (map[string
 	if err != nil {
 		return nil, err
 	}
-	tags, err := s.repo.GetUserTagsByUserID(user.GetID())
+	tags, err := s.repo.GetUserTagsByUserID(context.TODO(), user.GetID())
 	if err != nil {
 		return nil, err
 	}

--- a/service/oidc/userinfo.go
+++ b/service/oidc/userinfo.go
@@ -42,7 +42,7 @@ func (s *Service) GetUserInfo(userID uuid.UUID, scopes ScopeChecker) (map[string
 	if err != nil {
 		return nil, err
 	}
-	groups, err := s.repo.GetUserBelongingGroupIDs(user.GetID())
+	groups, err := s.repo.GetUserBelongingGroupIDs(context.TODO(), user.GetID())
 	if err != nil {
 		return nil, err
 	}

--- a/service/qall/soundboard_impl.go
+++ b/service/qall/soundboard_impl.go
@@ -2,6 +2,7 @@ package qall
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -64,7 +65,7 @@ func (m *soundboardManager) SaveSoundboardItem(soundID uuid.UUID, soundName stri
 		CreatorID: creatorID,
 	}
 
-	err = m.repo.CreateSoundboardItem(args)
+	err = m.repo.CreateSoundboardItem(context.TODO(), args)
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (m *soundboardManager) DeleteSoundboardItem(soundID uuid.UUID) error {
 		return err
 	}
 
-	err = m.repo.DeleteSoundboardItem(soundID)
+	err = m.repo.DeleteSoundboardItem(context.TODO(), soundID)
 	if err != nil {
 		return err
 	}

--- a/service/qall/soundboard_test.go
+++ b/service/qall/soundboard_test.go
@@ -89,7 +89,7 @@ func TestSoundboardManager_DeleteSoundboardItem(t *testing.T) {
 
 		// DeleteSoundboardItemが呼ばれることを期待
 		mockRepo.EXPECT().
-			DeleteSoundboardItem(soundID).
+			DeleteSoundboardItem(gomock.Any(), soundID).
 			Return(nil).
 			Times(1)
 
@@ -112,7 +112,7 @@ func TestSoundboardManager_DeleteSoundboardItem(t *testing.T) {
 			Times(1)
 
 		mockRepo.EXPECT().
-			DeleteSoundboardItem(soundID).
+			DeleteSoundboardItem(gomock.Any(), soundID).
 			Return(mockErr).
 			Times(1)
 

--- a/service/rbac/rbac_impl.go
+++ b/service/rbac/rbac_impl.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -68,7 +69,7 @@ func (r *rbacImpl) Reload() error {
 }
 
 func (r *rbacImpl) reload() error {
-	rs, err := r.repo.GetAllUserRoles()
+	rs, err := r.repo.GetAllUserRoles(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/service/rbac/rbac_impl_test.go
+++ b/service/rbac/rbac_impl_test.go
@@ -18,7 +18,7 @@ type Repo struct {
 	testutils.EmptyTestRepository
 }
 
-func (r *Repo) GetAllUserRoles(ctx context.Context) ([]*model.UserRole, error) {
+func (r *Repo) GetAllUserRoles(_ context.Context) ([]*model.UserRole, error) {
 	r1 := &model.UserRole{Name: "r1", Permissions: []model.RolePermission{{Permission: "p1"}}}
 	r2 := &model.UserRole{Name: "r2", Permissions: []model.RolePermission{{Permission: "p2"}}}
 	r3 := &model.UserRole{Name: "r3", Permissions: []model.RolePermission{{Permission: "p3"}}}

--- a/service/rbac/rbac_impl_test.go
+++ b/service/rbac/rbac_impl_test.go
@@ -1,6 +1,7 @@
 package rbac_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ type Repo struct {
 	testutils.EmptyTestRepository
 }
 
-func (r *Repo) GetAllUserRoles() ([]*model.UserRole, error) {
+func (r *Repo) GetAllUserRoles(ctx context.Context) ([]*model.UserRole, error) {
 	r1 := &model.UserRole{Name: "r1", Permissions: []model.RolePermission{{Permission: "p1"}}}
 	r2 := &model.UserRole{Name: "r2", Permissions: []model.RolePermission{{Permission: "p2"}}}
 	r3 := &model.UserRole{Name: "r3", Permissions: []model.RolePermission{{Permission: "p3"}}}

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -93,7 +93,7 @@ func (e *esEngine) getAttributes(m *model.Message, parseResult *message.ParseRes
 	attr.HasAttachments = len(parseResult.Attachments) != 0
 
 	for _, attachmentID := range parseResult.Attachments {
-		meta, err := e.repo.GetFileMeta(attachmentID)
+		meta, err := e.repo.GetFileMeta(context.TODO(), attachmentID)
 		if err != nil {
 			e.l.Warn(err.Error(), zap.Error(err))
 			continue

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -154,7 +154,7 @@ func (e *esEngine) sync() error {
 	var userCache userCache
 	lastInsert := lastSynced
 	for {
-		messages, more, err := e.repo.GetUpdatedMessagesAfter(lastInsert, syncMessageBulk)
+		messages, more, err := e.repo.GetUpdatedMessagesAfter(context.TODO(), lastInsert, syncMessageBulk)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func (e *esEngine) sync() error {
 
 	lastDelete := lastSynced
 	for {
-		messages, more, err := e.repo.GetDeletedMessagesAfter(lastDelete, syncMessageBulk)
+		messages, more, err := e.repo.GetDeletedMessagesAfter(context.TODO(), lastDelete, syncMessageBulk)
 		if err != nil {
 			return err
 		}

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -41,7 +41,7 @@ func (e *esEngine) convertMessageCreated(m *model.Message, parseResult *message.
 	var isBot, ok bool
 	if isBot, ok = userCache[m.UserID]; !ok {
 		// 新規ユーザー or キャッシュが存在しない
-		user, err := e.repo.GetUser(m.UserID, false)
+		user, err := e.repo.GetUser(context.TODO(), m.UserID, false)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +129,7 @@ loop:
 }
 
 func (e *esEngine) newUserCache() (userCache, error) {
-	users, err := e.repo.GetUsers(repository.UsersQuery{})
+	users, err := e.repo.GetUsers(context.TODO(), repository.UsersQuery{})
 	if err != nil {
 		return nil, err
 	}

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -1289,7 +1289,7 @@ func (repo *TestRepository) IsFileAccessible(fileID, userID uuid.UUID) (bool, er
 	return allow, nil
 }
 
-func (repo *TestRepository) CreateWebhook(name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
+func (repo *TestRepository) CreateWebhook(ctx context.Context, name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
 	if len(name) == 0 || utf8.RuneCountInString(name) > 32 {
 		return nil, repository.ArgError("name", "Name must be non-empty and shorter than 33 characters")
 	}
@@ -1343,7 +1343,7 @@ func (repo *TestRepository) CreateWebhook(name, description string, channelID, i
 	return &wb, nil
 }
 
-func (repo *TestRepository) UpdateWebhook(id uuid.UUID, args repository.UpdateWebhookArgs) error {
+func (repo *TestRepository) UpdateWebhook(ctx context.Context, id uuid.UUID, args repository.UpdateWebhookArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1393,7 +1393,7 @@ func (repo *TestRepository) UpdateWebhook(id uuid.UUID, args repository.UpdateWe
 	return nil
 }
 
-func (repo *TestRepository) DeleteWebhook(id uuid.UUID) error {
+func (repo *TestRepository) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1413,7 +1413,7 @@ func (repo *TestRepository) DeleteWebhook(id uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) GetWebhook(id uuid.UUID) (model.Webhook, error) {
+func (repo *TestRepository) GetWebhook(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1429,7 +1429,7 @@ func (repo *TestRepository) GetWebhook(id uuid.UUID) (model.Webhook, error) {
 	return &w, nil
 }
 
-func (repo *TestRepository) GetWebhookByBotUserID(id uuid.UUID) (model.Webhook, error) {
+func (repo *TestRepository) GetWebhookByBotUserID(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1455,7 +1455,7 @@ func (repo *TestRepository) GetWebhookByBotUserID(id uuid.UUID) (model.Webhook, 
 	return &w, nil
 }
 
-func (repo *TestRepository) GetAllWebhooks() ([]model.Webhook, error) {
+func (repo *TestRepository) GetAllWebhooks(ctx context.Context) ([]model.Webhook, error) {
 	arr := make([]model.Webhook, 0)
 	repo.WebhooksLock.RLock()
 	repo.UsersLock.RLock()
@@ -1469,7 +1469,7 @@ func (repo *TestRepository) GetAllWebhooks() ([]model.Webhook, error) {
 	return arr, nil
 }
 
-func (repo *TestRepository) GetWebhooksByCreator(creatorID uuid.UUID) ([]model.Webhook, error) {
+func (repo *TestRepository) GetWebhooksByCreator(ctx context.Context, creatorID uuid.UUID) ([]model.Webhook, error) {
 	arr := make([]model.Webhook, 0)
 	if creatorID == uuid.Nil {
 		return arr, nil

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -595,7 +595,7 @@ func (repo *TestRepository) RemoveUserFromGroupAdmin(userID, groupID uuid.UUID) 
 	return nil
 }
 
-func (repo *TestRepository) GetTagByID(id uuid.UUID) (*model.Tag, error) {
+func (repo *TestRepository) GetTagByID(ctx context.Context, id uuid.UUID) (*model.Tag, error) {
 	repo.TagsLock.RLock()
 	t, ok := repo.Tags[id]
 	repo.TagsLock.RUnlock()
@@ -605,7 +605,7 @@ func (repo *TestRepository) GetTagByID(id uuid.UUID) (*model.Tag, error) {
 	return &t, nil
 }
 
-func (repo *TestRepository) GetOrCreateTag(name string) (*model.Tag, error) {
+func (repo *TestRepository) GetOrCreateTag(ctx context.Context, name string) (*model.Tag, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
@@ -629,7 +629,7 @@ func (repo *TestRepository) GetOrCreateTag(name string) (*model.Tag, error) {
 	return &t, nil
 }
 
-func (repo *TestRepository) AddUserTag(userID, tagID uuid.UUID) error {
+func (repo *TestRepository) AddUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -653,7 +653,7 @@ func (repo *TestRepository) AddUserTag(userID, tagID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) ChangeUserTagLock(userID, tagID uuid.UUID, locked bool) error {
+func (repo *TestRepository) ChangeUserTagLock(ctx context.Context, userID, tagID uuid.UUID, locked bool) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -670,7 +670,7 @@ func (repo *TestRepository) ChangeUserTagLock(userID, tagID uuid.UUID, locked bo
 	return repository.ErrNotFound
 }
 
-func (repo *TestRepository) DeleteUserTag(userID, tagID uuid.UUID) error {
+func (repo *TestRepository) DeleteUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -683,7 +683,7 @@ func (repo *TestRepository) DeleteUserTag(userID, tagID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) GetUserTag(userID, tagID uuid.UUID) (model.UserTag, error) {
+func (repo *TestRepository) GetUserTag(ctx context.Context, userID, tagID uuid.UUID) (model.UserTag, error) {
 	repo.UserTagsLock.RLock()
 	defer repo.UserTagsLock.RUnlock()
 	tags, ok := repo.UserTags[userID]
@@ -700,7 +700,7 @@ func (repo *TestRepository) GetUserTag(userID, tagID uuid.UUID) (model.UserTag, 
 	return &ut, nil
 }
 
-func (repo *TestRepository) GetUserTagsByUserID(userID uuid.UUID) ([]model.UserTag, error) {
+func (repo *TestRepository) GetUserTagsByUserID(ctx context.Context, userID uuid.UUID) ([]model.UserTag, error) {
 	tags := make([]model.UserTag, 0)
 	repo.UserTagsLock.RLock()
 	for tid, ut := range repo.UserTags[userID] {
@@ -714,7 +714,7 @@ func (repo *TestRepository) GetUserTagsByUserID(userID uuid.UUID) ([]model.UserT
 	return tags, nil
 }
 
-func (repo *TestRepository) GetUserIDsByTagID(tagID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserIDsByTagID(ctx context.Context, tagID uuid.UUID) ([]uuid.UUID, error) {
 	users := make([]uuid.UUID, 0)
 	repo.UserTagsLock.RLock()
 	for uid, tags := range repo.UserTags {

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -60,7 +60,7 @@ type TestRepository struct {
 	OgpCacheLock              sync.RWMutex
 }
 
-func (repo *TestRepository) GetPublicChannels(ctx context.Context) ([]*model.Channel, error) {
+func (repo *TestRepository) GetPublicChannels(_ context.Context) ([]*model.Channel, error) {
 	repo.ChannelsLock.RLock()
 	defer repo.ChannelsLock.RUnlock()
 	result := make([]*model.Channel, 0)
@@ -96,7 +96,7 @@ func NewTestRepository() *TestRepository {
 	return r
 }
 
-func (repo *TestRepository) CreateUser(ctx context.Context, args repository.CreateUserArgs) (model.UserInfo, error) {
+func (repo *TestRepository) CreateUser(_ context.Context, args repository.CreateUserArgs) (model.UserInfo, error) {
 	repo.UsersLock.Lock()
 	defer repo.UsersLock.Unlock()
 
@@ -137,7 +137,7 @@ func (repo *TestRepository) CreateUser(ctx context.Context, args repository.Crea
 	return &user, nil
 }
 
-func (repo *TestRepository) GetUser(ctx context.Context, id uuid.UUID, _ bool) (model.UserInfo, error) {
+func (repo *TestRepository) GetUser(_ context.Context, id uuid.UUID, _ bool) (model.UserInfo, error) {
 	repo.UsersLock.RLock()
 	u, ok := repo.Users[id]
 	repo.UsersLock.RUnlock()
@@ -147,7 +147,7 @@ func (repo *TestRepository) GetUser(ctx context.Context, id uuid.UUID, _ bool) (
 	return &u, nil
 }
 
-func (repo *TestRepository) GetUserByName(ctx context.Context, name string, _ bool) (model.UserInfo, error) {
+func (repo *TestRepository) GetUserByName(_ context.Context, name string, _ bool) (model.UserInfo, error) {
 	repo.UsersLock.RLock()
 	defer repo.UsersLock.RUnlock()
 	for _, u := range repo.Users {
@@ -159,7 +159,7 @@ func (repo *TestRepository) GetUserByName(ctx context.Context, name string, _ bo
 	return nil, repository.ErrNotFound
 }
 
-func (repo *TestRepository) GetUsers(ctx context.Context, query repository.UsersQuery) ([]model.UserInfo, error) {
+func (repo *TestRepository) GetUsers(_ context.Context, query repository.UsersQuery) ([]model.UserInfo, error) {
 	result := make([]model.UserInfo, 0, len(repo.Users))
 	repo.UsersLock.RLock()
 	repo.PrivateChannelMembersLock.RLock()
@@ -207,7 +207,7 @@ func (repo *TestRepository) GetUsers(ctx context.Context, query repository.Users
 	return result, nil
 }
 
-func (repo *TestRepository) GetUserIDs(ctx context.Context, query repository.UsersQuery) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserIDs(_ context.Context, query repository.UsersQuery) ([]uuid.UUID, error) {
 	ids := make([]uuid.UUID, 0)
 	repo.UsersLock.RLock()
 	repo.PrivateChannelMembersLock.RLock()
@@ -254,14 +254,14 @@ func (repo *TestRepository) GetUserIDs(ctx context.Context, query repository.Use
 	return ids, nil
 }
 
-func (repo *TestRepository) UserExists(ctx context.Context, id uuid.UUID) (bool, error) {
+func (repo *TestRepository) UserExists(_ context.Context, id uuid.UUID) (bool, error) {
 	repo.UsersLock.RLock()
 	_, ok := repo.Users[id]
 	repo.UsersLock.RUnlock()
 	return ok, nil
 }
 
-func (repo *TestRepository) UpdateUser(ctx context.Context, id uuid.UUID, args repository.UpdateUserArgs) error {
+func (repo *TestRepository) UpdateUser(_ context.Context, id uuid.UUID, args repository.UpdateUserArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -311,7 +311,7 @@ func (repo *TestRepository) UpdateUser(ctx context.Context, id uuid.UUID, args r
 	return nil
 }
 
-func (repo *TestRepository) CreateUserGroup(ctx context.Context, name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
+func (repo *TestRepository) CreateUserGroup(_ context.Context, name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
 	g := model.UserGroup{
 		ID:          uuid.Must(uuid.NewV7()),
 		Name:        name,
@@ -349,7 +349,7 @@ func (repo *TestRepository) CreateUserGroup(ctx context.Context, name, descripti
 	return &g, nil
 }
 
-func (repo *TestRepository) UpdateUserGroup(ctx context.Context, id uuid.UUID, args repository.UpdateUserGroupArgs) error {
+func (repo *TestRepository) UpdateUserGroup(_ context.Context, id uuid.UUID, args repository.UpdateUserGroupArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -394,7 +394,7 @@ func (repo *TestRepository) UpdateUserGroup(ctx context.Context, id uuid.UUID, a
 	return nil
 }
 
-func (repo *TestRepository) DeleteUserGroup(ctx context.Context, id uuid.UUID) error {
+func (repo *TestRepository) DeleteUserGroup(_ context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -413,7 +413,7 @@ func (repo *TestRepository) DeleteUserGroup(ctx context.Context, id uuid.UUID) e
 	return nil
 }
 
-func (repo *TestRepository) GetUserGroup(ctx context.Context, id uuid.UUID) (*model.UserGroup, error) {
+func (repo *TestRepository) GetUserGroup(_ context.Context, id uuid.UUID) (*model.UserGroup, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -438,7 +438,7 @@ func (repo *TestRepository) GetUserGroup(ctx context.Context, id uuid.UUID) (*mo
 	return &g, nil
 }
 
-func (repo *TestRepository) GetUserGroupByName(ctx context.Context, name string) (*model.UserGroup, error) {
+func (repo *TestRepository) GetUserGroupByName(_ context.Context, name string) (*model.UserGroup, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
@@ -464,7 +464,7 @@ func (repo *TestRepository) GetUserGroupByName(ctx context.Context, name string)
 	return nil, repository.ErrNotFound
 }
 
-func (repo *TestRepository) GetUserBelongingGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserBelongingGroupIDs(_ context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
 	groups := make([]uuid.UUID, 0)
 	if userID == uuid.Nil {
 		return groups, nil
@@ -482,7 +482,7 @@ func (repo *TestRepository) GetUserBelongingGroupIDs(ctx context.Context, userID
 	return groups, nil
 }
 
-func (repo *TestRepository) GetAllUserGroups(ctx context.Context) ([]*model.UserGroup, error) {
+func (repo *TestRepository) GetAllUserGroups(_ context.Context) ([]*model.UserGroup, error) {
 	groups := make([]*model.UserGroup, 0)
 	repo.UserGroupsLock.RLock()
 	repo.UserGroupAdminsLock.Lock()
@@ -505,7 +505,7 @@ func (repo *TestRepository) GetAllUserGroups(ctx context.Context) ([]*model.User
 	return groups, nil
 }
 
-func (repo *TestRepository) AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID, _ string) error {
+func (repo *TestRepository) AddUserToGroup(_ context.Context, userID, groupID uuid.UUID, _ string) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -530,7 +530,7 @@ func (repo *TestRepository) AddUserToGroup(ctx context.Context, userID, groupID 
 	return nil
 }
 
-func (repo *TestRepository) RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID) error {
+func (repo *TestRepository) RemoveUserFromGroup(_ context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -552,7 +552,7 @@ func (repo *TestRepository) RemoveUserFromGroup(ctx context.Context, userID, gro
 	return nil
 }
 
-func (repo *TestRepository) AddUserToGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
+func (repo *TestRepository) AddUserToGroupAdmin(_ context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -573,7 +573,7 @@ func (repo *TestRepository) AddUserToGroupAdmin(ctx context.Context, userID, gro
 	return nil
 }
 
-func (repo *TestRepository) RemoveUserFromGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
+func (repo *TestRepository) RemoveUserFromGroupAdmin(_ context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -595,7 +595,7 @@ func (repo *TestRepository) RemoveUserFromGroupAdmin(ctx context.Context, userID
 	return nil
 }
 
-func (repo *TestRepository) GetTagByID(ctx context.Context, id uuid.UUID) (*model.Tag, error) {
+func (repo *TestRepository) GetTagByID(_ context.Context, id uuid.UUID) (*model.Tag, error) {
 	repo.TagsLock.RLock()
 	t, ok := repo.Tags[id]
 	repo.TagsLock.RUnlock()
@@ -605,7 +605,7 @@ func (repo *TestRepository) GetTagByID(ctx context.Context, id uuid.UUID) (*mode
 	return &t, nil
 }
 
-func (repo *TestRepository) GetOrCreateTag(ctx context.Context, name string) (*model.Tag, error) {
+func (repo *TestRepository) GetOrCreateTag(_ context.Context, name string) (*model.Tag, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
@@ -629,7 +629,7 @@ func (repo *TestRepository) GetOrCreateTag(ctx context.Context, name string) (*m
 	return &t, nil
 }
 
-func (repo *TestRepository) AddUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
+func (repo *TestRepository) AddUserTag(_ context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -653,7 +653,7 @@ func (repo *TestRepository) AddUserTag(ctx context.Context, userID, tagID uuid.U
 	return nil
 }
 
-func (repo *TestRepository) ChangeUserTagLock(ctx context.Context, userID, tagID uuid.UUID, locked bool) error {
+func (repo *TestRepository) ChangeUserTagLock(_ context.Context, userID, tagID uuid.UUID, locked bool) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -670,7 +670,7 @@ func (repo *TestRepository) ChangeUserTagLock(ctx context.Context, userID, tagID
 	return repository.ErrNotFound
 }
 
-func (repo *TestRepository) DeleteUserTag(ctx context.Context, userID, tagID uuid.UUID) error {
+func (repo *TestRepository) DeleteUserTag(_ context.Context, userID, tagID uuid.UUID) error {
 	if userID == uuid.Nil || tagID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -683,7 +683,7 @@ func (repo *TestRepository) DeleteUserTag(ctx context.Context, userID, tagID uui
 	return nil
 }
 
-func (repo *TestRepository) GetUserTag(ctx context.Context, userID, tagID uuid.UUID) (model.UserTag, error) {
+func (repo *TestRepository) GetUserTag(_ context.Context, userID, tagID uuid.UUID) (model.UserTag, error) {
 	repo.UserTagsLock.RLock()
 	defer repo.UserTagsLock.RUnlock()
 	tags, ok := repo.UserTags[userID]
@@ -700,7 +700,7 @@ func (repo *TestRepository) GetUserTag(ctx context.Context, userID, tagID uuid.U
 	return &ut, nil
 }
 
-func (repo *TestRepository) GetUserTagsByUserID(ctx context.Context, userID uuid.UUID) ([]model.UserTag, error) {
+func (repo *TestRepository) GetUserTagsByUserID(_ context.Context, userID uuid.UUID) ([]model.UserTag, error) {
 	tags := make([]model.UserTag, 0)
 	repo.UserTagsLock.RLock()
 	for tid, ut := range repo.UserTags[userID] {
@@ -714,7 +714,7 @@ func (repo *TestRepository) GetUserTagsByUserID(ctx context.Context, userID uuid
 	return tags, nil
 }
 
-func (repo *TestRepository) GetUserIDsByTagID(ctx context.Context, tagID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserIDsByTagID(_ context.Context, tagID uuid.UUID) ([]uuid.UUID, error) {
 	users := make([]uuid.UUID, 0)
 	repo.UserTagsLock.RLock()
 	for uid, tags := range repo.UserTags {
@@ -726,7 +726,7 @@ func (repo *TestRepository) GetUserIDsByTagID(ctx context.Context, tagID uuid.UU
 	return users, nil
 }
 
-func (repo *TestRepository) CreateChannel(ctx context.Context, ch model.Channel, _ set.UUID, _ bool) (*model.Channel, error) {
+func (repo *TestRepository) CreateChannel(_ context.Context, ch model.Channel, _ set.UUID, _ bool) (*model.Channel, error) {
 	ch.ID = uuid.Must(uuid.NewV7())
 	ch.IsPublic = true
 	ch.CreatedAt = time.Now()
@@ -738,7 +738,7 @@ func (repo *TestRepository) CreateChannel(ctx context.Context, ch model.Channel,
 	return &ch, nil
 }
 
-func (repo *TestRepository) UpdateChannel(ctx context.Context, channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
+func (repo *TestRepository) UpdateChannel(_ context.Context, channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
 	if channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -772,7 +772,7 @@ func (repo *TestRepository) UpdateChannel(ctx context.Context, channelID uuid.UU
 	return &ch, nil
 }
 
-func (repo *TestRepository) GetChannel(ctx context.Context, channelID uuid.UUID) (*model.Channel, error) {
+func (repo *TestRepository) GetChannel(_ context.Context, channelID uuid.UUID) (*model.Channel, error) {
 	repo.ChannelsLock.RLock()
 	ch, ok := repo.Channels[channelID]
 	repo.ChannelsLock.RUnlock()
@@ -782,7 +782,7 @@ func (repo *TestRepository) GetChannel(ctx context.Context, channelID uuid.UUID)
 	return &ch, nil
 }
 
-func (repo *TestRepository) GetPrivateChannelMemberIDs(ctx context.Context, channelID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetPrivateChannelMemberIDs(_ context.Context, channelID uuid.UUID) ([]uuid.UUID, error) {
 	result := make([]uuid.UUID, 0)
 	repo.PrivateChannelMembersLock.RLock()
 	for uid := range repo.PrivateChannelMembers[channelID] {
@@ -792,7 +792,7 @@ func (repo *TestRepository) GetPrivateChannelMemberIDs(ctx context.Context, chan
 	return result, nil
 }
 
-func (repo *TestRepository) ChangeChannelSubscription(ctx context.Context, channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
+func (repo *TestRepository) ChangeChannelSubscription(_ context.Context, channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
 	if channelID == uuid.Nil {
 		return nil, nil, repository.ErrNilID
 	}
@@ -855,7 +855,7 @@ func (repo *TestRepository) ChangeChannelSubscription(ctx context.Context, chann
 	return on, off, nil
 }
 
-func (repo *TestRepository) GetChannelSubscriptions(ctx context.Context, query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
+func (repo *TestRepository) GetChannelSubscriptions(_ context.Context, query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
 	repo.ChannelSubscribesLock.Lock()
 	result := make([]*model.UserSubscribeChannel, 0)
 
@@ -896,7 +896,7 @@ func (repo *TestRepository) GetChannelSubscriptions(ctx context.Context, query r
 	return result, nil
 }
 
-func (repo *TestRepository) CreateMessage(ctx context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error) {
+func (repo *TestRepository) CreateMessage(_ context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error) {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -917,7 +917,7 @@ func (repo *TestRepository) CreateMessage(ctx context.Context, userID, channelID
 	return m, nil
 }
 
-func (repo *TestRepository) UpdateMessage(ctx context.Context, messageID uuid.UUID, text string) error {
+func (repo *TestRepository) UpdateMessage(_ context.Context, messageID uuid.UUID, text string) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -934,7 +934,7 @@ func (repo *TestRepository) UpdateMessage(ctx context.Context, messageID uuid.UU
 	return nil
 }
 
-func (repo *TestRepository) DeleteMessage(ctx context.Context, messageID uuid.UUID) error {
+func (repo *TestRepository) DeleteMessage(_ context.Context, messageID uuid.UUID) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -948,7 +948,7 @@ func (repo *TestRepository) DeleteMessage(ctx context.Context, messageID uuid.UU
 	return nil
 }
 
-func (repo *TestRepository) GetMessageByID(ctx context.Context, messageID uuid.UUID) (*model.Message, error) {
+func (repo *TestRepository) GetMessageByID(_ context.Context, messageID uuid.UUID) (*model.Message, error) {
 	repo.MessagesLock.RLock()
 	m, ok := repo.Messages[messageID]
 	repo.MessagesLock.RUnlock()
@@ -959,7 +959,7 @@ func (repo *TestRepository) GetMessageByID(ctx context.Context, messageID uuid.U
 	return &m, nil
 }
 
-func (repo *TestRepository) GetMessages(ctx context.Context, query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetMessages(_ context.Context, query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1061,7 +1061,7 @@ func (repo *TestRepository) GetMessages(ctx context.Context, query repository.Me
 	return
 }
 
-func (repo *TestRepository) GetUpdatedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetUpdatedMessagesAfter(_ context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1087,7 +1087,7 @@ func (repo *TestRepository) GetUpdatedMessagesAfter(ctx context.Context, after t
 	return
 }
 
-func (repo *TestRepository) GetDeletedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetDeletedMessagesAfter(_ context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1113,7 +1113,7 @@ func (repo *TestRepository) GetDeletedMessagesAfter(ctx context.Context, after t
 	return
 }
 
-func (repo *TestRepository) SetMessageUnreads(ctx context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
+func (repo *TestRepository) SetMessageUnreads(_ context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
 	if len(userNoticeableMap) == 0 {
 		return nil
 	}
@@ -1139,7 +1139,7 @@ func (repo *TestRepository) SetMessageUnreads(ctx context.Context, userNoticeabl
 	return nil
 }
 
-func (repo *TestRepository) GetUnreadMessagesByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Message, error) {
+func (repo *TestRepository) GetUnreadMessagesByUserID(_ context.Context, userID uuid.UUID) ([]*model.Message, error) {
 	result := make([]*model.Message, 0)
 	repo.MessageUnreadsLock.RLock()
 	repo.MessagesLock.RLock()
@@ -1162,7 +1162,7 @@ func (repo *TestRepository) GetUnreadMessagesByUserID(ctx context.Context, userI
 	return result, nil
 }
 
-func (repo *TestRepository) DeleteUnreadsByChannelID(ctx context.Context, channelID, userID uuid.UUID) error {
+func (repo *TestRepository) DeleteUnreadsByChannelID(_ context.Context, channelID, userID uuid.UUID) error {
 	if channelID == uuid.Nil || userID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1190,7 +1190,7 @@ func (repo *TestRepository) DeleteUnreadsByChannelID(ctx context.Context, channe
 	return nil
 }
 
-func (repo *TestRepository) AddStar(ctx context.Context, userID, channelID uuid.UUID) error {
+func (repo *TestRepository) AddStar(_ context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1205,7 +1205,7 @@ func (repo *TestRepository) AddStar(ctx context.Context, userID, channelID uuid.
 	return nil
 }
 
-func (repo *TestRepository) RemoveStar(ctx context.Context, userID, channelID uuid.UUID) error {
+func (repo *TestRepository) RemoveStar(_ context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1219,7 +1219,7 @@ func (repo *TestRepository) RemoveStar(ctx context.Context, userID, channelID uu
 	return nil
 }
 
-func (repo *TestRepository) GetStaredChannels(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetStaredChannels(_ context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
 	repo.StarsLock.RLock()
 	result := make([]uuid.UUID, 0)
 	chMap, ok := repo.Stars[userID]
@@ -1232,7 +1232,7 @@ func (repo *TestRepository) GetStaredChannels(ctx context.Context, userID uuid.U
 	return result, nil
 }
 
-func (repo *TestRepository) GetFileMeta(ctx context.Context, fileID uuid.UUID) (*model.FileMeta, error) {
+func (repo *TestRepository) GetFileMeta(_ context.Context, fileID uuid.UUID) (*model.FileMeta, error) {
 	if fileID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1245,7 +1245,7 @@ func (repo *TestRepository) GetFileMeta(ctx context.Context, fileID uuid.UUID) (
 	return &meta, nil
 }
 
-func (repo *TestRepository) DeleteFileMeta(ctx context.Context, fileID uuid.UUID) error {
+func (repo *TestRepository) DeleteFileMeta(_ context.Context, fileID uuid.UUID) error {
 	if fileID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1255,7 +1255,7 @@ func (repo *TestRepository) DeleteFileMeta(ctx context.Context, fileID uuid.UUID
 	return nil
 }
 
-func (repo *TestRepository) SaveFileMeta(ctx context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error {
+func (repo *TestRepository) SaveFileMeta(_ context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error {
 	repo.FilesLock.Lock()
 	repo.FilesACLLock.Lock()
 	meta.CreatedAt = time.Now()
@@ -1273,7 +1273,7 @@ func (repo *TestRepository) SaveFileMeta(ctx context.Context, meta *model.FileMe
 	return nil
 }
 
-func (repo *TestRepository) IsFileAccessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error) {
+func (repo *TestRepository) IsFileAccessible(_ context.Context, fileID, userID uuid.UUID) (bool, error) {
 	var allow bool
 	repo.FilesACLLock.RLock()
 	defer repo.FilesACLLock.RUnlock()
@@ -1289,7 +1289,7 @@ func (repo *TestRepository) IsFileAccessible(ctx context.Context, fileID, userID
 	return allow, nil
 }
 
-func (repo *TestRepository) CreateWebhook(ctx context.Context, name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
+func (repo *TestRepository) CreateWebhook(_ context.Context, name, description string, channelID, iconFileID, creatorID uuid.UUID, secret string) (model.Webhook, error) {
 	if len(name) == 0 || utf8.RuneCountInString(name) > 32 {
 		return nil, repository.ArgError("name", "Name must be non-empty and shorter than 33 characters")
 	}
@@ -1343,7 +1343,7 @@ func (repo *TestRepository) CreateWebhook(ctx context.Context, name, description
 	return &wb, nil
 }
 
-func (repo *TestRepository) UpdateWebhook(ctx context.Context, id uuid.UUID, args repository.UpdateWebhookArgs) error {
+func (repo *TestRepository) UpdateWebhook(_ context.Context, id uuid.UUID, args repository.UpdateWebhookArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1393,7 +1393,7 @@ func (repo *TestRepository) UpdateWebhook(ctx context.Context, id uuid.UUID, arg
 	return nil
 }
 
-func (repo *TestRepository) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+func (repo *TestRepository) DeleteWebhook(_ context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1413,7 +1413,7 @@ func (repo *TestRepository) DeleteWebhook(ctx context.Context, id uuid.UUID) err
 	return nil
 }
 
-func (repo *TestRepository) GetWebhook(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
+func (repo *TestRepository) GetWebhook(_ context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1429,7 +1429,7 @@ func (repo *TestRepository) GetWebhook(ctx context.Context, id uuid.UUID) (model
 	return &w, nil
 }
 
-func (repo *TestRepository) GetWebhookByBotUserID(ctx context.Context, id uuid.UUID) (model.Webhook, error) {
+func (repo *TestRepository) GetWebhookByBotUserID(_ context.Context, id uuid.UUID) (model.Webhook, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1455,7 +1455,7 @@ func (repo *TestRepository) GetWebhookByBotUserID(ctx context.Context, id uuid.U
 	return &w, nil
 }
 
-func (repo *TestRepository) GetAllWebhooks(ctx context.Context) ([]model.Webhook, error) {
+func (repo *TestRepository) GetAllWebhooks(_ context.Context) ([]model.Webhook, error) {
 	arr := make([]model.Webhook, 0)
 	repo.WebhooksLock.RLock()
 	repo.UsersLock.RLock()
@@ -1469,7 +1469,7 @@ func (repo *TestRepository) GetAllWebhooks(ctx context.Context) ([]model.Webhook
 	return arr, nil
 }
 
-func (repo *TestRepository) GetWebhooksByCreator(ctx context.Context, creatorID uuid.UUID) ([]model.Webhook, error) {
+func (repo *TestRepository) GetWebhooksByCreator(_ context.Context, creatorID uuid.UUID) ([]model.Webhook, error) {
 	arr := make([]model.Webhook, 0)
 	if creatorID == uuid.Nil {
 		return arr, nil

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -896,7 +896,7 @@ func (repo *TestRepository) GetChannelSubscriptions(ctx context.Context, query r
 	return result, nil
 }
 
-func (repo *TestRepository) CreateMessage(userID, channelID uuid.UUID, text string) (*model.Message, error) {
+func (repo *TestRepository) CreateMessage(ctx context.Context, userID, channelID uuid.UUID, text string) (*model.Message, error) {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -917,7 +917,7 @@ func (repo *TestRepository) CreateMessage(userID, channelID uuid.UUID, text stri
 	return m, nil
 }
 
-func (repo *TestRepository) UpdateMessage(messageID uuid.UUID, text string) error {
+func (repo *TestRepository) UpdateMessage(ctx context.Context, messageID uuid.UUID, text string) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -934,7 +934,7 @@ func (repo *TestRepository) UpdateMessage(messageID uuid.UUID, text string) erro
 	return nil
 }
 
-func (repo *TestRepository) DeleteMessage(messageID uuid.UUID) error {
+func (repo *TestRepository) DeleteMessage(ctx context.Context, messageID uuid.UUID) error {
 	if messageID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -948,7 +948,7 @@ func (repo *TestRepository) DeleteMessage(messageID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) GetMessageByID(messageID uuid.UUID) (*model.Message, error) {
+func (repo *TestRepository) GetMessageByID(ctx context.Context, messageID uuid.UUID) (*model.Message, error) {
 	repo.MessagesLock.RLock()
 	m, ok := repo.Messages[messageID]
 	repo.MessagesLock.RUnlock()
@@ -959,7 +959,7 @@ func (repo *TestRepository) GetMessageByID(messageID uuid.UUID) (*model.Message,
 	return &m, nil
 }
 
-func (repo *TestRepository) GetMessages(query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetMessages(ctx context.Context, query repository.MessagesQuery) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1061,7 +1061,7 @@ func (repo *TestRepository) GetMessages(query repository.MessagesQuery) (message
 	return
 }
 
-func (repo *TestRepository) GetUpdatedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetUpdatedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1087,7 +1087,7 @@ func (repo *TestRepository) GetUpdatedMessagesAfter(after time.Time, limit int) 
 	return
 }
 
-func (repo *TestRepository) GetDeletedMessagesAfter(after time.Time, limit int) (messages []*model.Message, more bool, err error) {
+func (repo *TestRepository) GetDeletedMessagesAfter(ctx context.Context, after time.Time, limit int) (messages []*model.Message, more bool, err error) {
 	tmp := make([]*model.Message, 0)
 
 	repo.MessagesLock.RLock()
@@ -1113,7 +1113,7 @@ func (repo *TestRepository) GetDeletedMessagesAfter(after time.Time, limit int) 
 	return
 }
 
-func (repo *TestRepository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
+func (repo *TestRepository) SetMessageUnreads(ctx context.Context, userNoticeableMap map[uuid.UUID]bool, messageID uuid.UUID) error {
 	if len(userNoticeableMap) == 0 {
 		return nil
 	}
@@ -1139,7 +1139,7 @@ func (repo *TestRepository) SetMessageUnreads(userNoticeableMap map[uuid.UUID]bo
 	return nil
 }
 
-func (repo *TestRepository) GetUnreadMessagesByUserID(userID uuid.UUID) ([]*model.Message, error) {
+func (repo *TestRepository) GetUnreadMessagesByUserID(ctx context.Context, userID uuid.UUID) ([]*model.Message, error) {
 	result := make([]*model.Message, 0)
 	repo.MessageUnreadsLock.RLock()
 	repo.MessagesLock.RLock()
@@ -1162,7 +1162,7 @@ func (repo *TestRepository) GetUnreadMessagesByUserID(userID uuid.UUID) ([]*mode
 	return result, nil
 }
 
-func (repo *TestRepository) DeleteUnreadsByChannelID(channelID, userID uuid.UUID) error {
+func (repo *TestRepository) DeleteUnreadsByChannelID(ctx context.Context, channelID, userID uuid.UUID) error {
 	if channelID == uuid.Nil || userID == uuid.Nil {
 		return repository.ErrNilID
 	}

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"math"
@@ -1189,7 +1190,7 @@ func (repo *TestRepository) DeleteUnreadsByChannelID(channelID, userID uuid.UUID
 	return nil
 }
 
-func (repo *TestRepository) AddStar(userID, channelID uuid.UUID) error {
+func (repo *TestRepository) AddStar(ctx context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1204,7 +1205,7 @@ func (repo *TestRepository) AddStar(userID, channelID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) RemoveStar(userID, channelID uuid.UUID) error {
+func (repo *TestRepository) RemoveStar(ctx context.Context, userID, channelID uuid.UUID) error {
 	if userID == uuid.Nil || channelID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1218,7 +1219,7 @@ func (repo *TestRepository) RemoveStar(userID, channelID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) GetStaredChannels(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetStaredChannels(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
 	repo.StarsLock.RLock()
 	result := make([]uuid.UUID, 0)
 	chMap, ok := repo.Stars[userID]

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -60,7 +60,7 @@ type TestRepository struct {
 	OgpCacheLock              sync.RWMutex
 }
 
-func (repo *TestRepository) GetPublicChannels() ([]*model.Channel, error) {
+func (repo *TestRepository) GetPublicChannels(ctx context.Context) ([]*model.Channel, error) {
 	repo.ChannelsLock.RLock()
 	defer repo.ChannelsLock.RUnlock()
 	result := make([]*model.Channel, 0)
@@ -726,7 +726,7 @@ func (repo *TestRepository) GetUserIDsByTagID(tagID uuid.UUID) ([]uuid.UUID, err
 	return users, nil
 }
 
-func (repo *TestRepository) CreateChannel(ch model.Channel, _ set.UUID, _ bool) (*model.Channel, error) {
+func (repo *TestRepository) CreateChannel(ctx context.Context, ch model.Channel, _ set.UUID, _ bool) (*model.Channel, error) {
 	ch.ID = uuid.Must(uuid.NewV7())
 	ch.IsPublic = true
 	ch.CreatedAt = time.Now()
@@ -738,7 +738,7 @@ func (repo *TestRepository) CreateChannel(ch model.Channel, _ set.UUID, _ bool) 
 	return &ch, nil
 }
 
-func (repo *TestRepository) UpdateChannel(channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
+func (repo *TestRepository) UpdateChannel(ctx context.Context, channelID uuid.UUID, args repository.UpdateChannelArgs) (*model.Channel, error) {
 	if channelID == uuid.Nil {
 		return nil, repository.ErrNilID
 	}
@@ -772,7 +772,7 @@ func (repo *TestRepository) UpdateChannel(channelID uuid.UUID, args repository.U
 	return &ch, nil
 }
 
-func (repo *TestRepository) GetChannel(channelID uuid.UUID) (*model.Channel, error) {
+func (repo *TestRepository) GetChannel(ctx context.Context, channelID uuid.UUID) (*model.Channel, error) {
 	repo.ChannelsLock.RLock()
 	ch, ok := repo.Channels[channelID]
 	repo.ChannelsLock.RUnlock()
@@ -782,7 +782,7 @@ func (repo *TestRepository) GetChannel(channelID uuid.UUID) (*model.Channel, err
 	return &ch, nil
 }
 
-func (repo *TestRepository) GetPrivateChannelMemberIDs(channelID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetPrivateChannelMemberIDs(ctx context.Context, channelID uuid.UUID) ([]uuid.UUID, error) {
 	result := make([]uuid.UUID, 0)
 	repo.PrivateChannelMembersLock.RLock()
 	for uid := range repo.PrivateChannelMembers[channelID] {
@@ -792,7 +792,7 @@ func (repo *TestRepository) GetPrivateChannelMemberIDs(channelID uuid.UUID) ([]u
 	return result, nil
 }
 
-func (repo *TestRepository) ChangeChannelSubscription(channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
+func (repo *TestRepository) ChangeChannelSubscription(ctx context.Context, channelID uuid.UUID, args repository.ChangeChannelSubscriptionArgs) (on []uuid.UUID, off []uuid.UUID, err error) {
 	if channelID == uuid.Nil {
 		return nil, nil, repository.ErrNilID
 	}
@@ -855,7 +855,7 @@ func (repo *TestRepository) ChangeChannelSubscription(channelID uuid.UUID, args 
 	return on, off, nil
 }
 
-func (repo *TestRepository) GetChannelSubscriptions(query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
+func (repo *TestRepository) GetChannelSubscriptions(ctx context.Context, query repository.ChannelSubscriptionQuery) ([]*model.UserSubscribeChannel, error) {
 	repo.ChannelSubscribesLock.Lock()
 	result := make([]*model.UserSubscribeChannel, 0)
 
@@ -1488,6 +1488,6 @@ func (repo *TestRepository) GetWebhooksByCreator(ctx context.Context, creatorID 
 	return arr, nil
 }
 
-func (repo *TestRepository) RecordChannelEvent(_ uuid.UUID, _ model.ChannelEventType, _ model.ChannelEventDetail, _ time.Time) error {
+func (repo *TestRepository) RecordChannelEvent(_ context.Context, _ uuid.UUID, _ model.ChannelEventType, _ model.ChannelEventDetail, _ time.Time) error {
 	return nil
 }

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -1232,7 +1232,7 @@ func (repo *TestRepository) GetStaredChannels(ctx context.Context, userID uuid.U
 	return result, nil
 }
 
-func (repo *TestRepository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, error) {
+func (repo *TestRepository) GetFileMeta(ctx context.Context, fileID uuid.UUID) (*model.FileMeta, error) {
 	if fileID == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -1245,7 +1245,7 @@ func (repo *TestRepository) GetFileMeta(fileID uuid.UUID) (*model.FileMeta, erro
 	return &meta, nil
 }
 
-func (repo *TestRepository) DeleteFileMeta(fileID uuid.UUID) error {
+func (repo *TestRepository) DeleteFileMeta(ctx context.Context, fileID uuid.UUID) error {
 	if fileID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -1255,7 +1255,7 @@ func (repo *TestRepository) DeleteFileMeta(fileID uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) SaveFileMeta(meta *model.FileMeta, acl []*model.FileACLEntry) error {
+func (repo *TestRepository) SaveFileMeta(ctx context.Context, meta *model.FileMeta, acl []*model.FileACLEntry) error {
 	repo.FilesLock.Lock()
 	repo.FilesACLLock.Lock()
 	meta.CreatedAt = time.Now()
@@ -1273,7 +1273,7 @@ func (repo *TestRepository) SaveFileMeta(meta *model.FileMeta, acl []*model.File
 	return nil
 }
 
-func (repo *TestRepository) IsFileAccessible(fileID, userID uuid.UUID) (bool, error) {
+func (repo *TestRepository) IsFileAccessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error) {
 	var allow bool
 	repo.FilesACLLock.RLock()
 	defer repo.FilesACLLock.RUnlock()

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -311,7 +311,7 @@ func (repo *TestRepository) UpdateUser(ctx context.Context, id uuid.UUID, args r
 	return nil
 }
 
-func (repo *TestRepository) CreateUserGroup(name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
+func (repo *TestRepository) CreateUserGroup(ctx context.Context, name, description, gType string, adminID, iconFileID uuid.UUID) (*model.UserGroup, error) {
 	g := model.UserGroup{
 		ID:          uuid.Must(uuid.NewV7()),
 		Name:        name,
@@ -349,7 +349,7 @@ func (repo *TestRepository) CreateUserGroup(name, description, gType string, adm
 	return &g, nil
 }
 
-func (repo *TestRepository) UpdateUserGroup(id uuid.UUID, args repository.UpdateUserGroupArgs) error {
+func (repo *TestRepository) UpdateUserGroup(ctx context.Context, id uuid.UUID, args repository.UpdateUserGroupArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -394,7 +394,7 @@ func (repo *TestRepository) UpdateUserGroup(id uuid.UUID, args repository.Update
 	return nil
 }
 
-func (repo *TestRepository) DeleteUserGroup(id uuid.UUID) error {
+func (repo *TestRepository) DeleteUserGroup(ctx context.Context, id uuid.UUID) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -413,7 +413,7 @@ func (repo *TestRepository) DeleteUserGroup(id uuid.UUID) error {
 	return nil
 }
 
-func (repo *TestRepository) GetUserGroup(id uuid.UUID) (*model.UserGroup, error) {
+func (repo *TestRepository) GetUserGroup(ctx context.Context, id uuid.UUID) (*model.UserGroup, error) {
 	if id == uuid.Nil {
 		return nil, repository.ErrNotFound
 	}
@@ -438,7 +438,7 @@ func (repo *TestRepository) GetUserGroup(id uuid.UUID) (*model.UserGroup, error)
 	return &g, nil
 }
 
-func (repo *TestRepository) GetUserGroupByName(name string) (*model.UserGroup, error) {
+func (repo *TestRepository) GetUserGroupByName(ctx context.Context, name string) (*model.UserGroup, error) {
 	if len(name) == 0 {
 		return nil, repository.ErrNotFound
 	}
@@ -464,7 +464,7 @@ func (repo *TestRepository) GetUserGroupByName(name string) (*model.UserGroup, e
 	return nil, repository.ErrNotFound
 }
 
-func (repo *TestRepository) GetUserBelongingGroupIDs(userID uuid.UUID) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserBelongingGroupIDs(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error) {
 	groups := make([]uuid.UUID, 0)
 	if userID == uuid.Nil {
 		return groups, nil
@@ -482,7 +482,7 @@ func (repo *TestRepository) GetUserBelongingGroupIDs(userID uuid.UUID) ([]uuid.U
 	return groups, nil
 }
 
-func (repo *TestRepository) GetAllUserGroups() ([]*model.UserGroup, error) {
+func (repo *TestRepository) GetAllUserGroups(ctx context.Context) ([]*model.UserGroup, error) {
 	groups := make([]*model.UserGroup, 0)
 	repo.UserGroupsLock.RLock()
 	repo.UserGroupAdminsLock.Lock()
@@ -505,7 +505,7 @@ func (repo *TestRepository) GetAllUserGroups() ([]*model.UserGroup, error) {
 	return groups, nil
 }
 
-func (repo *TestRepository) AddUserToGroup(userID, groupID uuid.UUID, _ string) error {
+func (repo *TestRepository) AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID, _ string) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -530,7 +530,7 @@ func (repo *TestRepository) AddUserToGroup(userID, groupID uuid.UUID, _ string) 
 	return nil
 }
 
-func (repo *TestRepository) RemoveUserFromGroup(userID, groupID uuid.UUID) error {
+func (repo *TestRepository) RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -552,7 +552,7 @@ func (repo *TestRepository) RemoveUserFromGroup(userID, groupID uuid.UUID) error
 	return nil
 }
 
-func (repo *TestRepository) AddUserToGroupAdmin(userID, groupID uuid.UUID) error {
+func (repo *TestRepository) AddUserToGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}
@@ -573,7 +573,7 @@ func (repo *TestRepository) AddUserToGroupAdmin(userID, groupID uuid.UUID) error
 	return nil
 }
 
-func (repo *TestRepository) RemoveUserFromGroupAdmin(userID, groupID uuid.UUID) error {
+func (repo *TestRepository) RemoveUserFromGroupAdmin(ctx context.Context, userID, groupID uuid.UUID) error {
 	if userID == uuid.Nil || groupID == uuid.Nil {
 		return repository.ErrNilID
 	}

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -92,11 +92,11 @@ func NewTestRepository() *TestRepository {
 		Webhooks:              map[uuid.UUID]model.WebhookBot{},
 		OgpCache:              map[int]model.OgpCache{},
 	}
-	_, _ = r.CreateUser(repository.CreateUserArgs{Name: "traq", Password: "traq", Role: role.Admin})
+	_, _ = r.CreateUser(context.TODO(), repository.CreateUserArgs{Name: "traq", Password: "traq", Role: role.Admin})
 	return r
 }
 
-func (repo *TestRepository) CreateUser(args repository.CreateUserArgs) (model.UserInfo, error) {
+func (repo *TestRepository) CreateUser(ctx context.Context, args repository.CreateUserArgs) (model.UserInfo, error) {
 	repo.UsersLock.Lock()
 	defer repo.UsersLock.Unlock()
 
@@ -137,7 +137,7 @@ func (repo *TestRepository) CreateUser(args repository.CreateUserArgs) (model.Us
 	return &user, nil
 }
 
-func (repo *TestRepository) GetUser(id uuid.UUID, _ bool) (model.UserInfo, error) {
+func (repo *TestRepository) GetUser(ctx context.Context, id uuid.UUID, _ bool) (model.UserInfo, error) {
 	repo.UsersLock.RLock()
 	u, ok := repo.Users[id]
 	repo.UsersLock.RUnlock()
@@ -147,7 +147,7 @@ func (repo *TestRepository) GetUser(id uuid.UUID, _ bool) (model.UserInfo, error
 	return &u, nil
 }
 
-func (repo *TestRepository) GetUserByName(name string, _ bool) (model.UserInfo, error) {
+func (repo *TestRepository) GetUserByName(ctx context.Context, name string, _ bool) (model.UserInfo, error) {
 	repo.UsersLock.RLock()
 	defer repo.UsersLock.RUnlock()
 	for _, u := range repo.Users {
@@ -159,7 +159,7 @@ func (repo *TestRepository) GetUserByName(name string, _ bool) (model.UserInfo, 
 	return nil, repository.ErrNotFound
 }
 
-func (repo *TestRepository) GetUsers(query repository.UsersQuery) ([]model.UserInfo, error) {
+func (repo *TestRepository) GetUsers(ctx context.Context, query repository.UsersQuery) ([]model.UserInfo, error) {
 	result := make([]model.UserInfo, 0, len(repo.Users))
 	repo.UsersLock.RLock()
 	repo.PrivateChannelMembersLock.RLock()
@@ -207,7 +207,7 @@ func (repo *TestRepository) GetUsers(query repository.UsersQuery) ([]model.UserI
 	return result, nil
 }
 
-func (repo *TestRepository) GetUserIDs(query repository.UsersQuery) ([]uuid.UUID, error) {
+func (repo *TestRepository) GetUserIDs(ctx context.Context, query repository.UsersQuery) ([]uuid.UUID, error) {
 	ids := make([]uuid.UUID, 0)
 	repo.UsersLock.RLock()
 	repo.PrivateChannelMembersLock.RLock()
@@ -254,14 +254,14 @@ func (repo *TestRepository) GetUserIDs(query repository.UsersQuery) ([]uuid.UUID
 	return ids, nil
 }
 
-func (repo *TestRepository) UserExists(id uuid.UUID) (bool, error) {
+func (repo *TestRepository) UserExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	repo.UsersLock.RLock()
 	_, ok := repo.Users[id]
 	repo.UsersLock.RUnlock()
 	return ok, nil
 }
 
-func (repo *TestRepository) UpdateUser(id uuid.UUID, args repository.UpdateUserArgs) error {
+func (repo *TestRepository) UpdateUser(ctx context.Context, id uuid.UUID, args repository.UpdateUserArgs) error {
 	if id == uuid.Nil {
 		return repository.ErrNilID
 	}

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -3,6 +3,7 @@ package twemoji
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -122,7 +123,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 			name = replacedName
 		}
 
-		s, err := repo.GetStampByName(name)
+		s, err := repo.GetStampByName(context.TODO(), name)
 		if err != nil && err != repository.ErrNotFound {
 			return err
 		}
@@ -134,7 +135,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 				return err
 			}
 
-			s, err := repo.CreateStamp(repository.CreateStampArgs{
+			s, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{
 				Name:      name,
 				FileID:    meta.GetID(),
 				CreatorID: uuid.Nil,
@@ -156,7 +157,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 				return err
 			}
 
-			if err := repo.UpdateStamp(s.ID, repository.UpdateStampArgs{
+			if err := repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{
 				FileID: optional.From(meta.GetID()),
 			}); err != nil {
 				return err


### PR DESCRIPTION
Repository層で`ctx`を受け取るようにしました。
コミットは基本的にRepository別に分かれているはずです。
呼び出し側では、`ctx`が利用可能であったとしても、一旦`context.TODO()`を使うようにしています。今後適切なctxに置き換えていくつもりです