### PR TITLE
contextの伝播

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -115,7 +115,7 @@ func filePruneCommand() *cobra.Command {
 			for _, file := range files {
 				logger.Sugar().Infof("%s - %s", file.ID, file.CreatedAt)
 				if !dryRun {
-					if err := fm.Delete(file.ID); err != nil {
+					if err := fm.Delete(context.Background(), file.ID); err != nil {
 						logger.Fatal(err.Error())
 					}
 				}
@@ -390,7 +390,7 @@ func genGroupImages() *cobra.Command {
 			logger.Info(fmt.Sprintf("Generating default images for %v group(s)", len(groups)))
 
 			for _, group := range groups {
-				iconFileID, err := file.GenerateIconFile(fm, group.Name)
+				iconFileID, err := file.GenerateIconFile(context.Background(), fm, group.Name)
 				if err != nil {
 					logger.Fatal("failed to generate image", zap.Stringer("gid", group.ID), zap.String("group", group.Name), zap.Error(err))
 				}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -394,7 +394,7 @@ func genGroupImages() *cobra.Command {
 				if err != nil {
 					logger.Fatal("failed to generate image", zap.Stringer("gid", group.ID), zap.String("group", group.Name), zap.Error(err))
 				}
-				if err := repo.UpdateUserGroup(context.TODO(), group.ID, repository.UpdateUserGroupArgs{Icon: optional.From(iconFileID)}); err != nil {
+				if err := repo.UpdateUserGroup(context.Background(), group.ID, repository.UpdateUserGroupArgs{Icon: optional.From(iconFileID)}); err != nil {
 					logger.Fatal("failed to update user group", zap.Stringer("gid", group.ID), zap.String("group", group.Name), zap.Error(err))
 				}
 			}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -107,7 +107,7 @@ func serveCommand() *cobra.Command {
 				logger.Info("data initializing...")
 
 				// システムユーザーロール投入
-				if err := repo.CreateUserRoles(context.TODO(), role.SystemRoleModels()...); err != nil {
+				if err := repo.CreateUserRoles(context.Background(), role.SystemRoleModels()...); err != nil {
 					logger.Fatal("failed to init system user roles", zap.Error(err))
 				}
 				if err := server.SS.RBAC.Reload(); err != nil {
@@ -119,7 +119,7 @@ func serveCommand() *cobra.Command {
 				if err != nil {
 					logger.Fatal("failed to generate icon file", zap.Error(err))
 				}
-				u, err := repo.CreateUser(context.TODO(), repository.CreateUserArgs{
+				u, err := repo.CreateUser(context.Background(), repository.CreateUserArgs{
 					Name:       "traq",
 					Password:   "traq",
 					Role:       role.Admin,
@@ -188,7 +188,7 @@ func (s *Server) Start(address string) error {
 		for ev := range sub.Receiver {
 			userID := ev.Fields["user_id"].(uuid.UUID)
 			datetime := ev.Fields["datetime"].(time.Time)
-			_ = s.Repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{LastOnline: optional.From(datetime)})
+			_ = s.Repo.UpdateUser(context.Background(), userID, repository.UpdateUserArgs{LastOnline: optional.From(datetime)})
 		}
 	}()
 	s.SS.StampThrottler.Start()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -132,7 +132,7 @@ func serveCommand() *cobra.Command {
 				}
 
 				// generalチャンネル作成
-				if ch, err := server.SS.ChannelManager.CreatePublicChannel("general", uuid.Nil, uuid.Nil); err == nil {
+				if ch, err := server.SS.ChannelManager.CreatePublicChannel(context.Background(), "general", uuid.Nil, uuid.Nil); err == nil {
 					logger.Info("#general was created", zap.Stringer("cid", ch.ID))
 				} else {
 					logger.Error("failed to init general channel", zap.Error(err))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -115,7 +115,7 @@ func serveCommand() *cobra.Command {
 				}
 
 				// 管理者ユーザーの作成
-				fid, err := file.GenerateIconFile(server.SS.FileManager, "traq")
+				fid, err := file.GenerateIconFile(context.Background(), server.SS.FileManager, "traq")
 				if err != nil {
 					logger.Fatal("failed to generate icon file", zap.Error(err))
 				}

--- a/repository/gorm/oauth2.go
+++ b/repository/gorm/oauth2.go
@@ -71,7 +71,7 @@ func (repo *Repository) UpdateClient(ctx context.Context, clientID string, args 
 		}
 		if args.DeveloperID.Valid {
 			// 作成者検証
-			user, err := repo.GetUser(context.TODO(), args.DeveloperID.V, false)
+			user, err := repo.GetUser(ctx, args.DeveloperID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.DeveloperID", "the Developer is not found")

--- a/repository/gorm/stamp_palette.go
+++ b/repository/gorm/stamp_palette.go
@@ -43,7 +43,7 @@ func (repo *Repository) CreateStampPalette(ctx context.Context, name, descriptio
 			return repository.ArgError("stamps", "stamps must be 0-200")
 		}
 		// スタンプ存在チェック
-		if err = repo.ExistStamps(context.TODO(), stamps); err != nil {
+		if err = repo.ExistStamps(ctx, stamps); err != nil {
 			return err
 		}
 
@@ -94,7 +94,7 @@ func (repo *Repository) UpdateStampPalette(ctx context.Context, id uuid.UUID, ar
 			if err := vd.Validate(uuids, validator.StampPaletteStampsRuleNotNil...); err != nil {
 				return repository.ArgError("args.Stamps", "stamps must be 0-200")
 			}
-			if err := repo.ExistStamps(context.TODO(), args.Stamps); err != nil {
+			if err := repo.ExistStamps(ctx, args.Stamps); err != nil {
 				return err
 			}
 			changes["stamps"] = args.Stamps

--- a/repository/gorm/webhook.go
+++ b/repository/gorm/webhook.go
@@ -122,7 +122,7 @@ func (repo *Repository) UpdateWebhook(ctx context.Context, id uuid.UUID, args re
 		}
 		if args.CreatorID.Valid {
 			// 作成者検証
-			user, err := repo.GetUser(context.TODO(), args.CreatorID.V, false)
+			user, err := repo.GetUser(ctx, args.CreatorID.V, false)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return repository.ArgError("args.CreatorID", "the Creator is not found")

--- a/router/auth/provider.go
+++ b/router/auth/provider.go
@@ -139,7 +139,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// ユーザーアカウント状態を確認
-				user, err := repo.GetUser(context.TODO(), sess.UserID(), false)
+				user, err := repo.GetUser(c.Request().Context(), sess.UserID(), false)
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
@@ -148,7 +148,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// アカウントにリンク
-				if err := repo.LinkExternalUserAccount(context.TODO(), user.GetID(), repository.LinkExternalUserAccountArgs{
+				if err := repo.LinkExternalUserAccount(c.Request().Context(), user.GetID(), repository.LinkExternalUserAccountArgs{
 					ProviderName: tu.GetProviderName(),
 					ExternalID:   tu.GetID(),
 					Extra:        model.JSON{"externalName": tu.GetRawName()},
@@ -178,7 +178,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 			return herror.BadRequest("You have already logged in. Please logout once.")
 		}
 
-		user, err := repo.GetUserByExternalID(context.TODO(), tu.GetProviderName(), tu.GetID(), false)
+		user, err := repo.GetUserByExternalID(c.Request().Context(), tu.GetProviderName(), tu.GetID(), false)
 		if err != nil {
 			if err != repository.ErrNotFound {
 				return herror.InternalServerError(err)
@@ -209,14 +209,14 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 			}
 			if args.IconFileID == uuid.Nil {
-				fid, err := file.GenerateIconFile(context.TODO(), fm, tu.GetName())
+				fid, err := file.GenerateIconFile(c.Request().Context(), fm, tu.GetName())
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
 				args.IconFileID = fid
 			}
 
-			user, err = repo.CreateUser(context.TODO(), args)
+			user, err = repo.CreateUser(c.Request().Context(), args)
 			if err != nil {
 				if err == repository.ErrAlreadyExists {
 					return herror.Conflict("name conflicts") // TODO 名前被りをどうするか
@@ -269,7 +269,7 @@ func processProfileIcon(m file.Manager, src []byte) (uuid.UUID, error) {
 	_ = png.Encode(b, img)
 
 	// ファイル保存
-	f, err := m.Save(context.TODO(), file.SaveArgs{
+	f, err := m.Save(context.Background(), file.SaveArgs{
 		FileName:  "icon",
 		FileSize:  int64(b.Len()),
 		MimeType:  consts.MimeImagePNG,

--- a/router/auth/provider.go
+++ b/router/auth/provider.go
@@ -209,7 +209,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 			}
 			if args.IconFileID == uuid.Nil {
-				fid, err := file.GenerateIconFile(fm, tu.GetName())
+				fid, err := file.GenerateIconFile(context.TODO(), fm, tu.GetName())
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
@@ -269,7 +269,7 @@ func processProfileIcon(m file.Manager, src []byte) (uuid.UUID, error) {
 	_ = png.Encode(b, img)
 
 	// ファイル保存
-	f, err := m.Save(file.SaveArgs{
+	f, err := m.Save(context.TODO(), file.SaveArgs{
 		FileName:  "icon",
 		FileSize:  int64(b.Len()),
 		MimeType:  consts.MimeImagePNG,

--- a/router/middlewares/access_control.go
+++ b/router/middlewares/access_control.go
@@ -136,7 +136,7 @@ func CheckFileAccessPerm(fm file.Manager) echo.MiddlewareFunc {
 			}
 
 			// アクセス権確認
-			if ok, err := fm.Accessible(f.GetID(), userID); err != nil {
+			if ok, err := fm.Accessible(c.Request().Context(), f.GetID(), userID); err != nil {
 				return herror.InternalServerError(err)
 			} else if !ok {
 				return herror.Forbidden()

--- a/router/middlewares/access_control.go
+++ b/router/middlewares/access_control.go
@@ -172,7 +172,7 @@ func CheckMessageAccessPerm(cm channel.Manager) echo.MiddlewareFunc {
 			channelID := c.Get(consts.KeyParamMessage).(message.Message).GetChannelID()
 
 			// アクセス権確認
-			if ok, err := cm.IsChannelAccessibleToUser(userID, channelID); err != nil {
+			if ok, err := cm.IsChannelAccessibleToUser(c.Request().Context(), userID, channelID); err != nil {
 				return herror.InternalServerError(err)
 			} else if !ok {
 				return herror.NotFound()
@@ -191,7 +191,7 @@ func CheckChannelAccessPerm(cm channel.Manager) echo.MiddlewareFunc {
 			ch := c.Get(consts.KeyParamChannel).(*model.Channel)
 
 			// アクセス権確認
-			if ok, err := cm.IsChannelAccessibleToUser(userID, ch.ID); err != nil {
+			if ok, err := cm.IsChannelAccessibleToUser(c.Request().Context(), userID, ch.ID); err != nil {
 				return herror.InternalServerError(err)
 			} else if !ok {
 				return herror.NotFound()

--- a/router/middlewares/no_login.go
+++ b/router/middlewares/no_login.go
@@ -1,8 +1,6 @@
 package middlewares
 
 import (
-	"context"
-
 	"github.com/labstack/echo/v4"
 
 	"github.com/traPtitech/traQ/repository"
@@ -23,7 +21,7 @@ func NoLogin(sessStore session.Store, repo repository.Repository) echo.Middlewar
 				return herror.InternalServerError(err)
 			}
 			if sess != nil && sess.LoggedIn() {
-				user, err := repo.GetUser(context.TODO(), sess.UserID(), false)
+				user, err := repo.GetUser(c.Request().Context(), sess.UserID(), false)
 				if err != nil {
 					return herror.InternalServerError(err)
 				}

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -130,8 +130,8 @@ func (pr *ParamRetriever) ChannelID() echo.MiddlewareFunc {
 
 // FileID リクエストURLの`fileID`パラメータからFileを取り出す
 func (pr *ParamRetriever) FileID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamFileID, consts.KeyParamFile, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.fm.Get(v)
+	return pr.byUUID(consts.ParamFileID, consts.KeyParamFile, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.fm.Get(c.Request().Context(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -101,7 +101,7 @@ func (pr *ParamRetriever) GroupID() echo.MiddlewareFunc {
 // MessageID リクエストURLの`messageID`パラメータからMessageを取り出す
 func (pr *ParamRetriever) MessageID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamMessageID, consts.KeyParamMessage, func(c echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.mm.Get(v)
+		return pr.mm.Get(c.Request().Context(), v)
 	})
 }
 

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -1,8 +1,6 @@
 package middlewares
 
 import (
-	"context"
-
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 
@@ -95,35 +93,35 @@ func (pr *ParamRetriever) error(err error) error {
 
 // GroupID リクエストURLの`groupID`パラメータからGroupを取り出す
 func (pr *ParamRetriever) GroupID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamGroupID, consts.KeyParamGroup, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetUserGroup(context.TODO(), v)
+	return pr.byUUID(consts.ParamGroupID, consts.KeyParamGroup, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetUserGroup(c.Request().Context(), v)
 	})
 }
 
 // MessageID リクエストURLの`messageID`パラメータからMessageを取り出す
 func (pr *ParamRetriever) MessageID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamMessageID, consts.KeyParamMessage, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamMessageID, consts.KeyParamMessage, func(c echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.mm.Get(v)
 	})
 }
 
 // ClientID リクエストURLの`clientID`パラメータからOAuth2Clientを取り出す
 func (pr *ParamRetriever) ClientID() echo.MiddlewareFunc {
-	return pr.byString(consts.ParamClientID, consts.KeyParamClient, func(_ echo.Context, v string) (interface{}, error) {
-		return pr.repo.GetClient(context.TODO(), v)
+	return pr.byString(consts.ParamClientID, consts.KeyParamClient, func(c echo.Context, v string) (interface{}, error) {
+		return pr.repo.GetClient(c.Request().Context(), v)
 	})
 }
 
 // BotID リクエストURLの`botID`パラメータからBotを取り出す
 func (pr *ParamRetriever) BotID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamBotID, consts.KeyParamBot, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetBotByID(context.TODO(), v)
+	return pr.byUUID(consts.ParamBotID, consts.KeyParamBot, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetBotByID(c.Request().Context(), v)
 	})
 }
 
 // ChannelID リクエストURLの`channelID`パラメータからChannelを取り出す
 func (pr *ParamRetriever) ChannelID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamChannelID, consts.KeyParamChannel, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
+	return pr.byUUID(consts.ParamChannelID, consts.KeyParamChannel, func(c echo.Context, v uuid.UUID) (interface{}, error) {
 		return pr.cm.GetChannel(v)
 	})
 }
@@ -137,45 +135,45 @@ func (pr *ParamRetriever) FileID() echo.MiddlewareFunc {
 
 // WebhookID リクエストURLの`webhookID`パラメータからBotを取り出す
 func (pr *ParamRetriever) WebhookID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamWebhookID, consts.KeyParamWebhook, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetWebhook(context.TODO(), v)
+	return pr.byUUID(consts.ParamWebhookID, consts.KeyParamWebhook, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetWebhook(c.Request().Context(), v)
 	})
 }
 
 // StampID リクエストURLの`stampID`パラメータからStampを取り出します
 func (pr *ParamRetriever) StampID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
-		return pr.checkOnlyByUUID(consts.ParamStampID, func(_ echo.Context, v uuid.UUID) (bool, error) {
-			return pr.repo.StampExists(context.TODO(), v)
+		return pr.checkOnlyByUUID(consts.ParamStampID, func(c echo.Context, v uuid.UUID) (bool, error) {
+			return pr.repo.StampExists(c.Request().Context(), v)
 		})
 	}
-	return pr.byUUID(consts.ParamStampID, consts.KeyParamStamp, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetStamp(context.TODO(), v)
+	return pr.byUUID(consts.ParamStampID, consts.KeyParamStamp, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetStamp(c.Request().Context(), v)
 	})
 }
 
 // StampPalettesID リクエストURLの`paletteID`パラメータからStampPaletteを取り出す
 func (pr *ParamRetriever) StampPalettesID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamStampPaletteID, consts.KeyParamStampPalette, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetStampPalette(context.TODO(), v)
+	return pr.byUUID(consts.ParamStampPaletteID, consts.KeyParamStampPalette, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetStampPalette(c.Request().Context(), v)
 	})
 }
 
 // UserID リクエストURLの`userID`パラメータからUserを取り出す
 func (pr *ParamRetriever) UserID(checkOnly bool) echo.MiddlewareFunc {
 	if checkOnly {
-		return pr.checkOnlyByUUID(consts.ParamUserID, func(_ echo.Context, v uuid.UUID) (bool, error) {
-			return pr.repo.UserExists(context.TODO(), v)
+		return pr.checkOnlyByUUID(consts.ParamUserID, func(c echo.Context, v uuid.UUID) (bool, error) {
+			return pr.repo.UserExists(c.Request().Context(), v)
 		})
 	}
-	return pr.byUUID(consts.ParamUserID, consts.KeyParamUser, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetUser(context.TODO(), v, true)
+	return pr.byUUID(consts.ParamUserID, consts.KeyParamUser, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetUser(c.Request().Context(), v, true)
 	})
 }
 
 // ClipFolderID リクエストURLの`folderID`パラメータからClipFolderを取り出す
 func (pr *ParamRetriever) ClipFolderID() echo.MiddlewareFunc {
-	return pr.byUUID(consts.ParamClipFolderID, consts.KeyParamClipFolder, func(_ echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.repo.GetClipFolder(context.TODO(), v)
+	return pr.byUUID(consts.ParamClipFolderID, consts.KeyParamClipFolder, func(c echo.Context, v uuid.UUID) (interface{}, error) {
+		return pr.repo.GetClipFolder(c.Request().Context(), v)
 	})
 }

--- a/router/middlewares/param_retriever.go
+++ b/router/middlewares/param_retriever.go
@@ -122,7 +122,7 @@ func (pr *ParamRetriever) BotID() echo.MiddlewareFunc {
 // ChannelID リクエストURLの`channelID`パラメータからChannelを取り出す
 func (pr *ParamRetriever) ChannelID() echo.MiddlewareFunc {
 	return pr.byUUID(consts.ParamChannelID, consts.KeyParamChannel, func(c echo.Context, v uuid.UUID) (interface{}, error) {
-		return pr.cm.GetChannel(v)
+		return pr.cm.GetChannel(c.Request().Context(), v)
 	})
 }
 

--- a/router/middlewares/user_authenticate.go
+++ b/router/middlewares/user_authenticate.go
@@ -31,7 +31,7 @@ func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.
 				}
 
 				// OAuth2 Token検証
-				token, err := repo.GetTokenByAccess(context.TODO(), ah[l+1:])
+				token, err := repo.GetTokenByAccess(c.Request().Context(), ah[l+1:])
 				if err != nil {
 					switch err {
 					case repository.ErrNotFound:
@@ -68,7 +68,7 @@ func UserAuthenticate(repo repository.Repository, sessStore session.Store) echo.
 			}
 
 			// ユーザー取得
-			user, err := repo.GetUser(context.TODO(), uid, true)
+			user, err := repo.GetUser(c.Request().Context(), uid, true)
 			if err != nil {
 				return herror.InternalServerError(err)
 			}

--- a/router/oauth2/authorization_endpoint.go
+++ b/router/oauth2/authorization_endpoint.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -80,7 +79,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 	req.AccessTime = time.Now()
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), req.ClientID)
+	client, err := h.Repo.GetClient(c.Request().Context(), req.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -169,7 +168,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 		return c.Redirect(http.StatusFound, redirectURI.String())
 	}
 	if se != nil {
-		u, err := h.Repo.GetUser(context.TODO(), se.UserID(), false)
+		u, err := h.Repo.GetUser(c.Request().Context(), se.UserID(), false)
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
@@ -194,7 +193,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			redirectURI.RawQuery = q.Encode()
 			return c.Redirect(http.StatusFound, redirectURI.String())
 		}
-		tokens, err := h.Repo.GetTokensByUser(context.TODO(), se.UserID())
+		tokens, err := h.Repo.GetTokensByUser(c.Request().Context(), se.UserID())
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
@@ -236,7 +235,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			CodeChallengeMethod: req.CodeChallengeMethod,
 			Nonce:               req.Nonce,
 		}
-		if err := h.Repo.SaveAuthorize(context.TODO(), data); err != nil {
+		if err := h.Repo.SaveAuthorize(c.Request().Context(), data); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()
@@ -328,7 +327,7 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), reqAuth.ClientID)
+	client, err := h.Repo.GetClient(c.Request().Context(), reqAuth.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -376,7 +375,7 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 			CodeChallengeMethod: reqAuth.CodeChallengeMethod,
 			Nonce:               reqAuth.Nonce,
 		}
-		if err := h.Repo.SaveAuthorize(context.TODO(), data); err != nil {
+		if err := h.Repo.SaveAuthorize(c.Request().Context(), data); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()

--- a/router/oauth2/revoke_token_endpoint.go
+++ b/router/oauth2/revoke_token_endpoint.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -22,10 +21,10 @@ func (h *Handler) RevokeTokenEndpointHandler(c echo.Context) error {
 		return c.NoContent(http.StatusOK)
 	}
 
-	if err := h.Repo.DeleteTokenByAccess(context.TODO(), req.Token); err != nil {
+	if err := h.Repo.DeleteTokenByAccess(c.Request().Context(), req.Token); err != nil {
 		return herror.InternalServerError(err)
 	}
-	if err := h.Repo.DeleteTokenByRefresh(context.TODO(), req.Token); err != nil {
+	if err := h.Repo.DeleteTokenByRefresh(c.Request().Context(), req.Token); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/oauth2/token_endpoint.go
+++ b/router/oauth2/token_endpoint.go
@@ -123,7 +123,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 	}
 
 	// 認可コード確認
-	code, err := h.Repo.GetAuthorize(context.TODO(), req.Code)
+	code, err := h.Repo.GetAuthorize(c.Request().Context(), req.Code)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -134,7 +134,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 		}
 	}
 	// 認可コードは２回使えない
-	if err := h.Repo.DeleteAuthorize(context.TODO(), code.Code); err != nil {
+	if err := h.Repo.DeleteAuthorize(c.Request().Context(), code.Code); err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}
@@ -143,7 +143,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), code.ClientID)
+	client, err := h.Repo.GetClient(c.Request().Context(), code.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -215,7 +215,7 @@ func (h *Handler) tokenEndpointPasswordHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), cid)
+	client, err := h.Repo.GetClient(c.Request().Context(), cid)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -230,7 +230,7 @@ func (h *Handler) tokenEndpointPasswordHandler(c echo.Context) error {
 	}
 
 	// ユーザー確認
-	user, err := h.Repo.GetUserByName(context.TODO(), req.Username, false)
+	user, err := h.Repo.GetUserByName(c.Request().Context(), req.Username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -285,7 +285,7 @@ func (h *Handler) tokenEndpointClientCredentialsHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), id)
+	client, err := h.Repo.GetClient(c.Request().Context(), id)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -343,7 +343,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 	}
 
 	// リフレッシュトークン確認
-	token, err := h.Repo.GetTokenByRefresh(context.TODO(), req.RefreshToken)
+	token, err := h.Repo.GetTokenByRefresh(c.Request().Context(), req.RefreshToken)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -355,7 +355,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(context.TODO(), token.ClientID)
+	client, err := h.Repo.GetClient(c.Request().Context(), token.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -398,7 +398,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}
 	// 旧リフレッシュトークン削除
-	if err := h.Repo.DeleteTokenByRefresh(context.TODO(), req.RefreshToken); err != nil {
+	if err := h.Repo.DeleteTokenByRefresh(c.Request().Context(), req.RefreshToken); err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
 	}

--- a/router/oauth2/token_endpoint.go
+++ b/router/oauth2/token_endpoint.go
@@ -51,7 +51,7 @@ func (h *Handler) TokenEndpointHandler(c echo.Context) error {
 	}
 }
 
-func (h *Handler) issueIDToken(client *model.OAuth2Client, token *model.OAuth2Token, userID uuid.UUID, nonce string) (string, error) {
+func (h *Handler) issueIDToken(ctx context.Context, client *model.OAuth2Client, token *model.OAuth2Token, userID uuid.UUID, nonce string) (string, error) {
 	// Base claims
 	claims := jwt.MapClaims{
 		"iss": h.Origin,
@@ -64,7 +64,7 @@ func (h *Handler) issueIDToken(client *model.OAuth2Client, token *model.OAuth2To
 		claims["nonce"] = nonce
 	}
 	// Extra claims according to scopes (profile)
-	userInfo, err := h.OIDC.GetUserInfo(userID, token.Scopes)
+	userInfo, err := h.OIDC.GetUserInfo(ctx, userID, token.Scopes)
 	if err != nil {
 		return "", err
 	}
@@ -73,11 +73,11 @@ func (h *Handler) issueIDToken(client *model.OAuth2Client, token *model.OAuth2To
 	return jwt2.Sign(claims)
 }
 
-func (h *Handler) issueToken(client *model.OAuth2Client, userID uuid.UUID, scopes, originalScopes model.AccessScopes, grantTypeRefreshAllowed bool, nonce string) (*tokenResponse, error) {
+func (h *Handler) issueToken(ctx context.Context, client *model.OAuth2Client, userID uuid.UUID, scopes, originalScopes model.AccessScopes, grantTypeRefreshAllowed bool, nonce string) (*tokenResponse, error) {
 	isOIDC := scopes.Contains("openid")
 	// OIDCの場合は、Refresh TokenのScopeの管理（主にoffline_access周り）が面倒なので、一律で発行しないことにする
 	refresh := h.IsRefreshEnabled && grantTypeRefreshAllowed && !isOIDC
-	token, err := h.Repo.IssueToken(context.TODO(), client, userID, client.RedirectURI, scopes, h.AccessTokenExp, refresh)
+	token, err := h.Repo.IssueToken(ctx, client, userID, client.RedirectURI, scopes, h.AccessTokenExp, refresh)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (h *Handler) issueToken(client *model.OAuth2Client, userID uuid.UUID, scope
 		res.RefreshToken = token.RefreshToken
 	}
 	if scopes.Contains("openid") {
-		idToken, err := h.issueIDToken(client, token, userID, nonce)
+		idToken, err := h.issueIDToken(ctx, client, token, userID, nonce)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (h *Handler) tokenEndpointAuthorizationCodeHandler(c echo.Context) error {
 	}
 
 	// トークン発行
-	res, err := h.issueToken(client, code.UserID, code.Scopes, code.OriginalScopes, true, code.Nonce)
+	res, err := h.issueToken(c.Request().Context(), client, code.UserID, code.Scopes, code.OriginalScopes, true, code.Nonce)
 	if err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
@@ -257,7 +257,7 @@ func (h *Handler) tokenEndpointPasswordHandler(c echo.Context) error {
 	}
 
 	// トークン発行
-	res, err := h.issueToken(client, user.GetID(), validScopes, reqScopes, true, "")
+	res, err := h.issueToken(c.Request().Context(), client, user.GetID(), validScopes, reqScopes, true, "")
 	if err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
@@ -315,7 +315,7 @@ func (h *Handler) tokenEndpointClientCredentialsHandler(c echo.Context) error {
 	}
 
 	// トークン発行
-	res, err := h.issueToken(client, uuid.Nil, validScopes, reqScopes, false, "")
+	res, err := h.issueToken(c.Request().Context(), client, uuid.Nil, validScopes, reqScopes, false, "")
 	if err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})
@@ -392,7 +392,7 @@ func (h *Handler) tokenEndpointRefreshTokenHandler(c echo.Context) error {
 	}
 
 	// トークン発行
-	res, err := h.issueToken(client, token.UserID, newScopes, token.Scopes, true, "")
+	res, err := h.issueToken(c.Request().Context(), client, token.UserID, newScopes, token.Scopes, true, "")
 	if err != nil {
 		h.L(c).Error(err.Error(), zap.Error(err))
 		return c.JSON(http.StatusInternalServerError, oauth2ErrorResponse{ErrorType: errServerError})

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -42,7 +42,7 @@ func ChangeUserIcon(p imaging2.Processor, c echo.Context, repo repository.Reposi
 // ServeUserIcon userのアイコン画像ファイルをレスポンスとして返す
 func ServeUserIcon(c echo.Context, fm file.Manager, user model.UserInfo) error {
 	// ファイルメタ取得
-	meta, err := fm.Get(user.GetIconFileID())
+	meta, err := fm.Get(c.Request().Context(), user.GetIconFileID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -2,7 +2,6 @@
 package utils
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,7 +31,7 @@ func ChangeUserIcon(p imaging2.Processor, c echo.Context, repo repository.Reposi
 	}
 
 	// アイコン変更
-	if err := repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{IconFileID: optional.From(iconID)}); err != nil {
+	if err := repo.UpdateUser(c.Request().Context(), userID, repository.UpdateUserArgs{IconFileID: optional.From(iconID)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -65,7 +64,7 @@ func ServeUserIcon(c echo.Context, fm file.Manager, user model.UserInfo) error {
 
 // ChangeUserPassword userIDのユーザーのパスワードを変更する
 func ChangeUserPassword(c echo.Context, repo repository.Repository, seStore session.Store, userID uuid.UUID, newPassword string) error {
-	if err := repo.UpdateUser(context.TODO(), userID, repository.UpdateUserArgs{Password: optional.From(newPassword)}); err != nil {
+	if err := repo.UpdateUser(c.Request().Context(), userID, repository.UpdateUserArgs{Password: optional.From(newPassword)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -96,7 +95,7 @@ func ServeFileThumbnail(c echo.Context, meta model.File, repo repository.Reposit
 		if errors.Is(err, storage.ErrFileNotFound) {
 			// サムネイルが実際には存在しないのでDBの情報を更新する
 			fileID := meta.GetID()
-			err := repo.DeleteFileThumbnail(context.TODO(), fileID, thumbnailType)
+			err := repo.DeleteFileThumbnail(c.Request().Context(), fileID, thumbnailType)
 			if err != nil {
 				logger.Warn("failed to delete thumbnail from database", zap.Error(err))
 				return herror.InternalServerError(err)

--- a/router/utils/process_image.go
+++ b/router/utils/process_image.go
@@ -110,7 +110,7 @@ func saveUploadImage(p imaging.Processor, c echo.Context, m file.Manager, name s
 	}
 
 	// ファイル保存
-	f, err := m.Save(args)
+	f, err := m.Save(c.Request().Context(), args)
 	if err != nil {
 		return uuid.Nil, herror.InternalServerError(err)
 	}

--- a/router/utils/replace_mapper.go
+++ b/router/utils/replace_mapper.go
@@ -17,7 +17,7 @@ type replaceMapperImpl struct {
 }
 
 func (m *replaceMapperImpl) Channel(path string) (uuid.UUID, bool) {
-	id := m.cm.PublicChannelTree().GetChannelIDFromPath(path)
+	id := m.cm.PublicChannelTree(context.Background()).GetChannelIDFromPath(path)
 	return id, id != uuid.Nil
 }
 

--- a/router/utils/replace_mapper.go
+++ b/router/utils/replace_mapper.go
@@ -22,7 +22,7 @@ func (m *replaceMapperImpl) Channel(path string) (uuid.UUID, bool) {
 }
 
 func (m *replaceMapperImpl) Group(name string) (uuid.UUID, bool) {
-	g, err := m.repo.GetUserGroupByName(context.TODO(), name)
+	g, err := m.repo.GetUserGroupByName(context.Background(), name)
 	if err != nil {
 		return uuid.Nil, false
 	}
@@ -30,7 +30,7 @@ func (m *replaceMapperImpl) Group(name string) (uuid.UUID, bool) {
 }
 
 func (m *replaceMapperImpl) User(name string) (uuid.UUID, bool) {
-	u, err := m.repo.GetUserByName(context.TODO(), name, false)
+	u, err := m.repo.GetUserByName(context.Background(), name, false)
 	if err != nil {
 		return uuid.Nil, false
 	}

--- a/router/utils/validator.go
+++ b/router/utils/validator.go
@@ -25,7 +25,7 @@ const (
 )
 
 func NewRequestValidateContext(c echo.Context) context.Context {
-	return context.WithValue(context.WithValue(context.Background(), repoctxKey, c.Get(consts.KeyRepo)), cmctxKey, c.Get(consts.KeyChannelManager))
+	return context.WithValue(context.WithValue(c.Request().Context(), repoctxKey, c.Get(consts.KeyRepo)), cmctxKey, c.Get(consts.KeyChannelManager))
 }
 
 // IsPublicChannelID 公開チャンネルのUUIDである
@@ -79,16 +79,16 @@ var IsActiveHumanUserID = vd.WithContext(func(ctx context.Context, value interfa
 	case nil:
 		return nil
 	case uuid.UUID:
-		u, err = repo.GetUser(context.TODO(), v, false)
+		u, err = repo.GetUser(ctx, v, false)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		u, err = repo.GetUser(context.TODO(), v.V, false)
+		u, err = repo.GetUser(ctx, v.V, false)
 	case string:
-		u, err = repo.GetUser(context.TODO(), uuid.FromStringOrNil(v), false)
+		u, err = repo.GetUser(ctx, uuid.FromStringOrNil(v), false)
 	case []byte:
-		u, err = repo.GetUser(context.TODO(), uuid.FromBytesOrNil(v), false)
+		u, err = repo.GetUser(ctx, uuid.FromBytesOrNil(v), false)
 	default:
 		return errors.New(errMessage)
 	}
@@ -122,16 +122,16 @@ var IsUserID = vd.WithContext(func(ctx context.Context, value interface{}) error
 	case nil:
 		return nil
 	case uuid.UUID:
-		ok, err = repo.UserExists(context.TODO(), v)
+		ok, err = repo.UserExists(ctx, v)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		ok, err = repo.UserExists(context.TODO(), v.V)
+		ok, err = repo.UserExists(ctx, v.V)
 	case string:
-		ok, err = repo.UserExists(context.TODO(), uuid.FromStringOrNil(v))
+		ok, err = repo.UserExists(ctx, uuid.FromStringOrNil(v))
 	case []byte:
-		ok, err = repo.UserExists(context.TODO(), uuid.FromBytesOrNil(v))
+		ok, err = repo.UserExists(ctx, uuid.FromBytesOrNil(v))
 	default:
 		return errors.New(errMessage)
 	}
@@ -161,16 +161,16 @@ var IsNotWebhookUserID = vd.WithContext(func(ctx context.Context, value interfac
 	case nil:
 		return nil
 	case uuid.UUID:
-		user, err = repo.GetUser(context.TODO(), v, false)
+		user, err = repo.GetUser(ctx, v, false)
 	case optional.Of[uuid.UUID]:
 		if !v.Valid {
 			return nil
 		}
-		user, err = repo.GetUser(context.TODO(), v.V, false)
+		user, err = repo.GetUser(ctx, v.V, false)
 	case string:
-		user, err = repo.GetUser(context.TODO(), uuid.FromStringOrNil(v), false)
+		user, err = repo.GetUser(ctx, uuid.FromStringOrNil(v), false)
 	case []byte:
-		user, err = repo.GetUser(context.TODO(), uuid.FromBytesOrNil(v), false)
+		user, err = repo.GetUser(ctx, uuid.FromBytesOrNil(v), false)
 	default:
 		return errors.New(errMessage)
 	}

--- a/router/utils/validator.go
+++ b/router/utils/validator.go
@@ -41,19 +41,19 @@ var IsPublicChannelID = vd.WithContext(func(ctx context.Context, value interface
 	case nil:
 		return nil
 	case uuid.UUID:
-		if !cm.IsPublicChannel(v) {
+		if !cm.IsPublicChannel(ctx, v) {
 			return errors.New(errMessage)
 		}
 	case optional.Of[uuid.UUID]:
-		if v.Valid && !cm.IsPublicChannel(v.V) {
+		if v.Valid && !cm.IsPublicChannel(ctx, v.V) {
 			return errors.New(errMessage)
 		}
 	case string:
-		if !cm.IsPublicChannel(uuid.FromStringOrNil(v)) {
+		if !cm.IsPublicChannel(ctx, uuid.FromStringOrNil(v)) {
 			return errors.New(errMessage)
 		}
 	case []byte:
-		if !cm.IsPublicChannel(uuid.FromBytesOrNil(v)) {
+		if !cm.IsPublicChannel(ctx, uuid.FromBytesOrNil(v)) {
 			return errors.New(errMessage)
 		}
 	default:

--- a/router/v1/files_test.go
+++ b/router/v1/files_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,7 +26,7 @@ func TestHandlers_GetFileByID(t *testing.T) {
 	file := env.mustMakeFile(t)
 	grantedUser := env.mustMakeUser(t, rand)
 	secureContent := "secure"
-	secureFile, err := env.FileManager.Save(file2.SaveArgs{
+	secureFile, err := env.FileManager.Save(context.TODO(), file2.SaveArgs{
 		FileName:  "secure",
 		FileSize:  int64(len(secureContent)),
 		MimeType:  "text/plain",
@@ -88,9 +89,9 @@ func TestHandlers_GetFileByID(t *testing.T) {
 
 	t.Run("Success with icon file", func(t *testing.T) {
 		t.Parallel()
-		iconFileID, err := file2.GenerateIconFile(env.FileManager, "test")
+		iconFileID, err := file2.GenerateIconFile(context.TODO(), env.FileManager, "test")
 		require.NoError(err)
-		iconFile, err := env.FileManager.Get(iconFileID)
+		iconFile, err := env.FileManager.Get(context.TODO(), iconFileID)
 		require.NoError(err)
 
 		e := env.makeExp(t)
@@ -156,7 +157,7 @@ func TestHandlers_GetThumbnailByID(t *testing.T) {
 	file := env.mustMakeFile(t)
 	grantedUser := env.mustMakeUser(t, rand)
 	secureContent := "secure"
-	secureFile, err := env.FileManager.Save(file2.SaveArgs{
+	secureFile, err := env.FileManager.Save(context.TODO(), file2.SaveArgs{
 		FileName:  "secure",
 		FileSize:  int64(len(secureContent)),
 		MimeType:  "text/plain",
@@ -166,7 +167,7 @@ func TestHandlers_GetThumbnailByID(t *testing.T) {
 		Src:       strings.NewReader(secureContent),
 	})
 	require.NoError(err)
-	iconFileID, err := file2.GenerateIconFile(env.FileManager, "test")
+	iconFileID, err := file2.GenerateIconFile(context.TODO(), env.FileManager, "test")
 	require.NoError(err)
 
 	t.Run("NotLoggedIn", func(t *testing.T) {

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -34,7 +34,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	}
 
 	// ファイルメタ取得
-	meta, err := h.FileManager.Get(user.GetIconFileID())
+	meta, err := h.FileManager.Get(c.Request().Context(), user.GetIconFileID())
 	if err != nil {
 		switch err {
 		case file.ErrNotFound:
@@ -80,7 +80,7 @@ func (h *Handlers) GetPublicEmojiCSS(c echo.Context) error {
 func (h *Handlers) GetPublicEmojiImage(c echo.Context) error {
 	s := getStampFromContext(c)
 
-	meta, err := h.FileManager.Get(s.FileID)
+	meta, err := h.FileManager.Get(c.Request().Context(), s.FileID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v1/public.go
+++ b/router/v1/public.go
@@ -23,7 +23,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	username := c.Param("username")
 
 	// ユーザー取得
-	user, err := h.Repo.GetUserByName(context.TODO(), username, false)
+	user, err := h.Repo.GetUserByName(c.Request().Context(), username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -116,9 +116,9 @@ func (c *EmojiCache) Purge() {
 	c.css.Purge()
 }
 
-func emojiJSONGenerator(repo repository.Repository) func(_ context.Context, _ struct{}) ([]byte, error) {
-	return func(_ context.Context, _ struct{}) ([]byte, error) {
-		stamps, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
+func emojiJSONGenerator(repo repository.Repository) func(ctx context.Context, _ struct{}) ([]byte, error) {
+	return func(ctx context.Context, _ struct{}) ([]byte, error) {
+		stamps, err := repo.GetAllStampsWithThumbnail(ctx, repository.StampTypeAll)
 		if err != nil {
 			return nil, err
 		}
@@ -139,9 +139,9 @@ func emojiJSONGenerator(repo repository.Repository) func(_ context.Context, _ st
 	}
 }
 
-func emojiCSSGenerator(repo repository.Repository) func(_ context.Context, _ struct{}) ([]byte, error) {
-	return func(_ context.Context, _ struct{}) ([]byte, error) {
-		stamps, err := repo.GetAllStampsWithThumbnail(context.TODO(), repository.StampTypeAll)
+func emojiCSSGenerator(repo repository.Repository) func(ctx context.Context, _ struct{}) ([]byte, error) {
+	return func(ctx context.Context, _ struct{}) ([]byte, error) {
+		stamps, err := repo.GetAllStampsWithThumbnail(ctx, repository.StampTypeAll)
 		if err != nil {
 			return nil, err
 		}

--- a/router/v1/public_test.go
+++ b/router/v1/public_test.go
@@ -18,7 +18,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 	t.Parallel()
 	env, _, require, _, _ := setup(t, common2)
 
-	fid, err := file.GenerateIconFile(env.FileManager, "test")
+	fid, err := file.GenerateIconFile(context.TODO(), env.FileManager, "test")
 	require.NoError(err)
 
 	testUser, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
@@ -40,7 +40,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 		t.Parallel()
 		_, require := assertAndRequire(t)
 
-		meta, err := env.FileManager.Get(testUser.GetIconFileID())
+		meta, err := env.FileManager.Get(context.TODO(), testUser.GetIconFileID())
 		require.NoError(err)
 		e := env.makeExp(t)
 		e.GET("/api/1.0/public/icon/{username}", testUser.GetName()).
@@ -54,7 +54,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 		t.Parallel()
 		_, require := assertAndRequire(t)
 
-		meta, err := env.FileManager.Get(testUser.GetIconFileID())
+		meta, err := env.FileManager.Get(context.TODO(), testUser.GetIconFileID())
 		require.NoError(err)
 
 		e := env.makeExp(t)

--- a/router/v1/router_test.go
+++ b/router/v1/router_test.go
@@ -165,7 +165,7 @@ func (env *Env) mustMakeUser(t *testing.T, userName string) model.UserInfo {
 func (env *Env) mustMakeFile(t *testing.T) model.File {
 	t.Helper()
 	buf := bytes.NewBufferString("test message")
-	f, err := env.FileManager.Save(file.SaveArgs{
+	f, err := env.FileManager.Save(context.TODO(), file.SaveArgs{
 		FileName: "test.txt",
 		FileSize: int64(buf.Len()),
 		FileType: model.FileTypeUserFile,

--- a/router/v3/activity.go
+++ b/router/v3/activity.go
@@ -42,6 +42,7 @@ func (r *GetActivityTimelineRequest) Validate() error {
 
 // GetActivityTimeline GET /activity/timeline
 func (h *Handlers) GetActivityTimeline(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 
 	var req GetActivityTimelineRequest
@@ -60,7 +61,7 @@ func (h *Handlers) GetActivityTimeline(c echo.Context) error {
 			query.ChannelsSubscribedByUser = userID
 		}
 
-		timeline, err := h.MessageManager.GetTimeline(query)
+		timeline, err := h.MessageManager.GetTimeline(ctx, query)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -74,7 +75,7 @@ func (h *Handlers) GetActivityTimeline(c echo.Context) error {
 	if !req.All {
 		query.SubscribedByUser = optional.From(userID)
 	}
-	messages, err := h.Repo.GetChannelLatestMessages(c.Request().Context(), query)
+	messages, err := h.Repo.GetChannelLatestMessages(ctx, query)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/activity.go
+++ b/router/v3/activity.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -75,7 +74,7 @@ func (h *Handlers) GetActivityTimeline(c echo.Context) error {
 	if !req.All {
 		query.SubscribedByUser = optional.From(userID)
 	}
-	messages, err := h.Repo.GetChannelLatestMessages(context.TODO(), query)
+	messages, err := h.Repo.GetChannelLatestMessages(c.Request().Context(), query)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -30,7 +30,7 @@ func (h *Handlers) GetBots(c echo.Context) error {
 		q = q.CreatedBy(getRequestUserID(c))
 	}
 
-	list, err := h.Repo.GetBots(context.TODO(), q)
+	list, err := h.Repo.GetBots(c.Request().Context(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -75,7 +75,7 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	if _, err := h.Repo.GetUserByName(context.TODO(), "BOT_"+req.Name, false); err == nil {
+	if _, err := h.Repo.GetUserByName(c.Request().Context(), "BOT_"+req.Name, false); err == nil {
 		return herror.Conflict("this name is already used")
 	} else if err != repository.ErrNotFound {
 		return herror.InternalServerError(err)
@@ -89,12 +89,12 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		initialState = model.BotActive
 	}
 
-	b, err := h.Repo.CreateBot(context.TODO(), req.Name, req.DisplayName, req.Description, iconFileID, getRequestUserID(c), model.BotMode(req.Mode), initialState, req.Endpoint)
+	b, err := h.Repo.CreateBot(c.Request().Context(), req.Name, req.DisplayName, req.Description, iconFileID, getRequestUserID(c), model.BotMode(req.Mode), initialState, req.Endpoint)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
-	t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
+	t, err := h.Repo.GetTokenByID(c.Request().Context(), b.AccessTokenID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -114,7 +114,7 @@ func (h *Handlers) GetBot(c echo.Context) error {
 			return herror.Forbidden()
 		}
 
-		t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
+		t, err := h.Repo.GetTokenByID(c.Request().Context(), b.AccessTokenID)
 		if err != nil {
 			switch err {
 			case repository.ErrNotFound:
@@ -124,7 +124,7 @@ func (h *Handlers) GetBot(c echo.Context) error {
 			}
 		}
 
-		ids, err := h.Repo.GetParticipatingChannelIDsByBot(context.TODO(), b.ID)
+		ids, err := h.Repo.GetParticipatingChannelIDsByBot(c.Request().Context(), b.ID)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -189,7 +189,7 @@ func (h *Handlers) EditBot(c echo.Context) error {
 		Bio:             req.Bio,
 	}
 
-	if err := h.Repo.UpdateBot(context.TODO(), b.ID, args); err != nil {
+	if err := h.Repo.UpdateBot(c.Request().Context(), b.ID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -200,7 +200,7 @@ func (h *Handlers) EditBot(c echo.Context) error {
 func (h *Handlers) DeleteBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	if err := h.Repo.DeleteBot(context.TODO(), b.ID); err != nil {
+	if err := h.Repo.DeleteBot(c.Request().Context(), b.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -212,7 +212,7 @@ func (h *Handlers) GetBotIcon(c echo.Context) error {
 	w := getParamBot(c)
 
 	// ユーザー取得
-	user, err := h.Repo.GetUser(context.TODO(), w.BotUserID, false)
+	user, err := h.Repo.GetUser(c.Request().Context(), w.BotUserID, false)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -250,7 +250,7 @@ func (h *Handlers) GetBotLogs(c echo.Context) error {
 		return err
 	}
 
-	logs, err := h.Repo.GetBotEventLogs(context.TODO(), b.ID, req.Limit, req.Offset)
+	logs, err := h.Repo.GetBotEventLogs(c.Request().Context(), b.ID, req.Limit, req.Offset)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -262,7 +262,7 @@ func (h *Handlers) GetBotLogs(c echo.Context) error {
 func (h *Handlers) GetChannelBots(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	bots, err := h.Repo.GetBots(context.TODO(), repository.BotsQuery{}.CMemberOf(channelID))
+	bots, err := h.Repo.GetBots(c.Request().Context(), repository.BotsQuery{}.CMemberOf(channelID))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -295,7 +295,7 @@ func (h *Handlers) ActivateBot(c echo.Context) error {
 func (h *Handlers) InactivateBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	if err := h.Repo.ChangeBotState(context.TODO(), b.ID, model.BotInactive); err != nil {
+	if err := h.Repo.ChangeBotState(c.Request().Context(), b.ID, model.BotInactive); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -305,12 +305,12 @@ func (h *Handlers) InactivateBot(c echo.Context) error {
 func (h *Handlers) ReissueBot(c echo.Context) error {
 	b := getParamBot(c)
 
-	b, err := h.Repo.ReissueBotTokens(context.TODO(), b.ID)
+	b, err := h.Repo.ReissueBotTokens(c.Request().Context(), b.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
-	t, err := h.Repo.GetTokenByID(context.TODO(), b.AccessTokenID)
+	t, err := h.Repo.GetTokenByID(c.Request().Context(), b.AccessTokenID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -342,7 +342,7 @@ func (h *Handlers) LetBotJoinChannel(c echo.Context) error {
 	b := getParamBot(c)
 
 	// 参加
-	if err := h.Repo.AddBotToChannel(context.TODO(), b.ID, req.ChannelID); err != nil {
+	if err := h.Repo.AddBotToChannel(c.Request().Context(), b.ID, req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -370,7 +370,7 @@ func (h *Handlers) LetBotLeaveChannel(c echo.Context) error {
 	b := getParamBot(c)
 
 	// 退出
-	if err := h.Repo.RemoveBotFromChannel(context.TODO(), b.ID, req.ChannelID); err != nil {
+	if err := h.Repo.RemoveBotFromChannel(c.Request().Context(), b.ID, req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/bots.go
+++ b/router/v3/bots.go
@@ -70,7 +70,7 @@ func (h *Handlers) CreateBot(c echo.Context) error {
 		return err
 	}
 
-	iconFileID, err := file.GenerateIconFile(h.FileManager, req.Name)
+	iconFileID, err := file.GenerateIconFile(c.Request().Context(), h.FileManager, req.Name)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -188,7 +187,7 @@ func (h *Handlers) GetChannelViewers(c echo.Context) error {
 func (h *Handlers) GetChannelStats(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 	excludeDeletedMessages := isTrue(c.QueryParam("exclude-deleted-messages"))
-	stats, err := h.Repo.GetChannelStats(context.TODO(), channelID, excludeDeletedMessages)
+	stats, err := h.Repo.GetChannelStats(c.Request().Context(), channelID, excludeDeletedMessages)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -239,7 +238,7 @@ func (h *Handlers) EditChannelTopic(c echo.Context) error {
 func (h *Handlers) GetChannelPins(c echo.Context) error {
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	pins, err := h.Repo.GetPinnedMessageByChannelID(context.TODO(), channelID)
+	pins, err := h.Repo.GetPinnedMessageByChannelID(c.Request().Context(), channelID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -287,7 +286,7 @@ func (h *Handlers) GetChannelEvents(c echo.Context) error {
 		return err
 	}
 
-	events, more, err := h.Repo.GetChannelEvents(context.TODO(), req.convert(channelID))
+	events, more, err := h.Repo.GetChannelEvents(c.Request().Context(), req.convert(channelID))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -304,7 +303,7 @@ func (h *Handlers) GetChannelSubscribers(c echo.Context) error {
 		return herror.Forbidden()
 	}
 
-	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(c.Request().Context(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -330,7 +329,7 @@ func (h *Handlers) SetChannelSubscribers(c echo.Context) error {
 		return err
 	}
 
-	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(c.Request().Context(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -25,6 +25,7 @@ import (
 
 // GetChannels GET /channels
 func (h *Handlers) GetChannels(c echo.Context) error {
+	ctx := c.Request().Context()
 	if isTrue(c.QueryParam("include-dm")) && len(c.QueryParam("path")) > 0 {
 		return herror.BadRequest("include-dm and path cannot be specified at the same time")
 	}
@@ -32,7 +33,7 @@ func (h *Handlers) GetChannels(c echo.Context) error {
 	var res echo.Map
 
 	if channelPath := c.QueryParam("path"); channelPath != "" {
-		targetChannel, err := h.ChannelManager.GetChannelFromPath(channelPath)
+		targetChannel, err := h.ChannelManager.GetChannelFromPath(ctx, channelPath)
 		if err != nil {
 			if errors.Is(err, channel.ErrInvalidChannelPath) {
 				return herror.HTTPError(http.StatusNotFound, err)
@@ -41,17 +42,17 @@ func (h *Handlers) GetChannels(c echo.Context) error {
 		}
 		res = echo.Map{
 			"public": []*Channel{
-				formatChannel(targetChannel, h.ChannelManager.PublicChannelTree().GetChildrenIDs(targetChannel.ID)),
+				formatChannel(targetChannel, h.ChannelManager.PublicChannelTree(ctx).GetChildrenIDs(targetChannel.ID)),
 			},
 		}
 		return extension.ServeJSONWithETag(c, res)
 	}
 
 	res = echo.Map{
-		"public": h.ChannelManager.PublicChannelTree(),
+		"public": h.ChannelManager.PublicChannelTree(ctx),
 	}
 	if isTrue(c.QueryParam("include-dm")) {
-		mapping, err := h.ChannelManager.GetDMChannelMapping(getRequestUserID(c))
+		mapping, err := h.ChannelManager.GetDMChannelMapping(ctx, getRequestUserID(c))
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -74,6 +75,7 @@ func (r PostChannelRequest) Validate() error {
 
 // CreateChannels POST /channels
 func (h *Handlers) CreateChannels(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 
 	var req PostChannelRequest
@@ -81,7 +83,7 @@ func (h *Handlers) CreateChannels(c echo.Context) error {
 		return err
 	}
 
-	ch, err := h.ChannelManager.CreatePublicChannel(req.Name, req.Parent.V, userID)
+	ch, err := h.ChannelManager.CreatePublicChannel(ctx, req.Name, req.Parent.V, userID)
 	if err != nil {
 		switch err {
 		case channel.ErrChannelArchived:
@@ -104,8 +106,9 @@ func (h *Handlers) CreateChannels(c echo.Context) error {
 
 // GetChannel GET /channels/:channelID
 func (h *Handlers) GetChannel(c echo.Context) error {
+	ctx := c.Request().Context()
 	ch := getParamChannel(c)
-	return c.JSON(http.StatusOK, formatChannel(ch, h.ChannelManager.PublicChannelTree().GetChildrenIDs(ch.ID)))
+	return c.JSON(http.StatusOK, formatChannel(ch, h.ChannelManager.PublicChannelTree(ctx).GetChildrenIDs(ch.ID)))
 }
 
 // PatchChannelRequest PATCH /channels/:channelID リクエストボディ
@@ -124,6 +127,7 @@ func (r PatchChannelRequest) Validate() error {
 
 // EditChannel PATCH /channels/:channelID
 func (h *Handlers) EditChannel(c echo.Context) error {
+	ctx := c.Request().Context()
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
 	var req PatchChannelRequest
@@ -133,7 +137,7 @@ func (h *Handlers) EditChannel(c echo.Context) error {
 
 	if req.Archived.Valid {
 		if req.Archived.V {
-			if err := h.ChannelManager.ArchiveChannel(channelID, getRequestUserID(c)); err != nil {
+			if err := h.ChannelManager.ArchiveChannel(ctx, channelID, getRequestUserID(c)); err != nil {
 				switch err {
 				case channel.ErrInvalidChannel:
 					return herror.BadRequest("invalid channel id")
@@ -142,7 +146,7 @@ func (h *Handlers) EditChannel(c echo.Context) error {
 				}
 			}
 		} else {
-			if err := h.ChannelManager.UnarchiveChannel(channelID, getRequestUserID(c)); err != nil {
+			if err := h.ChannelManager.UnarchiveChannel(ctx, channelID, getRequestUserID(c)); err != nil {
 				switch err {
 				case channel.ErrInvalidParentChannel:
 					return herror.BadRequest("the parent channel has been archived")
@@ -159,7 +163,7 @@ func (h *Handlers) EditChannel(c echo.Context) error {
 		ForcedNotification: req.Force,
 		Parent:             req.Parent,
 	}
-	if err := h.ChannelManager.UpdateChannel(channelID, args); err != nil {
+	if err := h.ChannelManager.UpdateChannel(ctx, channelID, args); err != nil {
 		switch err {
 		case channel.ErrInvalidChannelName:
 			return herror.BadRequest("invalid channel name")
@@ -212,6 +216,7 @@ func (r PutChannelTopicRequest) Validate() error {
 
 // EditChannelTopic PUT /channels/:channelID/topic
 func (h *Handlers) EditChannelTopic(c echo.Context) error {
+	ctx := c.Request().Context()
 	ch := getParamChannel(c)
 
 	var req PutChannelTopicRequest
@@ -219,7 +224,7 @@ func (h *Handlers) EditChannelTopic(c echo.Context) error {
 		return err
 	}
 
-	if err := h.ChannelManager.UpdateChannel(ch.ID, repository.UpdateChannelArgs{
+	if err := h.ChannelManager.UpdateChannel(ctx, ch.ID, repository.UpdateChannelArgs{
 		UpdaterID: getRequestUserID(c),
 		Topic:     optional.From(req.Topic),
 	}); err != nil {
@@ -322,6 +327,7 @@ type PutChannelSubscribersRequest struct {
 
 // SetChannelSubscribers PUT /channels/:channelID/subscribers
 func (h *Handlers) SetChannelSubscribers(c echo.Context) error {
+	ctx := c.Request().Context()
 	ch := getParamChannel(c)
 
 	var req PutChannelSubscribersRequest
@@ -329,7 +335,7 @@ func (h *Handlers) SetChannelSubscribers(c echo.Context) error {
 		return err
 	}
 
-	subscriptions, err := h.Repo.GetChannelSubscriptions(c.Request().Context(), repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(ctx, repository.ChannelSubscriptionQuery{}.SetChannel(ch.ID).SetLevel(model.ChannelSubscribeLevelMarkAndNotify))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -342,7 +348,7 @@ func (h *Handlers) SetChannelSubscribers(c echo.Context) error {
 		subs[id] = model.ChannelSubscribeLevelMarkAndNotify
 	}
 
-	if err := h.ChannelManager.ChangeChannelSubscriptions(ch.ID, subs, true, getRequestUserID(c)); err != nil {
+	if err := h.ChannelManager.ChangeChannelSubscriptions(ctx, ch.ID, subs, true, getRequestUserID(c)); err != nil {
 		switch err {
 		case channel.ErrInvalidChannel:
 			return herror.Forbidden("the channel's subscriptions is not configurable")
@@ -363,6 +369,7 @@ type PatchChannelSubscribersRequest struct {
 
 // EditChannelSubscribers PATCH /channels/:channelID/subscribers
 func (h *Handlers) EditChannelSubscribers(c echo.Context) error {
+	ctx := c.Request().Context()
 	ch := getParamChannel(c)
 
 	var req PatchChannelSubscribersRequest
@@ -383,7 +390,7 @@ func (h *Handlers) EditChannelSubscribers(c echo.Context) error {
 		}
 	}
 
-	if err := h.ChannelManager.ChangeChannelSubscriptions(ch.ID, subscriptions, true, getRequestUserID(c)); err != nil {
+	if err := h.ChannelManager.ChangeChannelSubscriptions(ctx, ch.ID, subscriptions, true, getRequestUserID(c)); err != nil {
 		switch err {
 		case channel.ErrInvalidChannel:
 			return herror.Forbidden("the channel's subscriptions is not configurable")
@@ -398,11 +405,12 @@ func (h *Handlers) EditChannelSubscribers(c echo.Context) error {
 
 // GetUserDMChannel GET /users/:userID/dm-channel
 func (h *Handlers) GetUserDMChannel(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getParamAsUUID(c, consts.ParamUserID)
 	myID := getRequestUserID(c)
 
 	// DMチャンネルを取得
-	ch, err := h.ChannelManager.GetDMChannel(myID, userID)
+	ch, err := h.ChannelManager.GetDMChannel(ctx, myID, userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -412,9 +420,10 @@ func (h *Handlers) GetUserDMChannel(c echo.Context) error {
 
 // GetChannelPath GET /channels/:channelID/path
 func (h *Handlers) GetChannelPath(c echo.Context) error {
+	ctx := c.Request().Context()
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	channelPath := h.ChannelManager.GetChannelPathFromID(channelID)
+	channelPath := h.ChannelManager.GetChannelPathFromID(ctx, channelID)
 
 	return c.JSON(http.StatusOK, echo.Map{"path": channelPath})
 }

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -191,7 +191,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 		e := env.R(t)
 		obj := e.GET(path).
 			WithCookie(session.CookieName, user1Session).
-			WithQuery("path", env.CM.GetChannelPathFromID(channel.ID)).
+			WithQuery("path", env.CM.GetChannelPathFromID(context.TODO(), channel.ID)).
 			Expect().
 			Status(http.StatusOK).
 			JSON().
@@ -207,7 +207,7 @@ func TestHandlers_GetChannels(t *testing.T) {
 		e := env.R(t)
 		obj := e.GET(path).
 			WithCookie(session.CookieName, user1Session).
-			WithQuery("path", env.CM.GetChannelPathFromID(subchannel.ID)).
+			WithQuery("path", env.CM.GetChannelPathFromID(context.TODO(), subchannel.ID)).
 			Expect().
 			Status(http.StatusOK).
 			JSON().
@@ -340,7 +340,7 @@ func TestHandlers_CreateChannels(t *testing.T) {
 		obj.Value("name").String().IsEqual(cname2)
 		obj.Value("children").Array().Length().IsEqual(0)
 
-		ch, err := env.CM.GetChannel(c1)
+		ch, err := env.CM.GetChannel(context.TODO(), c1)
 		require.NoError(t, err)
 		if assert.Len(t, ch.ChildrenID, 1) {
 			assert.EqualValues(t, ch.ChildrenID[0].String(), obj.Value("id").String().Raw())
@@ -459,7 +459,7 @@ func TestHandlers_EditChannel(t *testing.T) {
 	parent := env.CreateChannel(t, rand)
 	unarchived := env.CreateChannel(t, rand)
 	archived := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, admin.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, admin.GetID()))
 
 	t.Run("not logged in", func(t *testing.T) {
 		t.Parallel()
@@ -509,7 +509,7 @@ func TestHandlers_EditChannel(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err := env.CM.GetChannel(unarchived.ID)
+		ch, err := env.CM.GetChannel(context.TODO(), unarchived.ID)
 		require.NoError(t, err)
 		assert.True(t, ch.IsArchived())
 	})
@@ -523,7 +523,7 @@ func TestHandlers_EditChannel(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err := env.CM.GetChannel(archived.ID)
+		ch, err := env.CM.GetChannel(context.TODO(), archived.ID)
 		require.NoError(t, err)
 		assert.False(t, ch.IsArchived())
 	})
@@ -538,7 +538,7 @@ func TestHandlers_EditChannel(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err := env.CM.GetChannel(channel.ID)
+		ch, err := env.CM.GetChannel(context.TODO(), channel.ID)
 		require.NoError(t, err)
 		assert.True(t, ch.IsForced)
 		assert.EqualValues(t, newName, ch.Name)
@@ -637,7 +637,7 @@ func TestHandlers_GetChannelTopic(t *testing.T) {
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
 	channel := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.UpdateChannel(channel.ID, repository.UpdateChannelArgs{Topic: optional.From("this is channel topic")}))
+	require.NoError(t, env.CM.UpdateChannel(context.TODO(), channel.ID, repository.UpdateChannelArgs{Topic: optional.From("this is channel topic")}))
 	commonSession := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -679,7 +679,7 @@ func TestHandlers_EditChannelTopic(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	channel := env.CreateChannel(t, rand)
 	archived := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	commonSession := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -729,7 +729,7 @@ func TestHandlers_EditChannelTopic(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err := env.CM.GetChannel(channel.ID)
+		ch, err := env.CM.GetChannel(context.TODO(), channel.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, "test", ch.Topic)
 
@@ -739,7 +739,7 @@ func TestHandlers_EditChannelTopic(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err = env.CM.GetChannel(channel.ID)
+		ch, err = env.CM.GetChannel(context.TODO(), channel.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, "", ch.Topic)
 
@@ -749,7 +749,7 @@ func TestHandlers_EditChannelTopic(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		ch, err = env.CM.GetChannel(channel.ID)
+		ch, err = env.CM.GetChannel(context.TODO(), channel.ID)
 		require.NoError(t, err)
 		assert.EqualValues(t, strings.Repeat("a", 500), ch.Topic)
 	})
@@ -764,9 +764,9 @@ func TestHandlers_GetChannelPins(t *testing.T) {
 	channel := env.CreateChannel(t, rand)
 	m1 := env.CreateMessage(t, user.GetID(), channel.ID, rand)
 	env.CreateMessage(t, user.GetID(), channel.ID, rand)
-	_, err := env.MM.Pin(m1.GetID(), user.GetID())
+	_, err := env.MM.Pin(context.TODO(), m1.GetID(), user.GetID())
 	require.NoError(t, err)
-	m1, err = env.MM.Get(m1.GetID())
+	m1, err = env.MM.Get(context.TODO(), m1.GetID())
 	require.NoError(t, err)
 	commonSession := env.S(t, user.GetID())
 
@@ -864,7 +864,7 @@ func TestHandlers_GetChannelEvents(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	channel := env.CreateChannel(t, rand)
 	// TopicChanged
-	require.NoError(t, env.CM.UpdateChannel(channel.ID, repository.UpdateChannelArgs{UpdaterID: user.GetID(), Topic: optional.From("test topic")}))
+	require.NoError(t, env.CM.UpdateChannel(context.TODO(), channel.ID, repository.UpdateChannelArgs{UpdaterID: user.GetID(), Topic: optional.From("test topic")}))
 	commonSession := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -925,12 +925,12 @@ func TestHandlers_GetChannelSubscribers(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	user2 := env.CreateUser(t, rand)
 	channel := env.CreateChannel(t, rand)
-	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+	err := env.CM.ChangeChannelSubscriptions(context.TODO(), channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
 		user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 	}, false, user.GetID())
 	require.NoError(t, err)
 	forced := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
+	require.NoError(t, env.CM.UpdateChannel(context.TODO(), forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	commonSession := env.S(t, user.GetID())
 
@@ -994,12 +994,12 @@ func TestHandlers_SetChannelSubscribers(t *testing.T) {
 	// user: none
 	// user2: mark and notify
 	channel := env.CreateChannel(t, rand)
-	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+	err := env.CM.ChangeChannelSubscriptions(context.TODO(), channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
 		user2.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 	}, false, user.GetID())
 	require.NoError(t, err)
 	forced := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
+	require.NoError(t, env.CM.UpdateChannel(context.TODO(), forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	commonSession := env.S(t, user.GetID())
 
@@ -1079,7 +1079,7 @@ func TestHandlers_EditChannelSubscribers(t *testing.T) {
 	// user4: mark and notify
 	// user5: mark and notify
 	channel := env.CreateChannel(t, rand)
-	err := env.CM.ChangeChannelSubscriptions(channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+	err := env.CM.ChangeChannelSubscriptions(context.TODO(), channel.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
 		user2.GetID(): model.ChannelSubscribeLevelMark,
 		user3.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 		user4.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
@@ -1087,7 +1087,7 @@ func TestHandlers_EditChannelSubscribers(t *testing.T) {
 	}, false, user.GetID())
 	require.NoError(t, err)
 	forced := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
+	require.NoError(t, env.CM.UpdateChannel(context.TODO(), forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)}))
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	commonSession := env.S(t, user.GetID())
 

--- a/router/v3/clients.go
+++ b/router/v3/clients.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 
 	vd "github.com/go-ozzo/ozzo-validation/v4"
@@ -26,7 +25,7 @@ func (h *Handlers) GetClients(c echo.Context) error {
 		q = q.IsDevelopedBy(getRequestUserID(c))
 	}
 
-	ocs, err := h.Repo.GetClients(context.TODO(), q)
+	ocs, err := h.Repo.GetClients(c.Request().Context(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -70,7 +69,7 @@ func (h *Handlers) CreateClient(c echo.Context) error {
 		Secret:       random.SecureAlphaNumeric(36),
 		Scopes:       req.Scopes,
 	}
-	if err := h.Repo.SaveClient(context.TODO(), client); err != nil {
+	if err := h.Repo.SaveClient(c.Request().Context(), client); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -126,7 +125,7 @@ func (h *Handlers) EditClient(c echo.Context) error {
 		CallbackURL:  req.CallbackURL,
 		Confidential: req.Confidential,
 	}
-	if err := h.Repo.UpdateClient(context.TODO(), oc.ID, args); err != nil {
+	if err := h.Repo.UpdateClient(c.Request().Context(), oc.ID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -138,7 +137,7 @@ func (h *Handlers) DeleteClient(c echo.Context) error {
 	oc := getParamClient(c)
 
 	// delete client
-	if err := h.Repo.DeleteClient(context.TODO(), oc.ID); err != nil {
+	if err := h.Repo.DeleteClient(c.Request().Context(), oc.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -150,7 +149,7 @@ func (h *Handlers) RevokeClientTokens(c echo.Context) error {
 	oc := getParamClient(c)
 	userID := getRequestUserID(c)
 
-	err := h.Repo.DeleteUserTokensByClient(context.TODO(), userID, oc.ID)
+	err := h.Repo.DeleteUserTokensByClient(c.Request().Context(), userID, oc.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -54,7 +53,7 @@ func (h *Handlers) CreateClipFolder(c echo.Context) error {
 		return err
 	}
 
-	cf, err := h.Repo.CreateClipFolder(context.TODO(), userID, req.Name, req.Description)
+	cf, err := h.Repo.CreateClipFolder(c.Request().Context(), userID, req.Name, req.Description)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -66,7 +65,7 @@ func (h *Handlers) CreateClipFolder(c echo.Context) error {
 func (h *Handlers) GetClipFolders(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	cfs, err := h.Repo.GetClipFoldersByUserID(context.TODO(), userID)
+	cfs, err := h.Repo.GetClipFoldersByUserID(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -83,7 +82,7 @@ func (h *Handlers) GetClipFolder(c echo.Context) error {
 func (h *Handlers) DeleteClipFolder(c echo.Context) error {
 	folderID := getParamAsUUID(c, consts.ParamClipFolderID)
 
-	if err := h.Repo.DeleteClipFolder(context.TODO(), folderID); err != nil {
+	if err := h.Repo.DeleteClipFolder(c.Request().Context(), folderID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -98,7 +97,7 @@ func (h *Handlers) EditClipFolder(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateClipFolder(context.TODO(), cf.ID, req.Name, req.Description); err != nil {
+	if err := h.Repo.UpdateClipFolder(c.Request().Context(), cf.ID, req.Name, req.Description); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -136,7 +135,7 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 	}
 
 	var cfm *model.ClipFolderMessage
-	cfm, err = h.Repo.AddClipFolderMessage(context.TODO(), cf.ID, req.MessageID)
+	cfm, err = h.Repo.AddClipFolderMessage(c.Request().Context(), cf.ID, req.MessageID)
 	if err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
@@ -182,7 +181,7 @@ func (h *Handlers) GetClipFolderMessages(c echo.Context) error {
 		return err
 	}
 
-	messages, more, err := h.Repo.GetClipFolderMessages(context.TODO(), cf.ID, req.convert())
+	messages, more, err := h.Repo.GetClipFolderMessages(c.Request().Context(), cf.ID, req.convert())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -197,7 +196,7 @@ func (h *Handlers) DeleteClipFolderMessages(c echo.Context) error {
 	messageID := getParamAsUUID(c, consts.ParamMessageID)
 
 	cf := getParamClipFolder(c)
-	if err := h.Repo.DeleteClipFolderMessage(context.TODO(), cf.ID, messageID); err != nil {
+	if err := h.Repo.DeleteClipFolderMessage(c.Request().Context(), cf.ID, messageID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -109,6 +109,7 @@ type PostClipFolderMessageRequest struct {
 
 // PostClipFolderMessage POST /clip-folders/:folderID/messages
 func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
+	ctx := c.Request().Context()
 	cf := getParamClipFolder(c)
 	userID := getRequestUserID(c)
 
@@ -128,7 +129,7 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 	}
 
 	// ユーザーがアクセスできるか
-	if ok, err := h.ChannelManager.IsChannelAccessibleToUser(userID, m.GetChannelID()); err != nil {
+	if ok, err := h.ChannelManager.IsChannelAccessibleToUser(ctx, userID, m.GetChannelID()); err != nil {
 		return herror.InternalServerError(err)
 	} else if !ok {
 		return herror.BadRequest("invalid messageId")

--- a/router/v3/clips.go
+++ b/router/v3/clips.go
@@ -118,7 +118,7 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 		return err
 	}
 
-	m, err := h.MessageManager.Get(req.MessageID)
+	m, err := h.MessageManager.Get(ctx, req.MessageID)
 	if err != nil {
 		switch err {
 		case message.ErrNotFound:
@@ -136,7 +136,7 @@ func (h *Handlers) PostClipFolderMessage(c echo.Context) error {
 	}
 
 	var cfm *model.ClipFolderMessage
-	cfm, err = h.Repo.AddClipFolderMessage(c.Request().Context(), cf.ID, req.MessageID)
+	cfm, err = h.Repo.AddClipFolderMessage(ctx, cf.ID, req.MessageID)
 	if err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:

--- a/router/v3/files.go
+++ b/router/v3/files.go
@@ -73,7 +73,7 @@ func (h *Handlers) GetFiles(c echo.Context) error {
 		q.ChannelID = optional.From(req.ChannelID)
 	}
 
-	files, more, err := h.FileManager.List(q)
+	files, more, err := h.FileManager.List(c.Request().Context(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -131,7 +131,7 @@ func (h *Handlers) PostFile(c echo.Context) error {
 	args.ChannelID = optional.From(channelID)
 
 	// 保存
-	file, err := h.FileManager.Save(args)
+	file, err := h.FileManager.Save(c.Request().Context(), args)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -166,7 +166,7 @@ func (h *Handlers) DeleteFile(c echo.Context) error {
 		return herror.Forbidden()
 	}
 
-	if err := h.FileManager.Delete(f.GetID()); err != nil {
+	if err := h.FileManager.Delete(c.Request().Context(), f.GetID()); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/files.go
+++ b/router/v3/files.go
@@ -65,7 +65,7 @@ func (h *Handlers) GetFiles(c echo.Context) error {
 	}
 	if req.ChannelID != uuid.Nil {
 		// チャンネルアクセス権確認
-		if ok, err := h.ChannelManager.IsChannelAccessibleToUser(getRequestUserID(c), req.ChannelID); err != nil {
+		if ok, err := h.ChannelManager.IsChannelAccessibleToUser(c.Request().Context(), getRequestUserID(c), req.ChannelID); err != nil {
 			return herror.InternalServerError(err)
 		} else if !ok {
 			return herror.BadRequest("invalid channelId")
@@ -83,6 +83,7 @@ func (h *Handlers) GetFiles(c echo.Context) error {
 
 // PostFile POST /files
 func (h *Handlers) PostFile(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 
 	// ファイルチェック
@@ -106,21 +107,21 @@ func (h *Handlers) PostFile(c echo.Context) error {
 
 	// チャンネルアクセス権確認
 	channelID := uuid.FromStringOrNil(c.FormValue("channelId"))
-	if ok, err := h.ChannelManager.IsChannelAccessibleToUser(userID, channelID); err != nil {
+	if ok, err := h.ChannelManager.IsChannelAccessibleToUser(ctx, userID, channelID); err != nil {
 		return herror.InternalServerError(err)
 	} else if !ok {
 		return herror.BadRequest("invalid channelId")
 	}
-	ch, err := h.ChannelManager.GetChannel(channelID)
+	ch, err := h.ChannelManager.GetChannel(ctx, channelID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 	if ch.IsArchived() {
-		return herror.BadRequest(fmt.Sprintf("channel #%s has been archived", h.ChannelManager.PublicChannelTree().GetChannelPath(ch.ID)))
+		return herror.BadRequest(fmt.Sprintf("channel #%s has been archived", h.ChannelManager.PublicChannelTree(ctx).GetChannelPath(ch.ID)))
 	}
 	if !ch.IsPublic {
 		// アクセスコントロール設定
-		members, err := h.ChannelManager.GetDMChannelMembers(ch.ID)
+		members, err := h.ChannelManager.GetDMChannelMembers(ctx, ch.ID)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}

--- a/router/v3/files_test.go
+++ b/router/v3/files_test.go
@@ -223,7 +223,7 @@ func TestHandlers_PostFile(t *testing.T) {
 	dm1 := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	dm2 := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
 	archived := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	s := env.S(t, user.GetID())
 
 	buf := []byte("test file")

--- a/router/v3/files_test.go
+++ b/router/v3/files_test.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"math"
@@ -390,7 +391,7 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 	t.Run("success with image thumbnail", func(t *testing.T) {
 		t.Parallel()
 
-		iconFileID, err := file2.GenerateIconFile(env.FM, "test")
+		iconFileID, err := file2.GenerateIconFile(context.TODO(), env.FM, "test")
 		require.NoError(t, err)
 
 		e := env.R(t)
@@ -415,7 +416,7 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 		t.Parallel()
 
 		sampleAudio := genSampleAudio(t)
-		file, err := env.FM.Save(file2.SaveArgs{
+		file, err := env.FM.Save(context.TODO(), file2.SaveArgs{
 			FileName: "sample.wav",
 			FileSize: sampleAudio.Size(),
 			MimeType: "audio/wav",
@@ -457,11 +458,11 @@ func TestHandlers_GetThumbnailImage(t *testing.T) {
 	dm := env.CreateDMChannel(t, user2.GetID(), user3.GetID())
 	s := env.S(t, user.GetID())
 
-	iconFile, err := file2.GenerateIconFile(env.FM, "test")
+	iconFile, err := file2.GenerateIconFile(context.TODO(), env.FM, "test")
 	require.NoError(t, err)
 
 	sampleAudio := genSampleAudio(t)
-	audioFile, err := env.FM.Save(file2.SaveArgs{
+	audioFile, err := env.FM.Save(context.TODO(), file2.SaveArgs{
 		FileName: "sample.wav",
 		FileSize: sampleAudio.Size(),
 		MimeType: "audio/wav",
@@ -607,7 +608,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 	secretFile := env.CreateFile(t, user2.GetID(), dm.ID)
 	s := env.S(t, user.GetID())
 
-	iconFile, err := file2.GenerateIconFile(env.FM, "test")
+	iconFile, err := file2.GenerateIconFile(context.TODO(), env.FM, "test")
 	require.NoError(t, err)
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -662,7 +663,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.FM.Get(f.GetID())
+		_, err := env.FM.Get(context.TODO(), f.GetID())
 		assert.ErrorIs(t, err, file2.ErrNotFound)
 	})
 }

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -99,6 +99,7 @@ func (r PostMessageRequest) Validate() error {
 
 // EditMessage PUT /messages/:messageID
 func (h *Handlers) EditMessage(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 	m := getParamMessage(c)
 
@@ -122,7 +123,7 @@ func (h *Handlers) EditMessage(c echo.Context) error {
 		req.Content = h.Replacer.Replace(req.Content)
 	}
 
-	if err := h.MessageManager.Edit(m.GetID(), req.Content); err != nil {
+	if err := h.MessageManager.Edit(ctx, m.GetID(), req.Content); err != nil {
 		switch err {
 		case message.ErrChannelArchived:
 			return herror.BadRequest("the channel of this message has been archived")
@@ -135,11 +136,12 @@ func (h *Handlers) EditMessage(c echo.Context) error {
 
 // DeleteMessage DELETE /messages/:messageID
 func (h *Handlers) DeleteMessage(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 	m := getParamMessage(c)
 
 	if muid := m.GetUserID(); muid != userID {
-		mUser, err := h.Repo.GetUser(c.Request().Context(), muid, false)
+		mUser, err := h.Repo.GetUser(ctx, muid, false)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -149,7 +151,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			return herror.Forbidden("you are not allowed to delete this message")
 		case model.UserTypeBot:
 			// BOTのメッセージの削除権限の確認
-			wh, err := h.Repo.GetBotByBotUserID(c.Request().Context(), mUser.GetID())
+			wh, err := h.Repo.GetBotByBotUserID(ctx, mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted bot
@@ -164,7 +166,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			}
 		case model.UserTypeWebhook:
 			// Webhookのメッセージの削除権限の確認
-			wh, err := h.Repo.GetWebhookByBotUserID(c.Request().Context(), mUser.GetID())
+			wh, err := h.Repo.GetWebhookByBotUserID(ctx, mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted webhook
@@ -180,7 +182,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 		}
 	}
 
-	if err := h.MessageManager.Delete(m.GetID()); err != nil {
+	if err := h.MessageManager.Delete(ctx, m.GetID()); err != nil {
 		switch err {
 		case message.ErrChannelArchived:
 			return herror.BadRequest("the channel of this message has been archived")
@@ -202,8 +204,9 @@ func (h *Handlers) GetPin(c echo.Context) error {
 
 // CreatePin POST /messages/:messageID/pin
 func (h *Handlers) CreatePin(c echo.Context) error {
+	ctx := c.Request().Context()
 	m := getParamMessage(c)
-	p, err := h.MessageManager.Pin(m.GetID(), getRequestUserID(c))
+	p, err := h.MessageManager.Pin(ctx, m.GetID(), getRequestUserID(c))
 	if err != nil {
 		switch err {
 		case message.ErrAlreadyExists:
@@ -221,8 +224,9 @@ func (h *Handlers) CreatePin(c echo.Context) error {
 
 // RemovePin DELETE /messages/:messageID/pin
 func (h *Handlers) RemovePin(c echo.Context) error {
+	ctx := c.Request().Context()
 	m := getParamMessage(c)
-	if err := h.MessageManager.Unpin(m.GetID(), getRequestUserID(c)); err != nil {
+	if err := h.MessageManager.Unpin(ctx, m.GetID(), getRequestUserID(c)); err != nil {
 		switch err {
 		case message.ErrNotFound:
 			return herror.NotFound("pin was not found")
@@ -256,6 +260,7 @@ func (r *PostMessageStampRequest) Validate() error {
 
 // AddMessageStamp POST /messages/:messageID/stamps/:stampID
 func (h *Handlers) AddMessageStamp(c echo.Context) error {
+	ctx := c.Request().Context()
 	var req PostMessageStampRequest
 	if err := bindAndValidate(c, &req); err != nil {
 		return err
@@ -266,7 +271,7 @@ func (h *Handlers) AddMessageStamp(c echo.Context) error {
 	stampID := getParamAsUUID(c, consts.ParamStampID)
 
 	// スタンプをメッセージに押す
-	if _, err := h.MessageManager.AddStamps(messageID, stampID, userID, req.Count); err != nil {
+	if _, err := h.MessageManager.AddStamps(ctx, messageID, stampID, userID, req.Count); err != nil {
 		switch err {
 		case message.ErrChannelArchived:
 			return herror.BadRequest("the channel of this message has been archived")
@@ -280,12 +285,13 @@ func (h *Handlers) AddMessageStamp(c echo.Context) error {
 
 // RemoveMessageStamp DELETE /messages/:messageID/stamps/:stampID
 func (h *Handlers) RemoveMessageStamp(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 	messageID := getParamAsUUID(c, consts.ParamMessageID)
 	stampID := getParamAsUUID(c, consts.ParamStampID)
 
 	// スタンプをメッセージから削除
-	if err := h.MessageManager.RemoveStamps(messageID, stampID, userID); err != nil {
+	if err := h.MessageManager.RemoveStamps(ctx, messageID, stampID, userID); err != nil {
 		switch err {
 		case message.ErrChannelArchived:
 			return herror.BadRequest("the channel of this message has been archived")
@@ -324,6 +330,7 @@ func (h *Handlers) GetMessages(c echo.Context) error {
 
 // PostMessage POST /channels/:channelID/messages
 func (h *Handlers) PostMessage(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 	ch := getParamChannel(c)
 
@@ -342,7 +349,7 @@ func (h *Handlers) PostMessage(c echo.Context) error {
 		req.Content = h.Replacer.Replace(req.Content)
 	}
 
-	m, err := h.MessageManager.Create(ch.ID, userID, req.Content)
+	m, err := h.MessageManager.Create(ctx, ch.ID, userID, req.Content)
 	if err != nil {
 		switch err {
 		case message.ErrChannelArchived:
@@ -376,6 +383,7 @@ func (h *Handlers) GetDirectMessages(c echo.Context) error {
 
 // PostDirectMessage POST /users/:userId/messages
 func (h *Handlers) PostDirectMessage(c echo.Context) error {
+	ctx := c.Request().Context()
 	myID := getRequestUserID(c)
 	targetID := getParamAsUUID(c, consts.ParamUserID)
 
@@ -394,7 +402,7 @@ func (h *Handlers) PostDirectMessage(c echo.Context) error {
 		req.Content = h.Replacer.Replace(req.Content)
 	}
 
-	m, err := h.MessageManager.CreateDM(myID, targetID, req.Content)
+	m, err := h.MessageManager.CreateDM(ctx, myID, targetID, req.Content)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -20,7 +19,7 @@ import (
 func (h *Handlers) GetMyUnreadChannels(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	list, err := h.Repo.GetUserUnreadChannels(context.TODO(), userID)
+	list, err := h.Repo.GetUserUnreadChannels(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -33,7 +32,7 @@ func (h *Handlers) ReadChannel(c echo.Context) error {
 	userID := getRequestUserID(c)
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	if err := h.Repo.DeleteUnreadsByChannelID(context.TODO(), channelID, userID); err != nil {
+	if err := h.Repo.DeleteUnreadsByChannelID(c.Request().Context(), channelID, userID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -139,7 +138,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 	m := getParamMessage(c)
 
 	if muid := m.GetUserID(); muid != userID {
-		mUser, err := h.Repo.GetUser(context.TODO(), muid, false)
+		mUser, err := h.Repo.GetUser(c.Request().Context(), muid, false)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -149,7 +148,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			return herror.Forbidden("you are not allowed to delete this message")
 		case model.UserTypeBot:
 			// BOTのメッセージの削除権限の確認
-			wh, err := h.Repo.GetBotByBotUserID(context.TODO(), mUser.GetID())
+			wh, err := h.Repo.GetBotByBotUserID(c.Request().Context(), mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted bot
@@ -164,7 +163,7 @@ func (h *Handlers) DeleteMessage(c echo.Context) error {
 			}
 		case model.UserTypeWebhook:
 			// Webhookのメッセージの削除権限の確認
-			wh, err := h.Repo.GetWebhookByBotUserID(context.TODO(), mUser.GetID())
+			wh, err := h.Repo.GetWebhookByBotUserID(c.Request().Context(), mUser.GetID())
 			if err != nil {
 				switch err {
 				case repository.ErrNotFound: // deleted webhook
@@ -302,7 +301,7 @@ func (h *Handlers) GetMessageClips(c echo.Context) error {
 	userID := getRequestUserID(c)
 	messageID := getParamAsUUID(c, consts.ParamMessageID)
 
-	clips, err := h.Repo.GetMessageClips(context.TODO(), userID, messageID)
+	clips, err := h.Repo.GetMessageClips(c.Request().Context(), userID, messageID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/messages.go
+++ b/router/v3/messages.go
@@ -41,6 +41,7 @@ func (h *Handlers) ReadChannel(c echo.Context) error {
 
 // SearchMessages GET /messages
 func (h *Handlers) SearchMessages(c echo.Context) error {
+	ctx := c.Request().Context()
 	if !h.SearchEngine.Available() {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "search service is currently unavailable")
 	}
@@ -52,7 +53,7 @@ func (h *Handlers) SearchMessages(c echo.Context) error {
 
 	if q.In.Valid {
 		// ユーザーが該当チャンネルへのアクセス権限があるかを確認
-		ok, err := h.ChannelManager.IsChannelAccessibleToUser(getRequestUserID(c), q.In.V)
+		ok, err := h.ChannelManager.IsChannelAccessibleToUser(ctx, getRequestUserID(c), q.In.V)
 		if err != nil {
 			return herror.InternalServerError(err)
 		}
@@ -355,6 +356,7 @@ func (h *Handlers) PostMessage(c echo.Context) error {
 
 // GetDirectMessages GET /users/:userId/messages
 func (h *Handlers) GetDirectMessages(c echo.Context) error {
+	ctx := c.Request().Context()
 	myID := getRequestUserID(c)
 	targetID := getParamAsUUID(c, consts.ParamUserID)
 
@@ -364,7 +366,7 @@ func (h *Handlers) GetDirectMessages(c echo.Context) error {
 	}
 
 	// DMチャンネルを取得
-	ch, err := h.ChannelManager.GetDMChannel(myID, targetID)
+	ch, err := h.ChannelManager.GetDMChannel(ctx, myID, targetID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/messages_test.go
+++ b/router/v3/messages_test.go
@@ -209,7 +209,7 @@ func TestHandlers_EditMessage(t *testing.T) {
 
 	m := env.CreateMessage(t, user.GetID(), pub.ID, rand)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
@@ -359,7 +359,7 @@ func TestHandlers_DeleteMessage(t *testing.T) {
 
 	m := env.CreateMessage(t, user.GetID(), pub.ID, rand)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 
 	bot3M := env.CreateMessage(t, bot3.BotUserID, pub.ID, rand)
 	w3M := env.CreateMessage(t, w3.GetBotUserID(), pub.ID, rand)
@@ -479,7 +479,7 @@ func TestHandlers_GetPin(t *testing.T) {
 	ch := env.CreateChannel(t, rand)
 	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	m2 := env.CreateMessage(t, user.GetID(), ch.ID, rand)
-	_, err := env.MM.Pin(m.GetID(), user.GetID())
+	_, err := env.MM.Pin(context.TODO(), m.GetID(), user.GetID())
 	require.NoError(t, err)
 	s := env.S(t, user.GetID())
 
@@ -535,8 +535,8 @@ func TestHandlers_CreatePin(t *testing.T) {
 	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	m2 := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
-	_, err := env.MM.Pin(m2.GetID(), user.GetID())
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
+	_, err := env.MM.Pin(context.TODO(), m2.GetID(), user.GetID())
 	require.NoError(t, err)
 	s := env.S(t, user.GetID())
 
@@ -600,12 +600,12 @@ func TestHandlers_RemovePin(t *testing.T) {
 	archived := env.CreateChannel(t, rand)
 	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	m2 := env.CreateMessage(t, user.GetID(), ch.ID, rand)
-	_, err := env.MM.Pin(m.GetID(), user.GetID())
+	_, err := env.MM.Pin(context.TODO(), m.GetID(), user.GetID())
 	require.NoError(t, err)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
-	_, err = env.MM.Pin(archivedM.GetID(), user.GetID())
+	_, err = env.MM.Pin(context.TODO(), archivedM.GetID(), user.GetID())
 	require.NoError(t, err)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	s := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -651,7 +651,7 @@ func TestHandlers_RemovePin(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		m, err := env.MM.Get(m.GetID())
+		m, err := env.MM.Get(context.TODO(), m.GetID())
 		require.NoError(t, err)
 		assert.Nil(t, m.GetPin())
 	})
@@ -670,7 +670,7 @@ func TestHandlers_GetMessageStamps(t *testing.T) {
 	s := env.S(t, user.GetID())
 
 	var err error
-	m, err = env.MM.Get(m.GetID())
+	m, err = env.MM.Get(context.TODO(), m.GetID())
 	require.NoError(t, err)
 	require.Len(t, m.GetStamps(), 1)
 
@@ -762,7 +762,7 @@ func TestHandlers_AddMessageStamp(t *testing.T) {
 	archived := env.CreateChannel(t, rand)
 	m := env.CreateMessage(t, user.GetID(), ch.ID, rand)
 	archivedM := env.CreateMessage(t, user.GetID(), archived.ID, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	stamp := env.CreateStamp(t, user.GetID(), rand)
 	s := env.S(t, user.GetID())
 
@@ -824,7 +824,7 @@ func TestHandlers_AddMessageStamp(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		m, err := env.MM.Get(m.GetID())
+		m, err := env.MM.Get(context.TODO(), m.GetID())
 		require.NoError(t, err)
 
 		if assert.Len(t, m.GetStamps(), 1) {
@@ -850,7 +850,7 @@ func TestHandlers_RemoveMessageStamp(t *testing.T) {
 	stamp := env.CreateStamp(t, user.GetID(), rand)
 	env.AddStampToMessage(t, m.GetID(), stamp.ID, user.GetID())
 	env.AddStampToMessage(t, archivedM.GetID(), stamp.ID, user.GetID())
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	s := env.S(t, user.GetID())
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -896,7 +896,7 @@ func TestHandlers_RemoveMessageStamp(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		m, err := env.MM.Get(m.GetID())
+		m, err := env.MM.Get(context.TODO(), m.GetID())
 		require.NoError(t, err)
 
 		assert.Len(t, m.GetStamps(), 0)
@@ -1014,7 +1014,7 @@ func TestHandlers_PostMessage(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	ch := env.CreateChannel(t, rand)
 	archived := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	s := env.S(t, user.GetID())
 
 	req := &PostMessageRequest{
@@ -1083,7 +1083,7 @@ func TestHandlers_PostMessage(t *testing.T) {
 
 		id, err := uuid.FromString(obj.Value("id").String().Raw())
 		if assert.NoError(t, err) {
-			m, err := env.MM.Get(id)
+			m, err := env.MM.Get(context.TODO(), id)
 			require.NoError(t, err)
 			messageEquals(t, m, obj)
 		}
@@ -1224,7 +1224,7 @@ func TestHandlers_PostDirectMessage(t *testing.T) {
 
 		id, err := uuid.FromString(obj.Value("id").String().Raw())
 		if assert.NoError(t, err) {
-			m, err := env.MM.Get(id)
+			m, err := env.MM.Get(context.TODO(), id)
 			require.NoError(t, err)
 			messageEquals(t, m, obj)
 		}
@@ -1252,7 +1252,7 @@ func TestHandlers_PostDirectMessage(t *testing.T) {
 
 		id, err := uuid.FromString(obj.Value("id").String().Raw())
 		if assert.NoError(t, err) {
-			m, err := env.MM.Get(id)
+			m, err := env.MM.Get(context.TODO(), id)
 			require.NoError(t, err)
 			messageEquals(t, m, obj)
 		}

--- a/router/v3/ogp.go
+++ b/router/v3/ogp.go
@@ -21,7 +21,7 @@ func (h *Handlers) GetOgp(c echo.Context) error {
 	}
 
 	// キャッシュの削除に対応するために Cache-Control でのキャッシュはしない
-	res, _, err := h.OGP.GetMeta(u)
+	res, _, err := h.OGP.GetMeta(c.Request().Context(), u)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -41,7 +41,7 @@ func (h *Handlers) DeleteOgpCache(c echo.Context) error {
 		return herror.BadRequest("invalid url")
 	}
 
-	err := h.OGP.DeleteCache(u)
+	err := h.OGP.DeleteCache(c.Request().Context(), u)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/public.go
+++ b/router/v3/public.go
@@ -55,7 +55,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	}
 
 	// ファイルメタ取得
-	meta, err := h.FileManager.Get(user.GetIconFileID())
+	meta, err := h.FileManager.Get(c.Request().Context(), user.GetIconFileID())
 	if err != nil {
 		switch err {
 		case file.ErrNotFound:

--- a/router/v3/public.go
+++ b/router/v3/public.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 
@@ -44,7 +43,7 @@ func (h *Handlers) GetPublicUserIcon(c echo.Context) error {
 	username := c.Param("username")
 
 	// ユーザー取得
-	user, err := h.Repo.GetUserByName(context.TODO(), username, false)
+	user, err := h.Repo.GetUserByName(c.Request().Context(), username, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/router/v3/public_test.go
+++ b/router/v3/public_test.go
@@ -43,7 +43,7 @@ func TestHandlers_GetPublicUserIcon(t *testing.T) {
 
 	path := "/api/v3/public/icon/{username}"
 	env := Setup(t, common1)
-	iconFileID, err := file2.GenerateIconFile(env.FM, "test")
+	iconFileID, err := file2.GenerateIconFile(context.TODO(), env.FM, "test")
 	require.NoError(t, err)
 	user, err := env.Repository.CreateUser(context.TODO(), repository.CreateUserArgs{
 		Name:       random.AlphaNumeric(20),

--- a/router/v3/qall.go
+++ b/router/v3/qall.go
@@ -28,7 +28,7 @@ func (h *Handlers) GetQallEndpoints(c echo.Context) error {
 
 // GetSoundboardItems GET /qall/soundboard
 func (h *Handlers) GetSoundboardItems(c echo.Context) error {
-	items, err := h.Repo.GetAllSoundboardItems(context.TODO())
+	items, err := h.Repo.GetAllSoundboardItems(c.Request().Context())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/qall.go
+++ b/router/v3/qall.go
@@ -306,6 +306,7 @@ func (h *Handlers) PatchRoomParticipants(c echo.Context) error {
 
 // GetLiveKitToken GET /qall/token
 func (h *Handlers) GetLiveKitToken(c echo.Context) error {
+	ctx := c.Request().Context()
 	// 1) roomクエリパラメータ取得 (必須)
 	room := c.QueryParam("roomId")
 	if room == "" {
@@ -317,7 +318,7 @@ func (h *Handlers) GetLiveKitToken(c echo.Context) error {
 		return herror.BadRequest("invalid room Id")
 	}
 
-	if !h.ChannelManager.PublicChannelTree().IsChannelPresent(roomID) {
+	if !h.ChannelManager.PublicChannelTree(ctx).IsChannelPresent(roomID) {
 		return herror.NotFound("channel not found")
 	}
 

--- a/router/v3/qall.go
+++ b/router/v3/qall.go
@@ -51,7 +51,7 @@ func (h *Handlers) CreateSoundboardItem(c echo.Context) error {
 	creatorID := uuid.FromStringOrNil(c.FormValue("creatorId"))
 	stampID := uuid.FromStringOrNil(c.FormValue("stampId"))
 
-	if err := h.Soundboard.SaveSoundboardItem(uuid.Must(uuid.NewV7()), soundName, mimeType, model.FileTypeSoundboardItem, src, &stampID, creatorID); err != nil {
+	if err := h.Soundboard.SaveSoundboardItem(c.Request().Context(), uuid.Must(uuid.NewV7()), soundName, mimeType, model.FileTypeSoundboardItem, src, &stampID, creatorID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -289,7 +289,7 @@ func (env *Env) CreateChannel(t *testing.T, name string) *model.Channel {
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	ch, err := env.CM.CreatePublicChannel(name, uuid.Nil, uuid.Nil)
+	ch, err := env.CM.CreatePublicChannel(context.TODO(), name, uuid.Nil, uuid.Nil)
 	require.NoError(t, err)
 	return ch
 }
@@ -300,10 +300,10 @@ func (env *Env) CreateSubchannel(t *testing.T, parent *model.Channel, name strin
 	if name == rand {
 		name = random.AlphaNumeric(20)
 	}
-	ch, err := env.CM.CreatePublicChannel(name, parent.ID, uuid.Nil)
+	ch, err := env.CM.CreatePublicChannel(context.TODO(), name, parent.ID, uuid.Nil)
 	require.NoError(t, err)
 	// parent.ChildrenId が更新されるので, 代入しなおす
-	newParent, err := env.CM.GetChannel(parent.ID)
+	newParent, err := env.CM.GetChannel(context.TODO(), parent.ID)
 	require.NoError(t, err)
 	*parent = *newParent
 	return ch
@@ -317,7 +317,7 @@ func (env *Env) AddStar(t *testing.T, userID, channelID uuid.UUID) {
 
 // CreateDMChannel DMチャンネルを必ず作成します
 func (env *Env) CreateDMChannel(t *testing.T, user1, user2 uuid.UUID) *model.Channel {
-	dm, err := env.CM.GetDMChannel(user1, user2)
+	dm, err := env.CM.GetDMChannel(context.TODO(), user1, user2)
 	require.NoError(t, err)
 	return dm
 }
@@ -328,7 +328,7 @@ func (env *Env) CreateMessage(t *testing.T, userID, channelID uuid.UUID, text st
 	if text == rand {
 		text = random.AlphaNumeric(20)
 	}
-	m, err := env.MM.Create(channelID, userID, text)
+	m, err := env.MM.Create(context.TODO(), channelID, userID, text)
 	require.NoError(t, err)
 	return m
 }
@@ -336,7 +336,7 @@ func (env *Env) CreateMessage(t *testing.T, userID, channelID uuid.UUID, text st
 // DeleteMessage メッセージを必ず削除します
 func (env *Env) DeleteMessage(t *testing.T, messageID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, env.MM.Delete(messageID))
+	require.NoError(t, env.MM.Delete(context.TODO(), messageID))
 }
 
 // MakeMessageUnread 指定したメッセージを未読にします
@@ -375,7 +375,7 @@ func (env *Env) CreateStampPalette(t *testing.T, creator uuid.UUID, name string,
 // AddStampToMessage メッセージにスタンプを必ず押します
 func (env *Env) AddStampToMessage(t *testing.T, messageID, stampID, userID uuid.UUID) {
 	t.Helper()
-	_, err := env.MM.AddStamps(messageID, stampID, userID, 1)
+	_, err := env.MM.AddStamps(context.TODO(), messageID, stampID, userID, 1)
 	require.NoError(t, err)
 }
 
@@ -406,7 +406,7 @@ func (env *Env) CreateFileWithName(t *testing.T, creatorID, channelID uuid.UUID,
 		Src:       buf,
 	}
 
-	members, err := env.CM.GetDMChannelMembers(channelID)
+	members, err := env.CM.GetDMChannelMembers(context.TODO(), channelID)
 	require.NoError(t, err)
 	for _, member := range members {
 		args.ACLAllow(member)

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -412,7 +412,7 @@ func (env *Env) CreateFileWithName(t *testing.T, creatorID, channelID uuid.UUID,
 		args.ACLAllow(member)
 	}
 
-	f, err := env.FM.Save(args)
+	f, err := env.FM.Save(context.TODO(), args)
 	require.NoError(t, err)
 	return f
 }

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -39,7 +38,7 @@ func (h *Handlers) Login(c echo.Context) error {
 		return err
 	}
 
-	user, err := h.Repo.GetUserByName(context.TODO(), req.Name, false)
+	user, err := h.Repo.GetUserByName(c.Request().Context(), req.Name, false)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -135,7 +134,7 @@ func (h *Handlers) RevokeMySession(c echo.Context) error {
 func (h *Handlers) GetMyTokens(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	ot, err := h.Repo.GetTokensByUser(context.TODO(), userID)
+	ot, err := h.Repo.GetTokensByUser(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -165,7 +164,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 	tokenID := getParamAsUUID(c, consts.ParamTokenID)
 	userID := getRequestUserID(c)
 
-	ot, err := h.Repo.GetTokenByID(context.TODO(), tokenID)
+	ot, err := h.Repo.GetTokenByID(c.Request().Context(), tokenID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -178,7 +177,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 		return herror.NotFound()
 	}
 
-	if err := h.Repo.DeleteTokenByAccess(context.TODO(), ot.AccessToken); err != nil {
+	if err := h.Repo.DeleteTokenByAccess(c.Request().Context(), ot.AccessToken); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -187,7 +186,7 @@ func (h *Handlers) RevokeMyToken(c echo.Context) error {
 
 // GetMyExternalAccounts GET /users/me/ex-accounts
 func (h *Handlers) GetMyExternalAccounts(c echo.Context) error {
-	links, err := h.Repo.GetLinkedExternalUserAccounts(context.TODO(), getRequestUserID(c))
+	links, err := h.Repo.GetLinkedExternalUserAccounts(c.Request().Context(), getRequestUserID(c))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -235,7 +234,7 @@ func (h *Handlers) LinkExternalAccount(c echo.Context) error {
 		return herror.BadRequest("invalid provider name")
 	}
 
-	links, err := h.Repo.GetLinkedExternalUserAccounts(context.TODO(), getRequestUserID(c))
+	links, err := h.Repo.GetLinkedExternalUserAccounts(c.Request().Context(), getRequestUserID(c))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -266,7 +265,7 @@ func (h *Handlers) UnlinkExternalAccount(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UnlinkExternalUserAccount(context.TODO(), getRequestUserID(c), req.ProviderName); err != nil {
+	if err := h.Repo.UnlinkExternalUserAccount(c.Request().Context(), getRequestUserID(c), req.ProviderName); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.BadRequest("invalid provider name")

--- a/router/v3/stamp_palettes.go
+++ b/router/v3/stamp_palettes.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/traPtitech/traQ/router/extension"
@@ -20,7 +19,7 @@ import (
 func (h *Handlers) GetStampPalettes(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	palettes, err := h.Repo.GetStampPalettes(context.TODO(), userID)
+	palettes, err := h.Repo.GetStampPalettes(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -57,7 +56,7 @@ func (h *Handlers) CreateStampPalette(c echo.Context) error {
 	}
 
 	// スタンプパレット作成
-	sp, err := h.Repo.CreateStampPalette(context.TODO(), req.Name, req.Description, req.Stamps, userID)
+	sp, err := h.Repo.CreateStampPalette(c.Request().Context(), req.Name, req.Description, req.Stamps, userID)
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -109,7 +108,7 @@ func (h *Handlers) EditStampPalette(c echo.Context) error {
 	}
 
 	// スタンプパレット更新
-	if err := h.Repo.UpdateStampPalette(context.TODO(), stampPalette.ID, args); err != nil {
+	if err := h.Repo.UpdateStampPalette(c.Request().Context(), stampPalette.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -135,7 +134,7 @@ func (h *Handlers) DeleteStampPalette(c echo.Context) error {
 		return herror.Forbidden("you are not permitted to delete stamp-palette created by others")
 	}
 
-	if err := h.Repo.DeleteStampPalette(context.TODO(), stampPalette.ID); err != nil {
+	if err := h.Repo.DeleteStampPalette(c.Request().Context(), stampPalette.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -66,7 +66,7 @@ func (h *Handlers) GetStamps(c echo.Context) error {
 		stampType = repository.StampTypeOriginal
 	}
 
-	stamps, err := h.Repo.GetAllStampsWithThumbnail(context.TODO(), stampType)
+	stamps, err := h.Repo.GetAllStampsWithThumbnail(c.Request().Context(), stampType)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -85,7 +85,7 @@ func (h *Handlers) CreateStamp(c echo.Context) error {
 	}
 
 	// スタンプ作成
-	s, err := h.Repo.CreateStamp(context.TODO(), repository.CreateStampArgs{Name: c.FormValue("name"), FileID: fileID, CreatorID: userID})
+	s, err := h.Repo.CreateStamp(c.Request().Context(), repository.CreateStampArgs{Name: c.FormValue("name"), FileID: fileID, CreatorID: userID})
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -138,7 +138,7 @@ func (h *Handlers) EditStamp(c echo.Context) error {
 	}
 
 	// 更新
-	if err := h.Repo.UpdateStamp(context.TODO(), stamp.ID, args); err != nil {
+	if err := h.Repo.UpdateStamp(c.Request().Context(), stamp.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -155,7 +155,7 @@ func (h *Handlers) EditStamp(c echo.Context) error {
 func (h *Handlers) DeleteStamp(c echo.Context) error {
 	stampID := getParamAsUUID(c, consts.ParamStampID)
 
-	if err := h.Repo.DeleteStamp(context.TODO(), stampID); err != nil {
+	if err := h.Repo.DeleteStamp(c.Request().Context(), stampID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -203,7 +203,7 @@ func (h *Handlers) ChangeStampImage(c echo.Context) error {
 
 	args := repository.UpdateStampArgs{FileID: optional.From(fileID)}
 	// 更新
-	if err := h.Repo.UpdateStamp(context.TODO(), stamp.ID, args); err != nil {
+	if err := h.Repo.UpdateStamp(c.Request().Context(), stamp.ID, args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -217,7 +217,7 @@ func (h *Handlers) ChangeStampImage(c echo.Context) error {
 // GetStampStats GET /stamps/:stampID/stats
 func (h *Handlers) GetStampStats(c echo.Context) error {
 	stampID := getParamAsUUID(c, consts.ParamStampID)
-	stats, err := h.Repo.GetStampStats(context.TODO(), stampID)
+	stats, err := h.Repo.GetStampStats(c.Request().Context(), stampID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/stamps.go
+++ b/router/v3/stamps.go
@@ -167,7 +167,7 @@ func (h *Handlers) GetStampImage(c echo.Context) error {
 	stamp := getParamStamp(c)
 
 	// ファイルメタ取得
-	meta, err := h.FileManager.Get(stamp.FileID)
+	meta, err := h.FileManager.Get(c.Request().Context(), stamp.FileID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/star.go
+++ b/router/v3/star.go
@@ -20,7 +20,7 @@ import (
 func (h *Handlers) GetMyStars(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	stars, err := h.Repo.GetStaredChannels(context.TODO(), userID)
+	stars, err := h.Repo.GetStaredChannels(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -47,7 +47,7 @@ func (h *Handlers) PostStar(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.AddStar(context.TODO(), getRequestUserID(c), req.ChannelID); err != nil {
+	if err := h.Repo.AddStar(c.Request().Context(), getRequestUserID(c), req.ChannelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -59,7 +59,7 @@ func (h *Handlers) RemoveMyStar(c echo.Context) error {
 	userID := getRequestUserID(c)
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
-	if err := h.Repo.RemoveStar(context.TODO(), userID, channelID); err != nil {
+	if err := h.Repo.RemoveStar(c.Request().Context(), userID, channelID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/tags.go
+++ b/router/v3/tags.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -27,7 +26,7 @@ func (h *Handlers) GetMyUserTags(c echo.Context) error {
 
 // serveUserTags 指定したユーザーのタグ一覧をレスポンスとして返す
 func serveUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) error {
-	tags, err := repo.GetUserTagsByUserID(context.TODO(), userID)
+	tags, err := repo.GetUserTagsByUserID(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -66,13 +65,13 @@ func addUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) e
 	}
 
 	// タグの確認
-	t, err := repo.GetOrCreateTag(context.TODO(), req.Tag)
+	t, err := repo.GetOrCreateTag(c.Request().Context(), req.Tag)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
 	// ユーザーにタグを付与
-	if err := repo.AddUserTag(context.TODO(), userID, t.ID); err != nil {
+	if err := repo.AddUserTag(c.Request().Context(), userID, t.ID); err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
 			return c.NoContent(http.StatusConflict)
@@ -81,7 +80,7 @@ func addUserTags(c echo.Context, repo repository.Repository, userID uuid.UUID) e
 		}
 	}
 
-	ut, err := repo.GetUserTag(context.TODO(), userID, t.ID)
+	ut, err := repo.GetUserTag(c.Request().Context(), userID, t.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -112,7 +111,7 @@ func (h *Handlers) EditUserTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// 更新
-	if err := h.Repo.ChangeUserTagLock(context.TODO(), userID, tagID, req.IsLocked); err != nil {
+	if err := h.Repo.ChangeUserTagLock(c.Request().Context(), userID, tagID, req.IsLocked); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.NotFound()
@@ -135,7 +134,7 @@ func (h *Handlers) EditMyUserTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// 更新
-	if err := h.Repo.ChangeUserTagLock(context.TODO(), userID, tagID, req.IsLocked); err != nil {
+	if err := h.Repo.ChangeUserTagLock(c.Request().Context(), userID, tagID, req.IsLocked); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return herror.NotFound()
@@ -162,7 +161,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
 	// タグがつけられているかを見る
-	ut, err := repo.GetUserTag(context.TODO(), userID, tagID)
+	ut, err := repo.GetUserTag(c.Request().Context(), userID, tagID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound: // 既にない
@@ -177,7 +176,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 	}
 
 	// 削除
-	if err := repo.DeleteUserTag(context.TODO(), userID, ut.GetTagID()); err != nil {
+	if err := repo.DeleteUserTag(c.Request().Context(), userID, ut.GetTagID()); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -188,7 +187,7 @@ func removeUserTag(c echo.Context, repo repository.Repository, userID uuid.UUID)
 func (h *Handlers) GetTag(c echo.Context) error {
 	tagID := getParamAsUUID(c, consts.ParamTagID)
 
-	t, err := h.Repo.GetTagByID(context.TODO(), tagID)
+	t, err := h.Repo.GetTagByID(c.Request().Context(), tagID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -198,7 +197,7 @@ func (h *Handlers) GetTag(c echo.Context) error {
 		}
 	}
 
-	users, err := h.Repo.GetUserIDsByTagID(context.TODO(), t.ID)
+	users, err := h.Repo.GetUserIDsByTagID(c.Request().Context(), t.ID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -25,7 +25,7 @@ import (
 
 // GetUserGroups GET /groups
 func (h *Handlers) GetUserGroups(c echo.Context) error {
-	gs, err := h.Repo.GetAllUserGroups(context.TODO())
+	gs, err := h.Repo.GetAllUserGroups(c.Request().Context())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -66,7 +66,7 @@ func (h *Handlers) PostUserGroups(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	g, err := h.Repo.CreateUserGroup(context.TODO(), req.Name, req.Description, req.Type, reqUserID, iconFileID)
+	g, err := h.Repo.CreateUserGroup(c.Request().Context(), req.Name, req.Description, req.Type, reqUserID, iconFileID)
 	if err != nil {
 		if err == repository.ErrAlreadyExists {
 			return herror.Conflict("group with the name already exists")
@@ -116,7 +116,7 @@ func (h *Handlers) EditUserGroup(c echo.Context) error {
 		Description: req.Description,
 		Type:        req.Type,
 	}
-	if err := h.Repo.UpdateUserGroup(context.TODO(), g.ID, args); err != nil {
+	if err := h.Repo.UpdateUserGroup(c.Request().Context(), g.ID, args); err != nil {
 		if err == repository.ErrAlreadyExists {
 			return herror.Conflict("group with the name already exists")
 		}
@@ -135,7 +135,7 @@ func (h *Handlers) PutUserGroupIcon(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateUserGroup(context.TODO(), g.ID, repository.UpdateUserGroupArgs{Icon: optional.From(fileID)}); err != nil {
+	if err := h.Repo.UpdateUserGroup(c.Request().Context(), g.ID, repository.UpdateUserGroupArgs{Icon: optional.From(fileID)}); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -146,7 +146,7 @@ func (h *Handlers) PutUserGroupIcon(c echo.Context) error {
 func (h *Handlers) DeleteUserGroup(c echo.Context) error {
 	g := getParamGroup(c)
 
-	if err := h.Repo.DeleteUserGroup(context.TODO(), g.ID); err != nil {
+	if err := h.Repo.DeleteUserGroup(c.Request().Context(), g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -182,7 +182,7 @@ func (h *Handlers) AddUserGroupMember(c echo.Context) error {
 	var singleReq PostUserGroupMemberRequest
 	c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	if err := bindAndValidate(c, &singleReq); err == nil {
-		if err := h.Repo.AddUserToGroup(context.TODO(), singleReq.ID, g.ID, singleReq.Role); err != nil {
+		if err := h.Repo.AddUserToGroup(c.Request().Context(), singleReq.ID, g.ID, singleReq.Role); err != nil {
 			return herror.InternalServerError(err)
 		}
 		return c.NoContent(http.StatusNoContent)
@@ -199,7 +199,7 @@ func (h *Handlers) AddUserGroupMember(c echo.Context) error {
 	for i, req := range reqs {
 		users[i] = model.UserGroupMember{UserID: req.ID, Role: req.Role, GroupID: g.ID}
 	}
-	if err := h.Repo.AddUsersToGroup(context.TODO(), users, g.ID); err != nil {
+	if err := h.Repo.AddUsersToGroup(c.Request().Context(), users, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -231,7 +231,7 @@ func (h *Handlers) EditUserGroupMember(c echo.Context) error {
 		return herror.BadRequest("this user is not this group's member")
 	}
 
-	if err := h.Repo.AddUserToGroup(context.TODO(), uid, g.ID, req.Role); err != nil {
+	if err := h.Repo.AddUserToGroup(c.Request().Context(), uid, g.ID, req.Role); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -242,7 +242,7 @@ func (h *Handlers) EditUserGroupMember(c echo.Context) error {
 func (h *Handlers) RemoveUserGroupMember(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
 	g := getParamGroup(c)
-	if err := h.Repo.RemoveUserFromGroup(context.TODO(), userID, g.ID); err != nil {
+	if err := h.Repo.RemoveUserFromGroup(c.Request().Context(), userID, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -252,7 +252,7 @@ func (h *Handlers) RemoveUserGroupMember(c echo.Context) error {
 // RemoveUserGroupMembers DELETE /groups/:groupID/members
 func (h *Handlers) RemoveUserGroupMembers(c echo.Context) error {
 	g := getParamGroup(c)
-	if err := h.Repo.RemoveUsersFromGroup(context.TODO(), g.ID); err != nil {
+	if err := h.Repo.RemoveUsersFromGroup(c.Request().Context(), g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -283,7 +283,7 @@ func (h *Handlers) AddUserGroupAdmin(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.AddUserToGroupAdmin(context.TODO(), req.ID, g.ID); err != nil {
+	if err := h.Repo.AddUserToGroupAdmin(c.Request().Context(), req.ID, g.ID); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -295,7 +295,7 @@ func (h *Handlers) RemoveUserGroupAdmin(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
 	g := getParamGroup(c)
 
-	if err := h.Repo.RemoveUserFromGroupAdmin(context.TODO(), userID, g.ID); err != nil {
+	if err := h.Repo.RemoveUserFromGroupAdmin(c.Request().Context(), userID, g.ID); err != nil {
 		if err == repository.ErrForbidden {
 			return herror.BadRequest()
 		}

--- a/router/v3/user_groups.go
+++ b/router/v3/user_groups.go
@@ -61,7 +61,7 @@ func (h *Handlers) PostUserGroups(c echo.Context) error {
 		return herror.Forbidden("you are not permitted to create groups of this type")
 	}
 
-	iconFileID, err := file2.GenerateIconFile(h.FileManager, req.Name)
+	iconFileID, err := file2.GenerateIconFile(c.Request().Context(), h.FileManager, req.Name)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/user_settings.go
+++ b/router/v3/user_settings.go
@@ -1,7 +1,6 @@
 package v3
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -23,7 +22,7 @@ func (h *Handlers) PutMyNotifyCitation(c echo.Context) error {
 		return err
 	}
 
-	if err := h.Repo.UpdateNotifyCitation(context.TODO(), id, us.NotifyCitation); err != nil {
+	if err := h.Repo.UpdateNotifyCitation(c.Request().Context(), id, us.NotifyCitation); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -34,7 +33,7 @@ func (h *Handlers) PutMyNotifyCitation(c echo.Context) error {
 func (h *Handlers) GetMySettings(c echo.Context) error {
 	id := getRequestUserID(c)
 
-	us, err := h.Repo.GetUserSettings(context.TODO(), id)
+	us, err := h.Repo.GetUserSettings(c.Request().Context(), id)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -46,7 +45,7 @@ func (h *Handlers) GetMySettings(c echo.Context) error {
 func (h *Handlers) GetMyNotifyCitation(c echo.Context) error {
 	id := getRequestUserID(c)
 
-	nc, err := h.Repo.GetNotifyCitation(context.TODO(), id)
+	nc, err := h.Repo.GetNotifyCitation(c.Request().Context(), id)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -129,7 +129,7 @@ func (h *Handlers) GetMeOIDC(c echo.Context) error {
 	tokenScopes, ok := c.Get(consts.KeyOAuth2AccessScopes).(model.AccessScopes)
 	scopes := lo.Ternary[oidc.ScopeChecker](ok, tokenScopes, userAccessScopes{})
 
-	userInfo, err := h.OIDC.GetUserInfo(getRequestUserID(c), scopes)
+	userInfo, err := h.OIDC.GetUserInfo(c.Request().Context(), getRequestUserID(c), scopes)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -69,7 +69,7 @@ func (h *Handlers) CreateUser(c echo.Context) error {
 		return err
 	}
 
-	iconFileID, err := file.GenerateIconFile(h.FileManager, req.Name)
+	iconFileID, err := file.GenerateIconFile(c.Request().Context(), h.FileManager, req.Name)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -42,7 +42,7 @@ func (h *Handlers) GetUsers(c echo.Context) error {
 		q = q.Active()
 	}
 
-	users, err := h.Repo.GetUsers(context.TODO(), q)
+	users, err := h.Repo.GetUsers(c.Request().Context(), q)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -74,7 +74,7 @@ func (h *Handlers) CreateUser(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	user, err := h.Repo.CreateUser(context.TODO(), repository.CreateUserArgs{Name: req.Name, Password: req.Password.ValueOrZero(), Role: role.User, IconFileID: iconFileID})
+	user, err := h.Repo.CreateUser(c.Request().Context(), repository.CreateUserArgs{Name: req.Name, Password: req.Password.ValueOrZero(), Role: role.User, IconFileID: iconFileID})
 	if err != nil {
 		switch err {
 		case repository.ErrAlreadyExists:
@@ -91,12 +91,12 @@ func (h *Handlers) CreateUser(c echo.Context) error {
 func (h *Handlers) GetMe(c echo.Context) error {
 	me := getRequestUser(c)
 
-	tags, err := h.Repo.GetUserTagsByUserID(context.TODO(), me.GetID())
+	tags, err := h.Repo.GetUserTagsByUserID(c.Request().Context(), me.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
-	groups, err := h.Repo.GetUserBelongingGroupIDs(context.TODO(), me.GetID())
+	groups, err := h.Repo.GetUserBelongingGroupIDs(c.Request().Context(), me.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -176,7 +176,7 @@ func (h *Handlers) EditMe(c echo.Context) error {
 		Bio:         req.Bio,
 		HomeChannel: req.HomeChannel,
 	}
-	if err := h.Repo.UpdateUser(context.TODO(), userID, args); err != nil {
+	if err := h.Repo.UpdateUser(c.Request().Context(), userID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -286,7 +286,7 @@ func (h *Handlers) GetMyStampHistory(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	history, err := h.Repo.GetUserStampHistory(context.TODO(), userID, req.Limit)
+	history, err := h.Repo.GetUserStampHistory(c.Request().Context(), userID, req.Limit)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -316,7 +316,7 @@ func (h *Handlers) GetMyStampRecommendations(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	recommendations, err := h.Repo.GetUserStampRecommendations(context.TODO(), userID, *req.Limit)
+	recommendations, err := h.Repo.GetUserStampRecommendations(c.Request().Context(), userID, *req.Limit)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -343,7 +343,7 @@ func (h *Handlers) PostMyFCMDevice(c echo.Context) error {
 	}
 
 	userID := getRequestUserID(c)
-	if err := h.Repo.RegisterDevice(context.TODO(), userID, req.Token); err != nil {
+	if err := h.Repo.RegisterDevice(c.Request().Context(), userID, req.Token); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -379,12 +379,12 @@ func (h *Handlers) ChangeUserPassword(c echo.Context) error {
 func (h *Handlers) GetUser(c echo.Context) error {
 	user := getParamUser(c)
 
-	tags, err := h.Repo.GetUserTagsByUserID(context.TODO(), user.GetID())
+	tags, err := h.Repo.GetUserTagsByUserID(c.Request().Context(), user.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
 
-	groups, err := h.Repo.GetUserBelongingGroupIDs(context.TODO(), user.GetID())
+	groups, err := h.Repo.GetUserBelongingGroupIDs(c.Request().Context(), user.GetID())
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -429,7 +429,7 @@ func (h *Handlers) EditUser(c echo.Context) error {
 		deactivate = req.State.V == model.UserAccountStatusDeactivated.Int()
 	}
 
-	if err := h.Repo.UpdateUser(context.TODO(), userID, args); err != nil {
+	if err := h.Repo.UpdateUser(c.Request().Context(), userID, args); err != nil {
 		return herror.InternalServerError(err)
 	}
 	// 凍結の際
@@ -450,7 +450,7 @@ func (h *Handlers) EditUser(c echo.Context) error {
 
 // GetMyChannelSubscriptions GET /users/me/subscriptions
 func (h *Handlers) GetMyChannelSubscriptions(c echo.Context) error {
-	subscriptions, err := h.Repo.GetChannelSubscriptions(context.TODO(), repository.ChannelSubscriptionQuery{}.SetUser(getRequestUserID(c)))
+	subscriptions, err := h.Repo.GetChannelSubscriptions(c.Request().Context(), repository.ChannelSubscriptionQuery{}.SetUser(getRequestUserID(c)))
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -512,7 +512,7 @@ func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
 // GetUserStats GET /users/me/:userID/stats
 func (h *Handlers) GetUserStats(c echo.Context) error {
 	userID := getParamAsUUID(c, consts.ParamUserID)
-	stats, err := h.Repo.GetUserStats(context.TODO(), userID)
+	stats, err := h.Repo.GetUserStats(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -154,6 +154,7 @@ func (r PatchMeRequest) ValidateWithContext(ctx context.Context) error {
 
 // EditMe PATCH /users/me
 func (h *Handlers) EditMe(c echo.Context) error {
+	ctx := c.Request().Context()
 	userID := getRequestUserID(c)
 
 	var req PatchMeRequest
@@ -164,7 +165,7 @@ func (h *Handlers) EditMe(c echo.Context) error {
 	if req.HomeChannel.Valid {
 		if req.HomeChannel.V != uuid.Nil {
 			// チャンネル存在確認
-			if !h.ChannelManager.PublicChannelTree().IsChannelPresent(req.HomeChannel.V) {
+			if !h.ChannelManager.PublicChannelTree(ctx).IsChannelPresent(req.HomeChannel.V) {
 				return herror.BadRequest("invalid homeChannel")
 			}
 		}
@@ -481,6 +482,7 @@ func (r PutChannelSubscribeLevelRequest) Validate() error {
 
 // SetChannelSubscribeLevel PUT /users/me/subscriptions/:channelID
 func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
+	ctx := c.Request().Context()
 	channelID := getParamAsUUID(c, consts.ParamChannelID)
 
 	var req PutChannelSubscribeLevelRequest
@@ -488,7 +490,7 @@ func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
 		return err
 	}
 
-	ch, err := h.ChannelManager.GetChannel(channelID)
+	ch, err := h.ChannelManager.GetChannel(ctx, channelID)
 	if err != nil {
 		if err == channel.ErrChannelNotFound {
 			return herror.NotFound()
@@ -496,7 +498,7 @@ func (h *Handlers) SetChannelSubscribeLevel(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	if err := h.ChannelManager.ChangeChannelSubscriptions(ch.ID, map[uuid.UUID]model.ChannelSubscribeLevel{getRequestUserID(c): model.ChannelSubscribeLevel(req.Level.V)}, false, getRequestUserID(c)); err != nil {
+	if err := h.ChannelManager.ChangeChannelSubscriptions(ctx, ch.ID, map[uuid.UUID]model.ChannelSubscribeLevel{getRequestUserID(c): model.ChannelSubscribeLevel(req.Level.V)}, false, getRequestUserID(c)); err != nil {
 		switch err {
 		case channel.ErrInvalidChannel:
 			return herror.Forbidden("the channel's subscriptions is not configurable")

--- a/router/v3/users_test.go
+++ b/router/v3/users_test.go
@@ -1013,7 +1013,7 @@ func TestHandlers_GetMyChannelSubscriptions(t *testing.T) {
 	env := Setup(t, common1)
 	user := env.CreateUser(t, rand)
 	ch := env.CreateChannel(t, rand)
-	err := env.CM.ChangeChannelSubscriptions(ch.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
+	err := env.CM.ChangeChannelSubscriptions(context.TODO(), ch.ID, map[uuid.UUID]model.ChannelSubscribeLevel{
 		user.GetID(): model.ChannelSubscribeLevelMarkAndNotify,
 	}, false, user.GetID())
 	require.NoError(t, err)
@@ -1094,7 +1094,7 @@ func TestHandlers_SetChannelSubscribeLevel(t *testing.T) {
 	ch := env.CreateChannel(t, rand)
 	forced := env.CreateChannel(t, rand)
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
-	err := env.CM.UpdateChannel(forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)})
+	err := env.CM.UpdateChannel(context.TODO(), forced.ID, repository.UpdateChannelArgs{ForcedNotification: optional.From(true)})
 	require.NoError(t, err)
 	s := env.S(t, user.GetID())
 

--- a/router/v3/utils.go
+++ b/router/v3/utils.go
@@ -151,7 +151,8 @@ func (q *MessagesQuery) convertU(uid uuid.UUID) message.TimelineQuery {
 }
 
 func serveMessages(c echo.Context, mm message.Manager, query message.TimelineQuery) error {
-	timeline, err := mm.GetTimeline(query)
+	ctx := c.Request().Context()
+	timeline, err := mm.GetTimeline(ctx, query)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -162,6 +162,7 @@ func (h *Handlers) EditWebhook(c echo.Context) error {
 
 // PostWebhook POST /webhooks/:webhookID
 func (h *Handlers) PostWebhook(c echo.Context) error {
+	ctx := c.Request().Context()
 	w := getParamWebhook(c)
 	channelID := w.GetChannelID()
 
@@ -202,7 +203,7 @@ func (h *Handlers) PostWebhook(c echo.Context) error {
 	}
 
 	// 投稿先チャンネル確認
-	if !h.ChannelManager.PublicChannelTree(c.Request().Context()).IsChannelPresent(channelID) {
+	if !h.ChannelManager.PublicChannelTree(ctx).IsChannelPresent(channelID) {
 		return herror.BadRequest("invalid channel")
 	}
 
@@ -212,7 +213,7 @@ func (h *Handlers) PostWebhook(c echo.Context) error {
 	}
 
 	// メッセージ投稿
-	if _, err := h.MessageManager.Create(channelID, w.GetBotUserID(), string(body)); err != nil {
+	if _, err := h.MessageManager.Create(ctx, channelID, w.GetBotUserID(), string(body)); err != nil {
 		switch err {
 		case message.ErrChannelArchived:
 			return herror.BadRequest("the channel has been archived")

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -35,9 +35,9 @@ func (h *Handlers) GetWebhooks(c echo.Context) error {
 		err  error
 	)
 	if isTrue(c.QueryParam("all")) && h.RBAC.IsGranted(user.GetRole(), permission.AccessOthersWebhook) {
-		list, err = h.Repo.GetAllWebhooks(context.TODO())
+		list, err = h.Repo.GetAllWebhooks(c.Request().Context())
 	} else {
-		list, err = h.Repo.GetWebhooksByCreator(context.TODO(), user.GetID())
+		list, err = h.Repo.GetWebhooksByCreator(c.Request().Context(), user.GetID())
 	}
 	if err != nil {
 		return herror.InternalServerError(err)
@@ -51,7 +51,7 @@ func (h *Handlers) GetWebhookIcon(c echo.Context) error {
 	w := getParamWebhook(c)
 
 	// ユーザー取得
-	user, err := h.Repo.GetUser(context.TODO(), w.GetBotUserID(), false)
+	user, err := h.Repo.GetUser(c.Request().Context(), w.GetBotUserID(), false)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -95,7 +95,7 @@ func (h *Handlers) CreateWebhook(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 
-	w, err := h.Repo.CreateWebhook(context.TODO(), req.Name, req.Description, req.ChannelID, iconFileID, userID, req.Secret)
+	w, err := h.Repo.CreateWebhook(c.Request().Context(), req.Name, req.Description, req.ChannelID, iconFileID, userID, req.Secret)
 	if err != nil {
 		switch {
 		case repository.IsArgError(err):
@@ -149,7 +149,7 @@ func (h *Handlers) EditWebhook(c echo.Context) error {
 		Secret:      req.Secret,
 		CreatorID:   req.OwnerID,
 	}
-	if err := h.Repo.UpdateWebhook(context.TODO(), w.GetID(), args); err != nil {
+	if err := h.Repo.UpdateWebhook(c.Request().Context(), w.GetID(), args); err != nil {
 		switch {
 		case repository.IsArgError(err):
 			return herror.BadRequest(err)
@@ -228,7 +228,7 @@ func (h *Handlers) PostWebhook(c echo.Context) error {
 func (h *Handlers) DeleteWebhook(c echo.Context) error {
 	w := getParamWebhook(c)
 
-	if err := h.Repo.DeleteWebhook(context.TODO(), w.GetID()); err != nil {
+	if err := h.Repo.DeleteWebhook(c.Request().Context(), w.GetID()); err != nil {
 		return herror.InternalServerError(err)
 	}
 
@@ -256,7 +256,7 @@ func (h *Handlers) DeleteWebhookMessage(c echo.Context) error {
 	messageUserID := m.GetUserID()
 
 	if botUserID == messageUserID {
-		if err := h.Repo.DeleteMessage(context.TODO(), messageID); err != nil {
+		if err := h.Repo.DeleteMessage(c.Request().Context(), messageID); err != nil {
 			return herror.InternalServerError(err)
 		}
 	} else {

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -202,7 +202,7 @@ func (h *Handlers) PostWebhook(c echo.Context) error {
 	}
 
 	// 投稿先チャンネル確認
-	if !h.ChannelManager.PublicChannelTree().IsChannelPresent(channelID) {
+	if !h.ChannelManager.PublicChannelTree(c.Request().Context()).IsChannelPresent(channelID) {
 		return herror.BadRequest("invalid channel")
 	}
 

--- a/router/v3/webhooks.go
+++ b/router/v3/webhooks.go
@@ -90,7 +90,7 @@ func (h *Handlers) CreateWebhook(c echo.Context) error {
 		return err
 	}
 
-	iconFileID, err := file.GenerateIconFile(h.FileManager, req.Name)
+	iconFileID, err := file.GenerateIconFile(c.Request().Context(), h.FileManager, req.Name)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}

--- a/router/v3/webhooks_test.go
+++ b/router/v3/webhooks_test.go
@@ -119,7 +119,7 @@ func TestHandlers_GetWebhookIcon(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	ch := env.CreateChannel(t, rand)
 
-	file, err := file2.GenerateIconFile(env.FM, "wh")
+	file, err := file2.GenerateIconFile(context.TODO(), env.FM, "wh")
 	require.NoError(t, err)
 	wh, err := env.Repository.CreateWebhook(context.TODO(), random2.AlphaNumeric(20), "", ch.ID, file, user.GetID(), "")
 	require.NoError(t, err)

--- a/router/v3/webhooks_test.go
+++ b/router/v3/webhooks_test.go
@@ -317,7 +317,7 @@ func TestHandlers_PostWebhook(t *testing.T) {
 	ch2 := env.CreateChannel(t, rand)
 	dm := env.CreateDMChannel(t, user.GetID(), user2.GetID())
 	archived := env.CreateChannel(t, rand)
-	require.NoError(t, env.CM.ArchiveChannel(archived.ID, user.GetID()))
+	require.NoError(t, env.CM.ArchiveChannel(context.TODO(), archived.ID, user.GetID()))
 	wh := env.CreateWebhook(t, rand, user.GetID(), ch.ID)
 
 	calcHMACSHA1 := func(t *testing.T, message, secret string) string {
@@ -419,7 +419,7 @@ func TestHandlers_PostWebhook(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		tl, err := env.MM.GetTimeline(message.TimelineQuery{Channel: ch2.ID})
+		tl, err := env.MM.GetTimeline(context.TODO(), message.TimelineQuery{Channel: ch2.ID})
 		require.NoError(t, err)
 		if assert.Len(t, tl.Records(), 1) {
 			m := tl.Records()[0]
@@ -438,7 +438,7 @@ func TestHandlers_PostWebhook(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		tl, err := env.MM.GetTimeline(message.TimelineQuery{Channel: ch.ID})
+		tl, err := env.MM.GetTimeline(context.TODO(), message.TimelineQuery{Channel: ch.ID})
 		require.NoError(t, err)
 		if assert.Len(t, tl.Records(), 1) {
 			m := tl.Records()[0]

--- a/service/bot/event/dispatcher_impl.go
+++ b/service/bot/event/dispatcher_impl.go
@@ -59,7 +59,7 @@ func (d *dispatcherImpl) Send(b *model.Bot, event model.BotEventType, body []byt
 }
 
 func (d *dispatcherImpl) writeLog(log *model.BotEventLog) {
-	if err := d.repo.WriteBotEventLog(context.TODO(), log); err != nil {
+	if err := d.repo.WriteBotEventLog(context.Background(), log); err != nil {
 		d.l.Warn("failed to write log", zap.Error(err), zap.Any("eventLog", log))
 	}
 }

--- a/service/bot/handler/ev_bot_joined.go
+++ b/service/bot/handler/ev_bot_joined.go
@@ -26,7 +26,7 @@ func BotJoined(ctx Context, datetime time.Time, _ string, fields hub.Fields) err
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
-	user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
+	user, err := ctx.R().GetUser(context.Background(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_bot_joined.go
+++ b/service/bot/handler/ev_bot_joined.go
@@ -22,7 +22,7 @@ func BotJoined(ctx Context, datetime time.Time, _ string, fields hub.Fields) err
 		return fmt.Errorf("failed to GetBot: %w", err)
 	}
 
-	ch, err := ctx.CM().GetChannel(channelID)
+	ch, err := ctx.CM().GetChannel(context.Background(), channelID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
@@ -33,7 +33,7 @@ func BotJoined(ctx Context, datetime time.Time, _ string, fields hub.Fields) err
 
 	err = ctx.Unicast(
 		event.Joined,
-		payload.MakeJoined(datetime, ch, ctx.CM().PublicChannelTree().GetChannelPath(channelID), user),
+		payload.MakeJoined(datetime, ch, ctx.CM().PublicChannelTree(context.Background()).GetChannelPath(channelID), user),
 		bot,
 	)
 	if err != nil {

--- a/service/bot/handler/ev_bot_joined_test.go
+++ b/service/bot/handler/ev_bot_joined_test.go
@@ -42,7 +42,7 @@ func TestBotJoined(t *testing.T) {
 		handlerCtx, cm, repo := setup(t, ctrl)
 
 		tree := mock_channel.NewMockTree(ctrl)
-		cm.EXPECT().PublicChannelTree().Return(tree).AnyTimes()
+		cm.EXPECT().PublicChannelTree(gomock.Any()).Return(tree).AnyTimes()
 		tree.EXPECT().GetChannelPath(ch.ID).Return("test").AnyTimes()
 
 		registerBot(t, handlerCtx, b)

--- a/service/bot/handler/ev_bot_left.go
+++ b/service/bot/handler/ev_bot_left.go
@@ -26,7 +26,7 @@ func BotLeft(ctx Context, datetime time.Time, _ string, fields hub.Fields) error
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
-	user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
+	user, err := ctx.R().GetUser(context.Background(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_bot_left.go
+++ b/service/bot/handler/ev_bot_left.go
@@ -22,7 +22,7 @@ func BotLeft(ctx Context, datetime time.Time, _ string, fields hub.Fields) error
 		return fmt.Errorf("failed to GetBot: %w", err)
 	}
 
-	ch, err := ctx.CM().GetChannel(channelID)
+	ch, err := ctx.CM().GetChannel(context.Background(), channelID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
@@ -33,7 +33,7 @@ func BotLeft(ctx Context, datetime time.Time, _ string, fields hub.Fields) error
 
 	err = ctx.Unicast(
 		event.Left,
-		payload.MakeLeft(datetime, ch, ctx.CM().PublicChannelTree().GetChannelPath(channelID), user),
+		payload.MakeLeft(datetime, ch, ctx.CM().PublicChannelTree(context.Background()).GetChannelPath(channelID), user),
 		bot,
 	)
 	if err != nil {

--- a/service/bot/handler/ev_bot_left_test.go
+++ b/service/bot/handler/ev_bot_left_test.go
@@ -42,7 +42,7 @@ func TestBotLeft(t *testing.T) {
 		handlerCtx, cm, repo := setup(t, ctrl)
 
 		tree := mock_channel.NewMockTree(ctrl)
-		cm.EXPECT().PublicChannelTree().Return(tree).AnyTimes()
+		cm.EXPECT().PublicChannelTree(gomock.Any()).Return(tree).AnyTimes()
 		tree.EXPECT().GetChannelPath(ch.ID).Return("test").AnyTimes()
 
 		registerBot(t, handlerCtx, b)

--- a/service/bot/handler/ev_bot_ping_request.go
+++ b/service/bot/handler/ev_bot_ping_request.go
@@ -23,12 +23,12 @@ func BotPingRequest(ctx Context, datetime time.Time, _ string, fields hub.Fields
 
 	if ctx.D().Send(bot, event.Ping, buf) {
 		// OK
-		if err := ctx.R().ChangeBotState(context.TODO(), bot.ID, model.BotActive); err != nil {
+		if err := ctx.R().ChangeBotState(context.Background(), bot.ID, model.BotActive); err != nil {
 			return fmt.Errorf("failed to ChangeBotState: %w", err)
 		}
 	} else {
 		// NG
-		if err := ctx.R().ChangeBotState(context.TODO(), bot.ID, model.BotPaused); err != nil {
+		if err := ctx.R().ChangeBotState(context.Background(), bot.ID, model.BotPaused); err != nil {
 			return fmt.Errorf("failed to ChangeBotState: %w", err)
 		}
 	}

--- a/service/bot/handler/ev_bot_ping_request_test.go
+++ b/service/bot/handler/ev_bot_ping_request_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -41,7 +40,7 @@ func TestBotPingRequest(t *testing.T) {
 		buf, err := jsonIter.ConfigFastest.Marshal(payload.MakePing(et))
 		require.NoError(t, err)
 
-		repo.MockBotRepository.EXPECT().ChangeBotState(context.TODO(), b.ID, model.BotActive).Return(nil).Times(1)
+		repo.MockBotRepository.EXPECT().ChangeBotState(gomock.Any(), b.ID, model.BotActive).Return(nil).Times(1)
 		d.EXPECT().Send(b, event.Ping, buf).Return(true).Times(1)
 
 		assert.NoError(t, BotPingRequest(handlerCtx, et, intevent.BotPingRequest, hub.Fields{
@@ -61,7 +60,7 @@ func TestBotPingRequest(t *testing.T) {
 		buf, err := jsonIter.ConfigFastest.Marshal(payload.MakePing(et))
 		require.NoError(t, err)
 
-		repo.MockBotRepository.EXPECT().ChangeBotState(context.TODO(), b.ID, model.BotPaused).Return(nil).Times(1)
+		repo.MockBotRepository.EXPECT().ChangeBotState(gomock.Any(), b.ID, model.BotPaused).Return(nil).Times(1)
 		d.EXPECT().Send(b, event.Ping, buf).Return(false).Times(1)
 
 		assert.NoError(t, BotPingRequest(handlerCtx, et, intevent.BotPingRequest, hub.Fields{

--- a/service/bot/handler/ev_channel_created.go
+++ b/service/bot/handler/ev_channel_created.go
@@ -30,7 +30,7 @@ func ChannelCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 
 		if err := ctx.Multicast(
 			event.ChannelCreated,
-			payload.MakeChannelCreated(datetime, ch, ctx.CM().PublicChannelTree().GetChannelPath(ch.ID), user),
+			payload.MakeChannelCreated(datetime, ch, ctx.CM().PublicChannelTree(context.Background()).GetChannelPath(ch.ID), user),
 			bots,
 		); err != nil {
 			return fmt.Errorf("failed to multicast: %w", err)

--- a/service/bot/handler/ev_channel_created.go
+++ b/service/bot/handler/ev_channel_created.go
@@ -23,7 +23,7 @@ func ChannelCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 			return nil
 		}
 
-		user, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
+		user, err := ctx.R().GetUser(context.Background(), ch.CreatorID, false)
 		if err != nil {
 			return fmt.Errorf("failed to GetUser: %w", err)
 		}

--- a/service/bot/handler/ev_channel_created_test.go
+++ b/service/bot/handler/ev_channel_created_test.go
@@ -41,7 +41,7 @@ func TestChannelCreated(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		handlerCtx, cm, repo := setup(t, ctrl)
 		tree := mock_channel.NewMockTree(ctrl)
-		cm.EXPECT().PublicChannelTree().Return(tree).AnyTimes()
+		cm.EXPECT().PublicChannelTree(gomock.Any()).Return(tree).AnyTimes()
 		tree.EXPECT().GetChannelPath(ch.ID).Return(ch.Name).AnyTimes()
 
 		registerBot(t, handlerCtx, b)

--- a/service/bot/handler/ev_channel_topic_updated.go
+++ b/service/bot/handler/ev_channel_topic_updated.go
@@ -26,7 +26,7 @@ func ChannelTopicUpdated(ctx Context, datetime time.Time, _ string, fields hub.F
 		return nil
 	}
 
-	ch, err := ctx.CM().GetChannel(chID)
+	ch, err := ctx.CM().GetChannel(context.Background(), chID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
@@ -43,7 +43,7 @@ func ChannelTopicUpdated(ctx Context, datetime time.Time, _ string, fields hub.F
 
 	if err := ctx.Multicast(
 		event.ChannelTopicChanged,
-		payload.MakeChannelTopicChanged(datetime, ch, ctx.CM().PublicChannelTree().GetChannelPath(ch.ID), chCreator, topic, user),
+		payload.MakeChannelTopicChanged(datetime, ch, ctx.CM().PublicChannelTree(context.Background()).GetChannelPath(ch.ID), chCreator, topic, user),
 		bots,
 	); err != nil {
 		return fmt.Errorf("failed to multicast: %w", err)

--- a/service/bot/handler/ev_channel_topic_updated.go
+++ b/service/bot/handler/ev_channel_topic_updated.go
@@ -31,12 +31,12 @@ func ChannelTopicUpdated(ctx Context, datetime time.Time, _ string, fields hub.F
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	chCreator, err := ctx.R().GetUser(context.TODO(), ch.CreatorID, false)
+	chCreator, err := ctx.R().GetUser(context.Background(), ch.CreatorID, false)
 	if err != nil && err != repository.ErrNotFound {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(context.TODO(), updaterID, false)
+	user, err := ctx.R().GetUser(context.Background(), updaterID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_channel_topic_updated_test.go
+++ b/service/bot/handler/ev_channel_topic_updated_test.go
@@ -42,7 +42,7 @@ func TestChannelTopicUpdated(t *testing.T) {
 		handlerCtx, cm, repo := setup(t, ctrl)
 
 		tree := mock_channel.NewMockTree(ctrl)
-		cm.EXPECT().PublicChannelTree().Return(tree).AnyTimes()
+		cm.EXPECT().PublicChannelTree(gomock.Any()).Return(tree).AnyTimes()
 		tree.EXPECT().GetChannelPath(ch.ID).Return(ch.Name).AnyTimes()
 
 		registerBot(t, handlerCtx, b)

--- a/service/bot/handler/ev_message_created.go
+++ b/service/bot/handler/ev_message_created.go
@@ -24,7 +24,7 @@ func MessageCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(context.TODO(), m.UserID, false)
+	user, err := ctx.R().GetUser(context.Background(), m.UserID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_message_created.go
+++ b/service/bot/handler/ev_message_created.go
@@ -19,7 +19,7 @@ func MessageCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 	m := fields["message"].(*model.Message)
 	parsed := fields["parse_result"].(*message.ParseResult)
 
-	ch, err := ctx.CM().GetChannel(m.ChannelID)
+	ch, err := ctx.CM().GetChannel(context.Background(), m.ChannelID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
@@ -30,7 +30,7 @@ func MessageCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 	}
 
 	if ch.IsDMChannel() {
-		ids, err := ctx.CM().GetDMChannelMembers(ch.ID)
+		ids, err := ctx.CM().GetDMChannelMembers(context.Background(), ch.ID)
 		if err != nil {
 			return fmt.Errorf("failed to GetDMChannelMembers: %w", err)
 		}

--- a/service/bot/handler/ev_message_deleted.go
+++ b/service/bot/handler/ev_message_deleted.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,13 +16,13 @@ import (
 func MessageDeleted(ctx Context, datetime time.Time, _ string, fields hub.Fields) error {
 	m := fields["message"].(*model.Message)
 
-	ch, err := ctx.CM().GetChannel(m.ChannelID)
+	ch, err := ctx.CM().GetChannel(context.Background(), m.ChannelID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
 	if ch.IsDMChannel() {
-		ids, err := ctx.CM().GetDMChannelMembers(ch.ID)
+		ids, err := ctx.CM().GetDMChannelMembers(context.Background(), ch.ID)
 		if err != nil {
 			return fmt.Errorf("failed to GetDMChannelMembers: %w", err)
 		}

--- a/service/bot/handler/ev_message_updated.go
+++ b/service/bot/handler/ev_message_updated.go
@@ -18,7 +18,7 @@ func MessageUpdated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 	m := fields["message"].(*model.Message)
 	parsed := message.Parse(m.Text)
 
-	ch, err := ctx.CM().GetChannel(m.ChannelID)
+	ch, err := ctx.CM().GetChannel(context.Background(), m.ChannelID)
 	if err != nil {
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
@@ -29,7 +29,7 @@ func MessageUpdated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 	}
 
 	if ch.IsDMChannel() {
-		ids, err := ctx.CM().GetDMChannelMembers(ch.ID)
+		ids, err := ctx.CM().GetDMChannelMembers(context.Background(), ch.ID)
 		if err != nil {
 			return fmt.Errorf("failed to GetDMChannelMembers: %w", err)
 		}

--- a/service/bot/handler/ev_message_updated.go
+++ b/service/bot/handler/ev_message_updated.go
@@ -23,7 +23,7 @@ func MessageUpdated(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return fmt.Errorf("failed to GetChannel: %w", err)
 	}
 
-	user, err := ctx.R().GetUser(context.TODO(), m.UserID, false)
+	user, err := ctx.R().GetUser(context.Background(), m.UserID, false)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}

--- a/service/bot/handler/ev_stamp_created.go
+++ b/service/bot/handler/ev_stamp_created.go
@@ -25,7 +25,7 @@ func StampCreated(ctx Context, datetime time.Time, _ string, fields hub.Fields) 
 
 	var user model.UserInfo
 	if !stamp.IsSystemStamp() {
-		user, err = ctx.R().GetUser(context.TODO(), stamp.CreatorID, false)
+		user, err = ctx.R().GetUser(context.Background(), stamp.CreatorID, false)
 		if err != nil {
 			return fmt.Errorf("failed to GetUser: %w", err)
 		}

--- a/service/bot/handler/ev_user_tag_added.go
+++ b/service/bot/handler/ev_user_tag_added.go
@@ -24,7 +24,7 @@ func UserTagAdded(ctx Context, datetime time.Time, _ string, fields hub.Fields) 
 		return nil
 	}
 
-	t, err := ctx.R().GetTagByID(context.TODO(), tagID)
+	t, err := ctx.R().GetTagByID(context.Background(), tagID)
 	if err != nil {
 		return fmt.Errorf("failed to GetTagByID: %w", err)
 	}

--- a/service/bot/handler/ev_user_tag_removed.go
+++ b/service/bot/handler/ev_user_tag_removed.go
@@ -24,7 +24,7 @@ func UserTagRemoved(ctx Context, datetime time.Time, _ string, fields hub.Fields
 		return nil
 	}
 
-	t, err := ctx.R().GetTagByID(context.TODO(), tagID)
+	t, err := ctx.R().GetTagByID(context.Background(), tagID)
 	if err != nil {
 		return fmt.Errorf("failed to GetTagByID: %w", err)
 	}

--- a/service/bot/handler/handler_test.go
+++ b/service/bot/handler/handler_test.go
@@ -73,7 +73,7 @@ func registerUser(repo *Repo, u *model.User) {
 
 func registerChannel(cm *mock_channel.MockManager, ch *model.Channel) {
 	cm.EXPECT().
-		GetChannel(ch.ID).
+		GetChannel(gomock.Any(), ch.ID).
 		Return(ch, nil).
 		AnyTimes()
 }
@@ -112,11 +112,11 @@ func createDMChannel(handlerCtx *mock_handler.MockContext, cm *mock_channel.Mock
 	}
 
 	cm.EXPECT().
-		GetChannel(dmc.ID).
+		GetChannel(gomock.Any(), dmc.ID).
 		Return(dmc, nil).
 		AnyTimes()
 	cm.EXPECT().
-		GetDMChannelMembers(dmc.ID).
+		GetDMChannelMembers(gomock.Any(), dmc.ID).
 		Return([]uuid.UUID{bot.BotUserID, u.GetID()}, nil).
 		AnyTimes()
 	handlerCtx.EXPECT().

--- a/service/bot/handler/handler_test.go
+++ b/service/bot/handler/handler_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -67,7 +66,7 @@ func registerBot(_ *testing.T, handlerCtx *mock_handler.MockContext, b *model.Bo
 
 func registerUser(repo *Repo, u *model.User) {
 	repo.MockUserRepository.EXPECT().
-		GetUser(context.TODO(), u.ID, gomock.Any()).
+		GetUser(gomock.Any(), u.ID, gomock.Any()).
 		Return(u, nil).
 		AnyTimes()
 }
@@ -81,7 +80,7 @@ func registerChannel(cm *mock_channel.MockManager, ch *model.Channel) {
 
 func registerTag(repo *Repo, t *model.Tag) {
 	repo.MockTagRepository.EXPECT().
-		GetTagByID(context.TODO(), t.ID).
+		GetTagByID(gomock.Any(), t.ID).
 		Return(t, nil).
 		AnyTimes()
 }

--- a/service/bot/service_impl.go
+++ b/service/bot/service_impl.go
@@ -91,7 +91,7 @@ func (p *serviceImpl) start() {
 				if !ok {
 					return
 				}
-				if err := p.repo.PurgeBotEventLogs(context.TODO(), time.Now().Add(-botEventLogPurgeBefore)); err != nil {
+				if err := p.repo.PurgeBotEventLogs(context.Background(), time.Now().Add(-botEventLogPurgeBefore)); err != nil {
 					p.logger.Error("an error occurred while purging old bot event logs", zap.Error(err))
 				}
 			case <-p.serviceDone:
@@ -137,7 +137,7 @@ func (p *serviceImpl) Multicast(ev model.BotEventType, payload interface{}, targ
 }
 
 func (p *serviceImpl) GetBot(id uuid.UUID) (*model.Bot, error) {
-	bots, err := p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().BotID(id))
+	bots, err := p.repo.GetBots(context.Background(), repository.BotsQuery{}.Active().BotID(id))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (p *serviceImpl) GetBot(id uuid.UUID) (*model.Bot, error) {
 }
 
 func (p *serviceImpl) GetBotByBotUserID(uid uuid.UUID) (*model.Bot, error) {
-	bots, err := p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().BotUserID(uid))
+	bots, err := p.repo.GetBots(context.Background(), repository.BotsQuery{}.Active().BotUserID(uid))
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +159,9 @@ func (p *serviceImpl) GetBotByBotUserID(uid uuid.UUID) (*model.Bot, error) {
 }
 
 func (p *serviceImpl) GetBots(event model.BotEventType) ([]*model.Bot, error) {
-	return p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().Subscribe(event))
+	return p.repo.GetBots(context.Background(), repository.BotsQuery{}.Active().Subscribe(event))
 }
 
 func (p *serviceImpl) GetChannelBots(cid uuid.UUID, event model.BotEventType) ([]*model.Bot, error) {
-	return p.repo.GetBots(context.TODO(), repository.BotsQuery{}.Active().Subscribe(event).CMemberOf(cid))
+	return p.repo.GetBots(context.Background(), repository.BotsQuery{}.Active().Subscribe(event).CMemberOf(cid))
 }

--- a/service/channel/manager.go
+++ b/service/channel/manager.go
@@ -2,6 +2,7 @@
 package channel
 
 import (
+	"context"
 	"errors"
 
 	"github.com/gofrs/uuid"
@@ -23,24 +24,24 @@ var (
 )
 
 type Manager interface {
-	GetChannel(id uuid.UUID) (*model.Channel, error)
-	GetChannelPathFromID(id uuid.UUID) string
-	GetChannelFromPath(path string) (*model.Channel, error)
-	CreatePublicChannel(name string, parent, creatorID uuid.UUID) (*model.Channel, error)
-	UpdateChannel(id uuid.UUID, args repository.UpdateChannelArgs) error
-	PublicChannelTree() Tree
+	GetChannel(ctx context.Context, id uuid.UUID) (*model.Channel, error)
+	GetChannelPathFromID(ctx context.Context, id uuid.UUID) string
+	GetChannelFromPath(ctx context.Context, path string) (*model.Channel, error)
+	CreatePublicChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error)
+	UpdateChannel(ctx context.Context, id uuid.UUID, args repository.UpdateChannelArgs) error
+	PublicChannelTree(ctx context.Context) Tree
 
-	ChangeChannelSubscriptions(channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error
+	ChangeChannelSubscriptions(ctx context.Context, channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error
 
-	ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error
-	UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error
+	ArchiveChannel(ctx context.Context, id uuid.UUID, updaterID uuid.UUID) error
+	UnarchiveChannel(ctx context.Context, id uuid.UUID, updaterID uuid.UUID) error
 
-	GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, error)
-	GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error)
-	GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error)
+	GetDMChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error)
+	GetDMChannelMembers(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error)
+	GetDMChannelMapping(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error)
 
-	IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bool, error)
-	IsPublicChannel(id uuid.UUID) bool
+	IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error)
+	IsPublicChannel(ctx context.Context, id uuid.UUID) bool
 
 	// Wait マネージャーの処理の完了を待ちます
 	Wait()

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -67,7 +67,7 @@ func (m *managerImpl) GetChannel(ctx context.Context, id uuid.UUID) (*model.Chan
 	return ch, nil
 }
 
-func (m *managerImpl) GetChannelPathFromID(ctx context.Context, id uuid.UUID) string {
+func (m *managerImpl) GetChannelPathFromID(_ context.Context, id uuid.UUID) string {
 	return m.T.getChannelPath(id)
 }
 
@@ -332,7 +332,7 @@ func (m *managerImpl) UnarchiveChannel(ctx context.Context, id uuid.UUID, update
 	return nil
 }
 
-func (m *managerImpl) PublicChannelTree(ctx context.Context) Tree {
+func (m *managerImpl) PublicChannelTree(_ context.Context) Tree {
 	return m.T
 }
 
@@ -430,7 +430,7 @@ func (m *managerImpl) IsChannelAccessibleToUser(ctx context.Context, userID, cha
 	return false, nil
 }
 
-func (m *managerImpl) IsPublicChannel(ctx context.Context, id uuid.UUID) bool {
+func (m *managerImpl) IsPublicChannel(_ context.Context, id uuid.UUID) bool {
 	return m.T.IsChannelPresent(id)
 }
 

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -32,7 +32,7 @@ type managerImpl struct {
 }
 
 func InitChannelManager(repo repository.ChannelRepository, logger *zap.Logger) (Manager, error) {
-	channels, err := repo.GetPublicChannels(context.TODO())
+	channels, err := repo.GetPublicChannels(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to init channel.Manager: %w", err)
 	}
@@ -56,7 +56,7 @@ func (m *managerImpl) GetChannel(id uuid.UUID) (*model.Channel, error) {
 		return ch, nil
 	}
 
-	ch, err = m.R.GetChannel(context.TODO(), id)
+	ch, err = m.R.GetChannel(context.Background(), id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil, ErrChannelNotFound
@@ -109,7 +109,7 @@ func (m *managerImpl) CreatePublicChannel(name string, parent, creatorID uuid.UU
 	}
 
 	// チャンネル作成
-	ch, err := m.R.CreateChannel(context.TODO(), model.Channel{
+	ch, err := m.R.CreateChannel(context.Background(), model.Channel{
 		Name:      name,
 		ParentID:  parent,
 		CreatorID: creatorID,
@@ -236,7 +236,7 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 		}
 	}
 
-	ch, err = m.R.UpdateChannel(context.TODO(), id, args)
+	ch, err = m.R.UpdateChannel(context.Background(), id, args)
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -285,7 +285,7 @@ func (m *managerImpl) ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
 		queue = append(queue, m.T.getChildrenIDs(id)...)
 	}
 
-	chs, err := m.R.ArchiveChannels(context.TODO(), targets)
+	chs, err := m.R.ArchiveChannels(context.Background(), targets)
 	if err != nil {
 		return fmt.Errorf("failed to ArchiveChannels: %w", err)
 	}
@@ -318,7 +318,7 @@ func (m *managerImpl) UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error 
 		return ErrInvalidParentChannel // 親チャンネルがアーカイブされている
 	}
 
-	ch, err = m.R.UpdateChannel(context.TODO(), id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
+	ch, err = m.R.UpdateChannel(context.Background(), id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -344,7 +344,7 @@ func (m *managerImpl) ChangeChannelSubscriptions(channelID uuid.UUID, subscripti
 		return ErrForcedNotification
 	}
 
-	on, off, err := m.R.ChangeChannelSubscription(context.TODO(), channelID, repository.ChangeChannelSubscriptionArgs{
+	on, off, err := m.R.ChangeChannelSubscription(context.Background(), channelID, repository.ChangeChannelSubscriptionArgs{
 		Subscription: subscriptions,
 		KeepOffLevel: keepOffLevel,
 	})
@@ -366,7 +366,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 		return nil, ErrChannelNotFound
 	}
 
-	ch, err := m.R.GetDirectMessageChannel(context.TODO(), user1, user2)
+	ch, err := m.R.GetDirectMessageChannel(context.Background(), user1, user2)
 	if err == nil {
 		return ch, nil
 	} else if err != repository.ErrNotFound {
@@ -374,7 +374,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 	}
 
 	// 存在しなかったので作成
-	ch, err = m.R.CreateChannel(context.TODO(), model.Channel{
+	ch, err = m.R.CreateChannel(context.Background(), model.Channel{
 		Name:      "dm_" + random.AlphaNumeric(17),
 		IsVisible: true,
 	},
@@ -388,7 +388,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 }
 
 func (m *managerImpl) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
-	members, err := m.R.GetPrivateChannelMemberIDs(context.TODO(), id)
+	members, err := m.R.GetPrivateChannelMemberIDs(context.Background(), id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMCHannelMembers: %w", err)
 	}
@@ -396,7 +396,7 @@ func (m *managerImpl) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
 }
 
 func (m *managerImpl) GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
-	mappings, err := m.R.GetDirectMessageChannelMapping(context.TODO(), userID)
+	mappings, err := m.R.GetDirectMessageChannelMapping(context.Background(), userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMChannelMapping: %w", err)
 	}
@@ -418,7 +418,7 @@ func (m *managerImpl) IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bo
 	}
 
 	// DMチャンネル
-	members, err := m.R.GetPrivateChannelMemberIDs(context.TODO(), channelID)
+	members, err := m.R.GetPrivateChannelMemberIDs(context.Background(), channelID)
 	if err != nil {
 		return false, fmt.Errorf("failed to IsChannelAccessibleToUser: %w", err)
 	}
@@ -443,7 +443,7 @@ func (m *managerImpl) recordChannelEvent(channelID uuid.UUID, eventType model.Ch
 	go func() {
 		defer m.P.Done()
 
-		err := m.R.RecordChannelEvent(context.TODO(), channelID, eventType, detail, datetime)
+		err := m.R.RecordChannelEvent(context.Background(), channelID, eventType, detail, datetime)
 		if err != nil {
 			m.L.Warn("failed to record channel event", zap.Error(err), zap.Stringer("channelID", channelID), zap.Stringer("type", eventType), zap.Any("detail", detail), zap.Time("datetime", datetime))
 		}

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -50,13 +50,13 @@ func InitChannelManager(repo repository.ChannelRepository, logger *zap.Logger) (
 	return m, nil
 }
 
-func (m *managerImpl) GetChannel(id uuid.UUID) (*model.Channel, error) {
+func (m *managerImpl) GetChannel(ctx context.Context, id uuid.UUID) (*model.Channel, error) {
 	ch, err := m.T.GetModel(id)
 	if err == nil {
 		return ch, nil
 	}
 
-	ch, err = m.R.GetChannel(context.Background(), id)
+	ch, err = m.R.GetChannel(ctx, id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil, ErrChannelNotFound
@@ -67,19 +67,19 @@ func (m *managerImpl) GetChannel(id uuid.UUID) (*model.Channel, error) {
 	return ch, nil
 }
 
-func (m *managerImpl) GetChannelPathFromID(id uuid.UUID) string {
+func (m *managerImpl) GetChannelPathFromID(ctx context.Context, id uuid.UUID) string {
 	return m.T.getChannelPath(id)
 }
 
-func (m *managerImpl) GetChannelFromPath(path string) (*model.Channel, error) {
+func (m *managerImpl) GetChannelFromPath(ctx context.Context, path string) (*model.Channel, error) {
 	id := m.T.getChannelIDFromPath(path)
 	if id == uuid.Nil {
 		return nil, ErrInvalidChannelPath
 	}
-	return m.GetChannel(id)
+	return m.GetChannel(ctx, id)
 }
 
-func (m *managerImpl) CreatePublicChannel(name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
+func (m *managerImpl) CreatePublicChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
 	m.T.Lock()
 	defer m.T.Unlock()
 
@@ -109,7 +109,7 @@ func (m *managerImpl) CreatePublicChannel(name string, parent, creatorID uuid.UU
 	}
 
 	// チャンネル作成
-	ch, err := m.R.CreateChannel(context.Background(), model.Channel{
+	ch, err := m.R.CreateChannel(ctx, model.Channel{
 		Name:      name,
 		ParentID:  parent,
 		CreatorID: creatorID,
@@ -132,8 +132,8 @@ func (m *managerImpl) CreatePublicChannel(name string, parent, creatorID uuid.UU
 	return ch, nil
 }
 
-func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelArgs) error {
-	ch, err := m.GetChannel(id)
+func (m *managerImpl) UpdateChannel(ctx context.Context, id uuid.UUID, args repository.UpdateChannelArgs) error {
+	ch, err := m.GetChannel(ctx, id)
 	if err != nil {
 		return ErrChannelNotFound
 	}
@@ -236,7 +236,7 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 		}
 	}
 
-	ch, err = m.R.UpdateChannel(context.Background(), id, args)
+	ch, err = m.R.UpdateChannel(ctx, id, args)
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -253,8 +253,8 @@ func (m *managerImpl) UpdateChannel(id uuid.UUID, args repository.UpdateChannelA
 	return nil
 }
 
-func (m *managerImpl) ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
-	ch, err := m.GetChannel(id)
+func (m *managerImpl) ArchiveChannel(ctx context.Context, id uuid.UUID, updaterID uuid.UUID) error {
+	ch, err := m.GetChannel(ctx, id)
 	if err != nil {
 		return ErrChannelNotFound
 	}
@@ -285,7 +285,7 @@ func (m *managerImpl) ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
 		queue = append(queue, m.T.getChildrenIDs(id)...)
 	}
 
-	chs, err := m.R.ArchiveChannels(context.Background(), targets)
+	chs, err := m.R.ArchiveChannels(ctx, targets)
 	if err != nil {
 		return fmt.Errorf("failed to ArchiveChannels: %w", err)
 	}
@@ -302,8 +302,8 @@ func (m *managerImpl) ArchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
 	return nil
 }
 
-func (m *managerImpl) UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error {
-	ch, err := m.GetChannel(id)
+func (m *managerImpl) UnarchiveChannel(ctx context.Context, id uuid.UUID, updaterID uuid.UUID) error {
+	ch, err := m.GetChannel(ctx, id)
 	if err != nil {
 		return ErrChannelNotFound
 	}
@@ -318,7 +318,7 @@ func (m *managerImpl) UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error 
 		return ErrInvalidParentChannel // 親チャンネルがアーカイブされている
 	}
 
-	ch, err = m.R.UpdateChannel(context.Background(), id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
+	ch, err = m.R.UpdateChannel(ctx, id, repository.UpdateChannelArgs{Visibility: optional.From(true)})
 	if err != nil {
 		return fmt.Errorf("failed to UpdateChannel: %w", err)
 	}
@@ -332,19 +332,19 @@ func (m *managerImpl) UnarchiveChannel(id uuid.UUID, updaterID uuid.UUID) error 
 	return nil
 }
 
-func (m *managerImpl) PublicChannelTree() Tree {
+func (m *managerImpl) PublicChannelTree(ctx context.Context) Tree {
 	return m.T
 }
 
-func (m *managerImpl) ChangeChannelSubscriptions(channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error {
-	if !m.IsPublicChannel(channelID) {
+func (m *managerImpl) ChangeChannelSubscriptions(ctx context.Context, channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error {
+	if !m.IsPublicChannel(ctx, channelID) {
 		return ErrInvalidChannel
 	}
-	if m.PublicChannelTree().IsForceChannel(channelID) {
+	if m.PublicChannelTree(ctx).IsForceChannel(channelID) {
 		return ErrForcedNotification
 	}
 
-	on, off, err := m.R.ChangeChannelSubscription(context.Background(), channelID, repository.ChangeChannelSubscriptionArgs{
+	on, off, err := m.R.ChangeChannelSubscription(ctx, channelID, repository.ChangeChannelSubscriptionArgs{
 		Subscription: subscriptions,
 		KeepOffLevel: keepOffLevel,
 	})
@@ -361,12 +361,12 @@ func (m *managerImpl) ChangeChannelSubscriptions(channelID uuid.UUID, subscripti
 	return nil
 }
 
-func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, error) {
+func (m *managerImpl) GetDMChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error) {
 	if user1 == uuid.Nil || user2 == uuid.Nil {
 		return nil, ErrChannelNotFound
 	}
 
-	ch, err := m.R.GetDirectMessageChannel(context.Background(), user1, user2)
+	ch, err := m.R.GetDirectMessageChannel(ctx, user1, user2)
 	if err == nil {
 		return ch, nil
 	} else if err != repository.ErrNotFound {
@@ -374,7 +374,7 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 	}
 
 	// 存在しなかったので作成
-	ch, err = m.R.CreateChannel(context.Background(), model.Channel{
+	ch, err = m.R.CreateChannel(ctx, model.Channel{
 		Name:      "dm_" + random.AlphaNumeric(17),
 		IsVisible: true,
 	},
@@ -387,16 +387,16 @@ func (m *managerImpl) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, erro
 	return ch, nil
 }
 
-func (m *managerImpl) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
-	members, err := m.R.GetPrivateChannelMemberIDs(context.Background(), id)
+func (m *managerImpl) GetDMChannelMembers(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error) {
+	members, err := m.R.GetPrivateChannelMemberIDs(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMCHannelMembers: %w", err)
 	}
 	return members, nil
 }
 
-func (m *managerImpl) GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
-	mappings, err := m.R.GetDirectMessageChannelMapping(context.Background(), userID)
+func (m *managerImpl) GetDMChannelMapping(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
+	mappings, err := m.R.GetDirectMessageChannelMapping(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetDMChannelMapping: %w", err)
 	}
@@ -412,13 +412,13 @@ func (m *managerImpl) GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.
 	return result, nil
 }
 
-func (m *managerImpl) IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bool, error) {
+func (m *managerImpl) IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error) {
 	if m.T.IsChannelPresent(channelID) {
 		return true, nil // 公開チャンネルは全員アクセス可能
 	}
 
 	// DMチャンネル
-	members, err := m.R.GetPrivateChannelMemberIDs(context.Background(), channelID)
+	members, err := m.R.GetPrivateChannelMemberIDs(ctx, channelID)
 	if err != nil {
 		return false, fmt.Errorf("failed to IsChannelAccessibleToUser: %w", err)
 	}
@@ -430,7 +430,7 @@ func (m *managerImpl) IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bo
 	return false, nil
 }
 
-func (m *managerImpl) IsPublicChannel(id uuid.UUID) bool {
+func (m *managerImpl) IsPublicChannel(ctx context.Context, id uuid.UUID) bool {
 	return m.T.IsChannelPresent(id)
 }
 

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -59,7 +59,7 @@ func TestInitChannelManager(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetPublicChannels(context.TODO()).
+			GetPublicChannels(gomock.Any()).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -75,7 +75,7 @@ func TestInitChannelManager(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 
 		repo.EXPECT().
-			GetPublicChannels(context.TODO()).
+			GetPublicChannels(gomock.Any()).
 			Return([]*model.Channel{
 				{ID: cABC, Name: "c", ParentID: cAB, Topic: "", IsForced: false, IsPublic: true, IsVisible: true},
 				{ID: cABCD, Name: "d", ParentID: cABC, Topic: "", IsForced: false, IsPublic: true, IsVisible: true},
@@ -93,7 +93,7 @@ func TestInitChannelManager(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 
 		repo.EXPECT().
-			GetPublicChannels(context.TODO()).
+			GetPublicChannels(gomock.Any()).
 			Return([]*model.Channel{}, nil).
 			Times(1)
 
@@ -125,7 +125,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(context.Background(), dm1.ID).
+			GetChannel(gomock.Any(), dm1.ID).
 			Return(dm1, nil).
 			Times(1)
 
@@ -133,13 +133,13 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 			ID  uuid.UUID
 			Exp *model.Channel
 		}{
-			{ID: cABFA, Exp: must(cm.PublicChannelTree().GetModel(cABFA))},
-			{ID: cABB, Exp: must(cm.PublicChannelTree().GetModel(cABB))},
+			{ID: cABFA, Exp: must(cm.PublicChannelTree(context.TODO()).GetModel(cABFA))},
+			{ID: cABB, Exp: must(cm.PublicChannelTree(context.TODO()).GetModel(cABB))},
 			{ID: dm1.ID, Exp: dm1},
 		}
 		for i, c := range cases {
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
-				ch, err := cm.GetChannel(c.ID)
+				ch, err := cm.GetChannel(context.TODO(), c.ID)
 				if assert.NoError(t, err) {
 					assert.EqualValues(t, c.Exp, ch)
 				}
@@ -154,11 +154,11 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.Background(), cNotFound).
+			GetChannel(gomock.Any(), cNotFound).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		_, err := cm.GetChannel(cNotFound)
+		_, err := cm.GetChannel(context.TODO(), cNotFound)
 		assert.EqualError(t, err, ErrChannelNotFound.Error())
 	})
 
@@ -170,11 +170,11 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetChannel(context.Background(), cNotFound).
+			GetChannel(gomock.Any(), cNotFound).
 			Return(nil, mockErr).
 			Times(1)
 
-		_, err := cm.GetChannel(cNotFound)
+		_, err := cm.GetChannel(context.TODO(), cNotFound)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -194,7 +194,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 			"ああああ",
 		}
 		for _, name := range cases {
-			_, err := cm.CreatePublicChannel(name, uuid.Nil, uuid.Nil)
+			_, err := cm.CreatePublicChannel(context.TODO(), name, uuid.Nil, uuid.Nil)
 			assert.EqualError(t, err, ErrInvalidChannelName.Error())
 		}
 	})
@@ -218,7 +218,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 			{Name: "e", Parent: uuid.Nil},
 		}
 		for _, ch := range cases {
-			_, err := cm.CreatePublicChannel(ch.Name, ch.Parent, uuid.Nil)
+			_, err := cm.CreatePublicChannel(context.TODO(), ch.Name, ch.Parent, uuid.Nil)
 			assert.EqualError(t, err, ErrChannelNameConflicts.Error())
 		}
 	})
@@ -236,7 +236,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 			{Name: "b", Parent: cNotFound},
 		}
 		for _, c := range cases {
-			_, err := cm.CreatePublicChannel(c.Name, c.Parent, uuid.Nil)
+			_, err := cm.CreatePublicChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
 			assert.EqualError(t, err, ErrInvalidParentChannel.Error())
 		}
 	})
@@ -255,7 +255,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 			{Name: "a", Parent: cABBC},
 		}
 		for _, c := range cases {
-			_, err := cm.CreatePublicChannel(c.Name, c.Parent, uuid.Nil)
+			_, err := cm.CreatePublicChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
 			assert.EqualError(t, err, ErrChannelArchived.Error())
 		}
 	})
@@ -273,7 +273,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 			{Name: "a", Parent: cEFGHI},
 		}
 		for _, c := range cases {
-			_, err := cm.CreatePublicChannel(c.Name, c.Parent, uuid.Nil)
+			_, err := cm.CreatePublicChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
 			assert.EqualError(t, err, ErrTooDeepChannel.Error())
 		}
 	})
@@ -286,11 +286,11 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
-		_, err := cm.CreatePublicChannel("test", uuid.Nil, uuid.Nil)
+		_, err := cm.CreatePublicChannel(context.TODO(), "test", uuid.Nil, uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -337,12 +337,12 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
+							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {
 							repo.EXPECT().
-								RecordChannelEvent(context.Background(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
 									"userId":    c.Creator,
 									"channelId": cid,
 								}), createdAt).
@@ -350,11 +350,11 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 								Times(1)
 						}
 
-						ch, err := cm.CreatePublicChannel(c.Name, c.Parent, c.Creator)
+						ch, err := cm.CreatePublicChannel(context.TODO(), c.Name, c.Parent, c.Creator)
 						cm.P.Wait()
 						if assert.NoError(t, err) {
 							assert.Equal(t, expected, ch)
-							assert.True(t, cm.PublicChannelTree().IsChannelPresent(cid))
+							assert.True(t, cm.PublicChannelTree(context.TODO()).IsChannelPresent(cid))
 						}
 					})
 				}
@@ -373,11 +373,11 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.Background(), gomock.Any()).
+			GetChannel(gomock.Any(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
-		err := cm.UpdateChannel(cNotFound, repository.UpdateChannelArgs{Topic: optional.From("test")})
+		err := cm.UpdateChannel(context.TODO(), cNotFound, repository.UpdateChannelArgs{Topic: optional.From("test")})
 		assert.EqualError(t, err, ErrChannelNotFound.Error())
 	})
 
@@ -387,7 +387,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Name: optional.From("e")})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Name: optional.From("e")})
 		assert.EqualError(t, err, ErrChannelNameConflicts.Error())
 	})
 
@@ -397,7 +397,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Name: optional.From("あああ")})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Name: optional.From("あああ")})
 		assert.EqualError(t, err, ErrInvalidChannelName.Error())
 	})
 
@@ -407,7 +407,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Parent: optional.From(cNotFound)})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Parent: optional.From(cNotFound)})
 		assert.EqualError(t, err, ErrInvalidParentChannel.Error())
 	})
 
@@ -417,7 +417,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Parent: optional.From(cABBC)})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Parent: optional.From(cABBC)})
 		assert.EqualError(t, err, ErrInvalidParentChannel.Error())
 	})
 
@@ -427,7 +427,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Parent: optional.From(cABCE)})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Parent: optional.From(cABCE)})
 		assert.EqualError(t, err, ErrTooDeepChannel.Error())
 	})
 
@@ -437,7 +437,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Parent: optional.From(cEF)})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Parent: optional.From(cEF)})
 		assert.EqualError(t, err, ErrTooDeepChannel.Error())
 	})
 
@@ -449,11 +449,11 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			UpdateChannel(context.Background(), gomock.Any(), gomock.Any()).
+			UpdateChannel(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
-		err := cm.UpdateChannel(cA, repository.UpdateChannelArgs{Topic: optional.From("test")})
+		err := cm.UpdateChannel(context.TODO(), cA, repository.UpdateChannelArgs{Topic: optional.From("test")})
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -537,7 +537,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						repo := mock_repository.NewMockChannelRepository(ctrl)
 						cm := initCM(t, repo)
 
-						ch, err := cm.PublicChannelTree().GetModel(c.ID)
+						ch, err := cm.PublicChannelTree(context.TODO()).GetModel(c.ID)
 						require.NoError(t, err)
 						args := c.Args(uuidVersion)
 						newChan := *ch
@@ -550,7 +550,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Topic.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventTopicChanged, model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventTopicChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.Topic,
 									"after":  args.Topic.V,
@@ -561,7 +561,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Visibility.Valid && ch.IsVisible != args.Visibility.V {
 							repo.EXPECT().
-								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
 									"userId":     args.UpdaterID,
 									"visibility": args.Visibility.V,
 								}, gomock.Any()).
@@ -571,7 +571,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.ForcedNotification.Valid && ch.IsForced != args.ForcedNotification.V {
 							repo.EXPECT().
-								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"force":  args.ForcedNotification.V,
 								}, gomock.Any()).
@@ -581,7 +581,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Name.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.Name,
 									"after":  args.Name.V,
@@ -592,7 +592,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Parent.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
+								RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.ParentID,
 									"after":  args.Parent.V,
@@ -603,14 +603,14 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							UpdateChannel(context.Background(), c.ID, args).
+							UpdateChannel(gomock.Any(), c.ID, args).
 							Return(&newChan, nil).
 							Times(1)
 
-						err = cm.UpdateChannel(c.ID, args)
+						err = cm.UpdateChannel(context.TODO(), c.ID, args)
 						cm.P.Wait()
 						if assert.NoError(t, err) {
-							v, err := cm.GetChannel(c.ID)
+							v, err := cm.GetChannel(context.TODO(), c.ID)
 							require.NoError(t, err)
 							sort.Slice(v.ChildrenID, func(i, j int) bool {
 								return strings.Compare(v.ChildrenID[i].String(), v.ChildrenID[j].String()) > 0
@@ -639,7 +639,7 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.ChangeChannelSubscriptions(cNotFound, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
+		err := cm.ChangeChannelSubscriptions(context.TODO(), cNotFound, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
 		assert.EqualError(t, err, ErrInvalidChannel.Error())
 	})
 
@@ -649,7 +649,7 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.ChangeChannelSubscriptions(cE, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
+		err := cm.ChangeChannelSubscriptions(context.TODO(), cE, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
 		assert.EqualError(t, err, ErrForcedNotification.Error())
 	})
 
@@ -661,11 +661,11 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			ChangeChannelSubscription(context.Background(), gomock.Any(), gomock.Any()).
+			ChangeChannelSubscription(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, nil, mockErr).
 			AnyTimes()
 
-		err := cm.ChangeChannelSubscriptions(cA, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
+		err := cm.ChangeChannelSubscriptions(context.TODO(), cA, map[uuid.UUID]model.ChannelSubscribeLevel{}, false, uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -699,11 +699,11 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 				}
 
 				repo.EXPECT().
-					ChangeChannelSubscription(context.Background(), c.ID, gomock.Any()).
+					ChangeChannelSubscription(gomock.Any(), c.ID, gomock.Any()).
 					Return(on, off, nil).
 					AnyTimes()
 				repo.EXPECT().
-					RecordChannelEvent(context.Background(), c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
+					RecordChannelEvent(gomock.Any(), c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
 						"userId": uid1,
 						"on":     on,
 						"off":    off,
@@ -711,7 +711,7 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 					Return(nil).
 					Times(1)
 
-				err := cm.ChangeChannelSubscriptions(c.ID, c.Subscriptions, false, uid1)
+				err := cm.ChangeChannelSubscriptions(context.TODO(), c.ID, c.Subscriptions, false, uid1)
 				cm.P.Wait()
 				assert.NoError(t, err)
 			})
@@ -729,11 +729,11 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.Background(), gomock.Any()).
+			GetChannel(gomock.Any(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
-		err := cm.ArchiveChannel(cNotFound, uuid.Nil)
+		err := cm.ArchiveChannel(context.TODO(), cNotFound, uuid.Nil)
 		assert.EqualError(t, err, ErrChannelNotFound.Error())
 	})
 
@@ -753,11 +753,11 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(context.Background(), dm1.ID).
+			GetChannel(gomock.Any(), dm1.ID).
 			Return(dm1, nil).
 			AnyTimes()
 
-		err := cm.ArchiveChannel(dm1.ID, uuid.Nil)
+		err := cm.ArchiveChannel(context.TODO(), dm1.ID, uuid.Nil)
 		assert.EqualError(t, err, ErrInvalidChannel.Error())
 	})
 
@@ -767,7 +767,7 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.ArchiveChannel(cABBC, uuid.Nil)
+		err := cm.ArchiveChannel(context.TODO(), cABBC, uuid.Nil)
 		assert.NoError(t, err)
 	})
 
@@ -788,21 +788,21 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 			{ID: cAD, Name: "d", ParentID: cA, Topic: "", IsForced: false, IsPublic: true, IsVisible: false},
 		}
 		repo.EXPECT().
-			ArchiveChannels(context.Background(), gomock.Len(len(expects))).
+			ArchiveChannels(gomock.Any(), gomock.Len(len(expects))).
 			Return(expects, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(context.Background(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(gomock.Any(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(len(expects))
 
-		err := cm.ArchiveChannel(cA, uuid.Nil)
+		err := cm.ArchiveChannel(context.TODO(), cA, uuid.Nil)
 		cm.P.Wait()
 		if assert.NoError(t, err) {
 			for _, expect := range expects {
-				assert.True(t, cm.PublicChannelTree().IsArchivedChannel(expect.ID))
+				assert.True(t, cm.PublicChannelTree(context.TODO()).IsArchivedChannel(expect.ID))
 			}
-			assert.False(t, cm.PublicChannelTree().IsArchivedChannel(cE))
+			assert.False(t, cm.PublicChannelTree(context.TODO()).IsArchivedChannel(cE))
 		}
 	})
 }
@@ -817,11 +817,11 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.Background(), gomock.Any()).
+			GetChannel(gomock.Any(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
-		err := cm.UnarchiveChannel(cNotFound, uuid.Nil)
+		err := cm.UnarchiveChannel(context.TODO(), cNotFound, uuid.Nil)
 		assert.EqualError(t, err, ErrChannelNotFound.Error())
 	})
 
@@ -831,7 +831,7 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UnarchiveChannel(cA, uuid.Nil)
+		err := cm.UnarchiveChannel(context.TODO(), cA, uuid.Nil)
 		assert.NoError(t, err)
 	})
 
@@ -841,7 +841,7 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		repo := mock_repository.NewMockChannelRepository(ctrl)
 		cm := initCM(t, repo)
 
-		err := cm.UnarchiveChannel(cABBC, uuid.Nil)
+		err := cm.UnarchiveChannel(context.TODO(), cABBC, uuid.Nil)
 		assert.EqualError(t, err, ErrInvalidParentChannel.Error())
 	})
 
@@ -852,19 +852,19 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			UpdateChannel(context.Background(), cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
+			UpdateChannel(gomock.Any(), cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
 			Return(&model.Channel{ID: cABB, Name: "b", ParentID: cAB, Topic: "", IsForced: false, IsPublic: true, IsVisible: true}, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(context.Background(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(gomock.Any(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
-		err := cm.UnarchiveChannel(cABB, uuid.Nil)
+		err := cm.UnarchiveChannel(context.TODO(), cABB, uuid.Nil)
 		cm.P.Wait()
 		if assert.NoError(t, err) {
-			assert.False(t, cm.PublicChannelTree().IsArchivedChannel(cABB))
-			assert.True(t, cm.PublicChannelTree().IsArchivedChannel(cABBC))
+			assert.False(t, cm.PublicChannelTree(context.TODO()).IsArchivedChannel(cABB))
+			assert.True(t, cm.PublicChannelTree(context.TODO()).IsArchivedChannel(cABBC))
 		}
 	})
 }
@@ -881,11 +881,11 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 				repo := mock_repository.NewMockChannelRepository(ctrl)
 				cm := initCM(t, repo)
 
-				_, err := cm.GetDMChannel(uuid.Nil, uuid.Nil)
+				_, err := cm.GetDMChannel(context.TODO(), uuid.Nil, uuid.Nil)
 				assert.EqualError(t, err, ErrChannelNotFound.Error())
-				_, err = cm.GetDMChannel(mustGenerateUUID(uuidVersion), uuid.Nil)
+				_, err = cm.GetDMChannel(context.TODO(), mustGenerateUUID(uuidVersion), uuid.Nil)
 				assert.EqualError(t, err, ErrChannelNotFound.Error())
-				_, err = cm.GetDMChannel(uuid.Nil, mustGenerateUUID(uuidVersion))
+				_, err = cm.GetDMChannel(context.TODO(), uuid.Nil, mustGenerateUUID(uuidVersion))
 				assert.EqualError(t, err, ErrChannelNotFound.Error())
 			})
 
@@ -897,11 +897,11 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.Background(), gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					AnyTimes()
 
-				_, err := cm.GetDMChannel(mustGenerateUUID(uuidVersion), mustGenerateUUID(uuidVersion))
+				_, err := cm.GetDMChannel(context.TODO(), mustGenerateUUID(uuidVersion), mustGenerateUUID(uuidVersion))
 				if assert.Error(t, err) {
 					assert.Equal(t, mockErr, errors.Unwrap(err))
 				}
@@ -915,15 +915,15 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.Background(), gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 				repo.EXPECT().
-					CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
-				_, err := cm.GetDMChannel(mustGenerateUUID(uuidVersion), mustGenerateUUID(uuidVersion))
+				_, err := cm.GetDMChannel(context.TODO(), mustGenerateUUID(uuidVersion), mustGenerateUUID(uuidVersion))
 				if assert.Error(t, err) {
 					assert.Equal(t, mockErr, errors.Unwrap(err))
 				}
@@ -946,11 +946,11 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 					IsVisible: true,
 				}
 				repo.EXPECT().
-					GetDirectMessageChannel(context.Background(), uid1, uid2).
+					GetDirectMessageChannel(gomock.Any(), uid1, uid2).
 					Return(dm1, nil).
 					Times(1)
 
-				ch, err := cm.GetDMChannel(uid1, uid2)
+				ch, err := cm.GetDMChannel(context.TODO(), uid1, uid2)
 				if assert.NoError(t, err) {
 					assert.EqualValues(t, dm1, ch)
 				}
@@ -965,12 +965,12 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 				uid1 := uuid.NewV3(uuid.Nil, "u1")
 				uid2 := uuid.NewV3(uuid.Nil, "u2")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.Background(), uid1, uid2).
+					GetDirectMessageChannel(gomock.Any(), uid1, uid2).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 
 				repo.EXPECT().
-					CreateChannel(context.Background(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
+					CreateChannel(gomock.Any(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
 					Return(&model.Channel{
 						ID:        uuid.NewV3(uuid.Nil, "c 1-1"),
 						Name:      "dm_" + random.AlphaNumeric(17),
@@ -981,7 +981,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 					}, nil).
 					Times(1)
 
-				_, err := cm.GetDMChannel(uid1, uid2)
+				_, err := cm.GetDMChannel(context.TODO(), uid1, uid2)
 				assert.NoError(t, err)
 			})
 		})
@@ -1003,20 +1003,20 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 				id := mustGenerateUUID(uuidVersion)
 				expected := []uuid.UUID{cA, cE}
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.Background(), id).
+					GetPrivateChannelMemberIDs(gomock.Any(), id).
 					Return(expected, nil).
 					Times(1)
 
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.Background(), cNotFound).
+					GetPrivateChannelMemberIDs(gomock.Any(), cNotFound).
 					Return([]uuid.UUID{}, nil).
 					Times(1)
 
-				if ids, err := cm.GetDMChannelMembers(id); assert.NoError(t, err) {
+				if ids, err := cm.GetDMChannelMembers(context.TODO(), id); assert.NoError(t, err) {
 					assert.ElementsMatch(t, expected, ids)
 				}
 
-				if ids, err := cm.GetDMChannelMembers(cNotFound); assert.NoError(t, err) {
+				if ids, err := cm.GetDMChannelMembers(context.TODO(), cNotFound); assert.NoError(t, err) {
 					assert.Empty(t, ids)
 				}
 			})
@@ -1029,11 +1029,11 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.Background(), gomock.Any()).
+					GetPrivateChannelMemberIDs(gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
-				_, err := cm.GetDMChannelMembers(uuid.Nil)
+				_, err := cm.GetDMChannelMembers(context.TODO(), uuid.Nil)
 				if assert.Error(t, err) {
 					assert.Equal(t, mockErr, errors.Unwrap(err))
 				}
@@ -1060,7 +1060,7 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.Background(), uid1).
+			GetDirectMessageChannelMapping(gomock.Any(), uid1).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid1, User1: uid1, User2: uid1},
 				{ChannelID: cid2, User1: uid1, User2: uid2},
@@ -1069,18 +1069,18 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.Background(), uid2).
+			GetDirectMessageChannelMapping(gomock.Any(), uid2).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid2, User1: uid1, User2: uid2},
 			}, nil).
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.Background(), uid4).
+			GetDirectMessageChannelMapping(gomock.Any(), uid4).
 			Return([]*model.DMChannelMapping{}, nil).
 			Times(1)
 
-		if m, err := cm.GetDMChannelMapping(uid1); assert.NoError(t, err) {
+		if m, err := cm.GetDMChannelMapping(context.TODO(), uid1); assert.NoError(t, err) {
 			assert.EqualValues(t, m, map[uuid.UUID]uuid.UUID{
 				cid1: uid1,
 				cid2: uid2,
@@ -1088,13 +1088,13 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 			})
 		}
 
-		if m, err := cm.GetDMChannelMapping(uid2); assert.NoError(t, err) {
+		if m, err := cm.GetDMChannelMapping(context.TODO(), uid2); assert.NoError(t, err) {
 			assert.EqualValues(t, m, map[uuid.UUID]uuid.UUID{
 				cid2: uid1,
 			})
 		}
 
-		if m, err := cm.GetDMChannelMapping(uid4); assert.NoError(t, err) {
+		if m, err := cm.GetDMChannelMapping(context.TODO(), uid4); assert.NoError(t, err) {
 			assert.EqualValues(t, m, map[uuid.UUID]uuid.UUID{})
 		}
 	})
@@ -1107,11 +1107,11 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.Background(), uid1).
+			GetDirectMessageChannelMapping(gomock.Any(), uid1).
 			Return(nil, mockErr).
 			Times(1)
 
-		_, err := cm.GetDMChannelMapping(uid1)
+		_, err := cm.GetDMChannelMapping(context.TODO(), uid1)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -1135,22 +1135,22 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.Background(), cNotFound).
+			GetPrivateChannelMemberIDs(gomock.Any(), cNotFound).
 			Return([]uuid.UUID{}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.Background(), cid1).
+			GetPrivateChannelMemberIDs(gomock.Any(), cid1).
 			Return([]uuid.UUID{uid1}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.Background(), cid2).
+			GetPrivateChannelMemberIDs(gomock.Any(), cid2).
 			Return([]uuid.UUID{uid1, uid2}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.Background(), cid3).
+			GetPrivateChannelMemberIDs(gomock.Any(), cid3).
 			Return([]uuid.UUID{uid1, uid3}, nil).
 			AnyTimes()
 
@@ -1170,7 +1170,7 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 		}
 		for i, c := range cases {
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
-				ok, err := cm.IsChannelAccessibleToUser(c.User, c.Channel)
+				ok, err := cm.IsChannelAccessibleToUser(context.TODO(), c.User, c.Channel)
 				if assert.NoError(t, err) {
 					assert.Equal(t, c.OK, ok)
 				}
@@ -1186,11 +1186,11 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.Background(), gomock.Any()).
+			GetPrivateChannelMemberIDs(gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			Times(1)
 
-		_, err := cm.IsChannelAccessibleToUser(uid1, cid1)
+		_, err := cm.IsChannelAccessibleToUser(context.TODO(), uid1, cid1)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -1204,6 +1204,6 @@ func TestManagerImpl_IsPublicChannel(t *testing.T) {
 	repo := mock_repository.NewMockChannelRepository(ctrl)
 	cm := initCM(t, repo)
 
-	assert.True(t, cm.IsPublicChannel(cA))
-	assert.False(t, cm.IsPublicChannel(cNotFound))
+	assert.True(t, cm.IsPublicChannel(context.TODO(), cA))
+	assert.False(t, cm.IsPublicChannel(context.TODO(), cNotFound))
 }

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -125,7 +125,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), dm1.ID).
+			GetChannel(context.Background(), dm1.ID).
 			Return(dm1, nil).
 			Times(1)
 
@@ -154,7 +154,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), cNotFound).
+			GetChannel(context.Background(), cNotFound).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -170,7 +170,7 @@ func TestManagerImpl_GetChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetChannel(context.TODO(), cNotFound).
+			GetChannel(context.Background(), cNotFound).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -286,7 +286,7 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
@@ -337,12 +337,12 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
+							CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
+								RecordChannelEvent(context.Background(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
 									"userId":    c.Creator,
 									"channelId": cid,
 								}), createdAt).
@@ -373,7 +373,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), gomock.Any()).
+			GetChannel(context.Background(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -449,7 +449,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			UpdateChannel(context.TODO(), gomock.Any(), gomock.Any()).
+			UpdateChannel(context.Background(), gomock.Any(), gomock.Any()).
 			Return(nil, mockErr).
 			AnyTimes()
 
@@ -561,7 +561,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Visibility.Valid && ch.IsVisible != args.Visibility.V {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventVisibilityChanged, model.ChannelEventDetail{
 									"userId":     args.UpdaterID,
 									"visibility": args.Visibility.V,
 								}, gomock.Any()).
@@ -571,7 +571,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.ForcedNotification.Valid && ch.IsForced != args.ForcedNotification.V {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventForcedNotificationChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"force":  args.ForcedNotification.V,
 								}, gomock.Any()).
@@ -581,7 +581,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Name.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventNameChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.Name,
 									"after":  args.Name.V,
@@ -592,7 +592,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 						if args.Parent.Valid {
 							repo.EXPECT().
-								RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
+								RecordChannelEvent(context.Background(), c.ID, model.ChannelEventParentChanged, model.ChannelEventDetail{
 									"userId": args.UpdaterID,
 									"before": ch.ParentID,
 									"after":  args.Parent.V,
@@ -603,7 +603,7 @@ func TestManagerImpl_UpdateChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							UpdateChannel(context.TODO(), c.ID, args).
+							UpdateChannel(context.Background(), c.ID, args).
 							Return(&newChan, nil).
 							Times(1)
 
@@ -661,7 +661,7 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			ChangeChannelSubscription(context.TODO(), gomock.Any(), gomock.Any()).
+			ChangeChannelSubscription(context.Background(), gomock.Any(), gomock.Any()).
 			Return(nil, nil, mockErr).
 			AnyTimes()
 
@@ -699,11 +699,11 @@ func TestManagerImpl_ChangeChannelSubscriptions(t *testing.T) {
 				}
 
 				repo.EXPECT().
-					ChangeChannelSubscription(context.TODO(), c.ID, gomock.Any()).
+					ChangeChannelSubscription(context.Background(), c.ID, gomock.Any()).
 					Return(on, off, nil).
 					AnyTimes()
 				repo.EXPECT().
-					RecordChannelEvent(context.TODO(), c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
+					RecordChannelEvent(context.Background(), c.ID, model.ChannelEventSubscribersChanged, model.ChannelEventDetail{
 						"userId": uid1,
 						"on":     on,
 						"off":    off,
@@ -729,7 +729,7 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), gomock.Any()).
+			GetChannel(context.Background(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -753,7 +753,7 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), dm1.ID).
+			GetChannel(context.Background(), dm1.ID).
 			Return(dm1, nil).
 			AnyTimes()
 
@@ -788,11 +788,11 @@ func TestManagerImpl_ArchiveChannel(t *testing.T) {
 			{ID: cAD, Name: "d", ParentID: cA, Topic: "", IsForced: false, IsPublic: true, IsVisible: false},
 		}
 		repo.EXPECT().
-			ArchiveChannels(context.TODO(), gomock.Len(len(expects))).
+			ArchiveChannels(context.Background(), gomock.Len(len(expects))).
 			Return(expects, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(context.TODO(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(context.Background(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(len(expects))
 
@@ -817,7 +817,7 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetChannel(context.TODO(), gomock.Any()).
+			GetChannel(context.Background(), gomock.Any()).
 			Return(nil, repository.ErrNotFound).
 			AnyTimes()
 
@@ -852,11 +852,11 @@ func TestManagerImpl_UnarchiveChannel(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			UpdateChannel(context.TODO(), cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
+			UpdateChannel(context.Background(), cABB, repository.UpdateChannelArgs{Visibility: optional.From(true)}).
 			Return(&model.Channel{ID: cABB, Name: "b", ParentID: cAB, Topic: "", IsForced: false, IsPublic: true, IsVisible: true}, nil).
 			Times(1)
 		repo.EXPECT().
-			RecordChannelEvent(context.TODO(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
+			RecordChannelEvent(context.Background(), gomock.Any(), model.ChannelEventVisibilityChanged, gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -897,7 +897,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.TODO(), gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(context.Background(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					AnyTimes()
 
@@ -915,11 +915,11 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.TODO(), gomock.Any(), gomock.Any()).
+					GetDirectMessageChannel(context.Background(), gomock.Any(), gomock.Any()).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 				repo.EXPECT().
-					CreateChannel(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CreateChannel(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
@@ -946,7 +946,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 					IsVisible: true,
 				}
 				repo.EXPECT().
-					GetDirectMessageChannel(context.TODO(), uid1, uid2).
+					GetDirectMessageChannel(context.Background(), uid1, uid2).
 					Return(dm1, nil).
 					Times(1)
 
@@ -965,12 +965,12 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 				uid1 := uuid.NewV3(uuid.Nil, "u1")
 				uid2 := uuid.NewV3(uuid.Nil, "u2")
 				repo.EXPECT().
-					GetDirectMessageChannel(context.TODO(), uid1, uid2).
+					GetDirectMessageChannel(context.Background(), uid1, uid2).
 					Return(nil, repository.ErrNotFound).
 					Times(1)
 
 				repo.EXPECT().
-					CreateChannel(context.TODO(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
+					CreateChannel(context.Background(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
 					Return(&model.Channel{
 						ID:        uuid.NewV3(uuid.Nil, "c 1-1"),
 						Name:      "dm_" + random.AlphaNumeric(17),
@@ -1003,12 +1003,12 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 				id := mustGenerateUUID(uuidVersion)
 				expected := []uuid.UUID{cA, cE}
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.TODO(), id).
+					GetPrivateChannelMemberIDs(context.Background(), id).
 					Return(expected, nil).
 					Times(1)
 
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.TODO(), cNotFound).
+					GetPrivateChannelMemberIDs(context.Background(), cNotFound).
 					Return([]uuid.UUID{}, nil).
 					Times(1)
 
@@ -1029,7 +1029,7 @@ func TestManagerImpl_GetDMChannelMembers(t *testing.T) {
 
 				mockErr := errors.New("mock error")
 				repo.EXPECT().
-					GetPrivateChannelMemberIDs(context.TODO(), gomock.Any()).
+					GetPrivateChannelMemberIDs(context.Background(), gomock.Any()).
 					Return(nil, mockErr).
 					Times(1)
 
@@ -1060,7 +1060,7 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.TODO(), uid1).
+			GetDirectMessageChannelMapping(context.Background(), uid1).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid1, User1: uid1, User2: uid1},
 				{ChannelID: cid2, User1: uid1, User2: uid2},
@@ -1069,14 +1069,14 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.TODO(), uid2).
+			GetDirectMessageChannelMapping(context.Background(), uid2).
 			Return([]*model.DMChannelMapping{
 				{ChannelID: cid2, User1: uid1, User2: uid2},
 			}, nil).
 			Times(1)
 
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.TODO(), uid4).
+			GetDirectMessageChannelMapping(context.Background(), uid4).
 			Return([]*model.DMChannelMapping{}, nil).
 			Times(1)
 
@@ -1107,7 +1107,7 @@ func TestManagerImpl_GetDMChannelMapping(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetDirectMessageChannelMapping(context.TODO(), uid1).
+			GetDirectMessageChannelMapping(context.Background(), uid1).
 			Return(nil, mockErr).
 			Times(1)
 
@@ -1135,22 +1135,22 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 		cm := initCM(t, repo)
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.TODO(), cNotFound).
+			GetPrivateChannelMemberIDs(context.Background(), cNotFound).
 			Return([]uuid.UUID{}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.TODO(), cid1).
+			GetPrivateChannelMemberIDs(context.Background(), cid1).
 			Return([]uuid.UUID{uid1}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.TODO(), cid2).
+			GetPrivateChannelMemberIDs(context.Background(), cid2).
 			Return([]uuid.UUID{uid1, uid2}, nil).
 			AnyTimes()
 
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.TODO(), cid3).
+			GetPrivateChannelMemberIDs(context.Background(), cid3).
 			Return([]uuid.UUID{uid1, uid3}, nil).
 			AnyTimes()
 
@@ -1186,7 +1186,7 @@ func TestManagerImpl_IsChannelAccessibleToUser(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		repo.EXPECT().
-			GetPrivateChannelMemberIDs(context.TODO(), gomock.Any()).
+			GetPrivateChannelMemberIDs(context.Background(), gomock.Any()).
 			Return(nil, mockErr).
 			Times(1)
 

--- a/service/channel/mock_channel/mock_manager.go
+++ b/service/channel/mock_channel/mock_manager.go
@@ -5,6 +5,7 @@
 package mock_channel
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -38,206 +39,206 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // ArchiveChannel mocks base method.
-func (m *MockManager) ArchiveChannel(id, updaterID uuid.UUID) error {
+func (m *MockManager) ArchiveChannel(ctx context.Context, id, updaterID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ArchiveChannel", id, updaterID)
+	ret := m.ctrl.Call(m, "ArchiveChannel", ctx, id, updaterID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ArchiveChannel indicates an expected call of ArchiveChannel.
-func (mr *MockManagerMockRecorder) ArchiveChannel(id, updaterID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) ArchiveChannel(ctx, id, updaterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveChannel", reflect.TypeOf((*MockManager)(nil).ArchiveChannel), id, updaterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveChannel", reflect.TypeOf((*MockManager)(nil).ArchiveChannel), ctx, id, updaterID)
 }
 
 // ChangeChannelSubscriptions mocks base method.
-func (m *MockManager) ChangeChannelSubscriptions(channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error {
+func (m *MockManager) ChangeChannelSubscriptions(ctx context.Context, channelID uuid.UUID, subscriptions map[uuid.UUID]model.ChannelSubscribeLevel, keepOffLevel bool, updaterID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeChannelSubscriptions", channelID, subscriptions, keepOffLevel, updaterID)
+	ret := m.ctrl.Call(m, "ChangeChannelSubscriptions", ctx, channelID, subscriptions, keepOffLevel, updaterID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ChangeChannelSubscriptions indicates an expected call of ChangeChannelSubscriptions.
-func (mr *MockManagerMockRecorder) ChangeChannelSubscriptions(channelID, subscriptions, keepOffLevel, updaterID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) ChangeChannelSubscriptions(ctx, channelID, subscriptions, keepOffLevel, updaterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeChannelSubscriptions", reflect.TypeOf((*MockManager)(nil).ChangeChannelSubscriptions), channelID, subscriptions, keepOffLevel, updaterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeChannelSubscriptions", reflect.TypeOf((*MockManager)(nil).ChangeChannelSubscriptions), ctx, channelID, subscriptions, keepOffLevel, updaterID)
 }
 
 // CreatePublicChannel mocks base method.
-func (m *MockManager) CreatePublicChannel(name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
+func (m *MockManager) CreatePublicChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePublicChannel", name, parent, creatorID)
+	ret := m.ctrl.Call(m, "CreatePublicChannel", ctx, name, parent, creatorID)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePublicChannel indicates an expected call of CreatePublicChannel.
-func (mr *MockManagerMockRecorder) CreatePublicChannel(name, parent, creatorID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) CreatePublicChannel(ctx, name, parent, creatorID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicChannel", reflect.TypeOf((*MockManager)(nil).CreatePublicChannel), name, parent, creatorID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicChannel", reflect.TypeOf((*MockManager)(nil).CreatePublicChannel), ctx, name, parent, creatorID)
 }
 
 // GetChannel mocks base method.
-func (m *MockManager) GetChannel(id uuid.UUID) (*model.Channel, error) {
+func (m *MockManager) GetChannel(ctx context.Context, id uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannel", id)
+	ret := m.ctrl.Call(m, "GetChannel", ctx, id)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannel indicates an expected call of GetChannel.
-func (mr *MockManagerMockRecorder) GetChannel(id interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetChannel(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannel", reflect.TypeOf((*MockManager)(nil).GetChannel), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannel", reflect.TypeOf((*MockManager)(nil).GetChannel), ctx, id)
 }
 
 // GetChannelFromPath mocks base method.
-func (m *MockManager) GetChannelFromPath(path string) (*model.Channel, error) {
+func (m *MockManager) GetChannelFromPath(ctx context.Context, path string) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelFromPath", path)
+	ret := m.ctrl.Call(m, "GetChannelFromPath", ctx, path)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChannelFromPath indicates an expected call of GetChannelFromPath.
-func (mr *MockManagerMockRecorder) GetChannelFromPath(path interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetChannelFromPath(ctx, path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelFromPath", reflect.TypeOf((*MockManager)(nil).GetChannelFromPath), path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelFromPath", reflect.TypeOf((*MockManager)(nil).GetChannelFromPath), ctx, path)
 }
 
 // GetChannelPathFromID mocks base method.
-func (m *MockManager) GetChannelPathFromID(id uuid.UUID) string {
+func (m *MockManager) GetChannelPathFromID(ctx context.Context, id uuid.UUID) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelPathFromID", id)
+	ret := m.ctrl.Call(m, "GetChannelPathFromID", ctx, id)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // GetChannelPathFromID indicates an expected call of GetChannelPathFromID.
-func (mr *MockManagerMockRecorder) GetChannelPathFromID(id interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetChannelPathFromID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelPathFromID", reflect.TypeOf((*MockManager)(nil).GetChannelPathFromID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelPathFromID", reflect.TypeOf((*MockManager)(nil).GetChannelPathFromID), ctx, id)
 }
 
 // GetDMChannel mocks base method.
-func (m *MockManager) GetDMChannel(user1, user2 uuid.UUID) (*model.Channel, error) {
+func (m *MockManager) GetDMChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDMChannel", user1, user2)
+	ret := m.ctrl.Call(m, "GetDMChannel", ctx, user1, user2)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDMChannel indicates an expected call of GetDMChannel.
-func (mr *MockManagerMockRecorder) GetDMChannel(user1, user2 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetDMChannel(ctx, user1, user2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannel", reflect.TypeOf((*MockManager)(nil).GetDMChannel), user1, user2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannel", reflect.TypeOf((*MockManager)(nil).GetDMChannel), ctx, user1, user2)
 }
 
 // GetDMChannelMapping mocks base method.
-func (m *MockManager) GetDMChannelMapping(userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
+func (m *MockManager) GetDMChannelMapping(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDMChannelMapping", userID)
+	ret := m.ctrl.Call(m, "GetDMChannelMapping", ctx, userID)
 	ret0, _ := ret[0].(map[uuid.UUID]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDMChannelMapping indicates an expected call of GetDMChannelMapping.
-func (mr *MockManagerMockRecorder) GetDMChannelMapping(userID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetDMChannelMapping(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannelMapping", reflect.TypeOf((*MockManager)(nil).GetDMChannelMapping), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannelMapping", reflect.TypeOf((*MockManager)(nil).GetDMChannelMapping), ctx, userID)
 }
 
 // GetDMChannelMembers mocks base method.
-func (m *MockManager) GetDMChannelMembers(id uuid.UUID) ([]uuid.UUID, error) {
+func (m *MockManager) GetDMChannelMembers(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDMChannelMembers", id)
+	ret := m.ctrl.Call(m, "GetDMChannelMembers", ctx, id)
 	ret0, _ := ret[0].([]uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDMChannelMembers indicates an expected call of GetDMChannelMembers.
-func (mr *MockManagerMockRecorder) GetDMChannelMembers(id interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetDMChannelMembers(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannelMembers", reflect.TypeOf((*MockManager)(nil).GetDMChannelMembers), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMChannelMembers", reflect.TypeOf((*MockManager)(nil).GetDMChannelMembers), ctx, id)
 }
 
 // IsChannelAccessibleToUser mocks base method.
-func (m *MockManager) IsChannelAccessibleToUser(userID, channelID uuid.UUID) (bool, error) {
+func (m *MockManager) IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsChannelAccessibleToUser", userID, channelID)
+	ret := m.ctrl.Call(m, "IsChannelAccessibleToUser", ctx, userID, channelID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsChannelAccessibleToUser indicates an expected call of IsChannelAccessibleToUser.
-func (mr *MockManagerMockRecorder) IsChannelAccessibleToUser(userID, channelID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) IsChannelAccessibleToUser(ctx, userID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsChannelAccessibleToUser", reflect.TypeOf((*MockManager)(nil).IsChannelAccessibleToUser), userID, channelID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsChannelAccessibleToUser", reflect.TypeOf((*MockManager)(nil).IsChannelAccessibleToUser), ctx, userID, channelID)
 }
 
 // IsPublicChannel mocks base method.
-func (m *MockManager) IsPublicChannel(id uuid.UUID) bool {
+func (m *MockManager) IsPublicChannel(ctx context.Context, id uuid.UUID) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPublicChannel", id)
+	ret := m.ctrl.Call(m, "IsPublicChannel", ctx, id)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsPublicChannel indicates an expected call of IsPublicChannel.
-func (mr *MockManagerMockRecorder) IsPublicChannel(id interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) IsPublicChannel(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPublicChannel", reflect.TypeOf((*MockManager)(nil).IsPublicChannel), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPublicChannel", reflect.TypeOf((*MockManager)(nil).IsPublicChannel), ctx, id)
 }
 
 // PublicChannelTree mocks base method.
-func (m *MockManager) PublicChannelTree() channel.Tree {
+func (m *MockManager) PublicChannelTree(ctx context.Context) channel.Tree {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicChannelTree")
+	ret := m.ctrl.Call(m, "PublicChannelTree", ctx)
 	ret0, _ := ret[0].(channel.Tree)
 	return ret0
 }
 
 // PublicChannelTree indicates an expected call of PublicChannelTree.
-func (mr *MockManagerMockRecorder) PublicChannelTree() *gomock.Call {
+func (mr *MockManagerMockRecorder) PublicChannelTree(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicChannelTree", reflect.TypeOf((*MockManager)(nil).PublicChannelTree))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicChannelTree", reflect.TypeOf((*MockManager)(nil).PublicChannelTree), ctx)
 }
 
 // UnarchiveChannel mocks base method.
-func (m *MockManager) UnarchiveChannel(id, updaterID uuid.UUID) error {
+func (m *MockManager) UnarchiveChannel(ctx context.Context, id, updaterID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnarchiveChannel", id, updaterID)
+	ret := m.ctrl.Call(m, "UnarchiveChannel", ctx, id, updaterID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnarchiveChannel indicates an expected call of UnarchiveChannel.
-func (mr *MockManagerMockRecorder) UnarchiveChannel(id, updaterID interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) UnarchiveChannel(ctx, id, updaterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnarchiveChannel", reflect.TypeOf((*MockManager)(nil).UnarchiveChannel), id, updaterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnarchiveChannel", reflect.TypeOf((*MockManager)(nil).UnarchiveChannel), ctx, id, updaterID)
 }
 
 // UpdateChannel mocks base method.
-func (m *MockManager) UpdateChannel(id uuid.UUID, args repository.UpdateChannelArgs) error {
+func (m *MockManager) UpdateChannel(ctx context.Context, id uuid.UUID, args repository.UpdateChannelArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateChannel", id, args)
+	ret := m.ctrl.Call(m, "UpdateChannel", ctx, id, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateChannel indicates an expected call of UpdateChannel.
-func (mr *MockManagerMockRecorder) UpdateChannel(id, args interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) UpdateChannel(ctx, id, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockManager)(nil).UpdateChannel), id, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockManager)(nil).UpdateChannel), ctx, id, args)
 }
 
 // Wait mocks base method.

--- a/service/exevent/stamp_throttler.go
+++ b/service/exevent/stamp_throttler.go
@@ -1,6 +1,7 @@
 package exevent
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -47,7 +48,7 @@ func (st *StampThrottler) run() {
 }
 
 func (st *StampThrottler) publishMessageStampsUpdated(messageID uuid.UUID) {
-	msg, err := st.mm.Get(messageID)
+	msg, err := st.mm.Get(context.Background(), messageID)
 	if err != nil {
 		return // ignore error
 	}

--- a/service/fcm/impl.go
+++ b/service/fcm/impl.go
@@ -83,7 +83,7 @@ func (c *clientImpl) send(targetUserIDs set.UUID, p *Payload, withUnreadCount bo
 
 	logger := c.logger.With(zap.Reflect("payload", p))
 
-	tokensMap, err := c.repo.GetDeviceTokens(context.TODO(), targetUserIDs)
+	tokensMap, err := c.repo.GetDeviceTokens(context.Background(), targetUserIDs)
 	if err != nil {
 		logger.Error("failed to GetDeviceTokens", zap.Error(err), zap.Strings("target_user_ids", targetUserIDs.StringArray()))
 		return err
@@ -222,7 +222,7 @@ func (c *clientImpl) sendMessages(messages []*messaging.Message) {
 		}
 	}
 	if len(invalidTokens) > 0 {
-		err := c.repo.DeleteDeviceTokens(context.TODO(), invalidTokens)
+		err := c.repo.DeleteDeviceTokens(context.Background(), invalidTokens)
 		if err != nil {
 			c.logger.Error("failed to DeleteDeviceTokens", zap.Error(err), zap.Strings("invalid_tokens", invalidTokens))
 			return

--- a/service/file/manager.go
+++ b/service/file/manager.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"errors"
 	"image"
 	"io"
@@ -75,23 +76,23 @@ type Manager interface {
 	// サムネイルが生成可能な場合はサムネイルを生成し同時に保存します
 	//
 	// 成功した場合、ファイルとnilを返します。
-	Save(args SaveArgs) (model.File, error)
+	Save(ctx context.Context, args SaveArgs) (model.File, error)
 	// Get ファイルを取得します
 	//
 	// 成功した場合、ファイルとnilを返します。
-	Get(id uuid.UUID) (model.File, error)
+	Get(ctx context.Context, id uuid.UUID) (model.File, error)
 	// List ファイルの一覧を取得します
 	//
 	// 成功した場合、ファイルの一覧を返します。負のoffset, limitは無視されます。
 	// 指定した範囲内にlimitを超えてメッセージが存在していた場合、trueを返します。
-	List(q repository.FilesQuery) ([]model.File, bool, error)
+	List(ctx context.Context, q repository.FilesQuery) ([]model.File, bool, error)
 	// Delete ファイルを削除します
 	//
 	// 成功した場合、nilを返します。
-	Delete(id uuid.UUID) error
+	Delete(ctx context.Context, id uuid.UUID) error
 	// Accessible ユーザーがファイルへのアクセス権限を持っているかを確認します
 	//
 	// ユーザーがアクセス権限を持っている場合、trueを返します。
 	// ファイルもしくはユーザーが存在しない場合は、falseを返します。
-	Accessible(fileID, userID uuid.UUID) (bool, error)
+	Accessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error)
 }

--- a/service/file/manager_impl.go
+++ b/service/file/manager_impl.go
@@ -65,7 +65,7 @@ func (m *managerImpl) canGenerateWaveform(mimeType string) bool {
 	}
 }
 
-func (m *managerImpl) Save(args SaveArgs) (model.File, error) {
+func (m *managerImpl) Save(ctx context.Context, args SaveArgs) (model.File, error) {
 	if err := args.Validate(); err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (m *managerImpl) Save(args SaveArgs) (model.File, error) {
 		})
 	}
 
-	err := m.repo.SaveFileMeta(context.TODO(), f, acl)
+	err := m.repo.SaveFileMeta(ctx, f, acl)
 	if err != nil {
 		if err := m.fs.DeleteByKey(f.ID.String(), f.Type); err != nil {
 			m.l.Warn("failed to delete file from storage during rollback", zap.Error(err), zap.Stringer("fid", f.ID))
@@ -219,8 +219,8 @@ func (m *managerImpl) Save(args SaveArgs) (model.File, error) {
 	return m.makeFileMeta(f), nil
 }
 
-func (m *managerImpl) Get(id uuid.UUID) (model.File, error) {
-	meta, err := m.repo.GetFileMeta(context.TODO(), id)
+func (m *managerImpl) Get(ctx context.Context, id uuid.UUID) (model.File, error) {
+	meta, err := m.repo.GetFileMeta(ctx, id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil, ErrNotFound
@@ -230,16 +230,16 @@ func (m *managerImpl) Get(id uuid.UUID) (model.File, error) {
 	return m.makeFileMeta(meta), nil
 }
 
-func (m *managerImpl) List(q repository.FilesQuery) ([]model.File, bool, error) {
-	r, more, err := m.repo.GetFileMetas(context.TODO(), q)
+func (m *managerImpl) List(ctx context.Context, q repository.FilesQuery) ([]model.File, bool, error) {
+	r, more, err := m.repo.GetFileMetas(ctx, q)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to GetFileMetas: %w", err)
 	}
 	return m.makeFileMetas(r), more, nil
 }
 
-func (m *managerImpl) Delete(id uuid.UUID) error {
-	meta, err := m.repo.GetFileMeta(context.TODO(), id)
+func (m *managerImpl) Delete(ctx context.Context, id uuid.UUID) error {
+	meta, err := m.repo.GetFileMeta(ctx, id)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return ErrNotFound
@@ -247,7 +247,7 @@ func (m *managerImpl) Delete(id uuid.UUID) error {
 		return fmt.Errorf("failed to GetFileMeta: %w", err)
 	}
 
-	if err := m.repo.DeleteFileMeta(context.TODO(), id); err != nil {
+	if err := m.repo.DeleteFileMeta(ctx, id); err != nil {
 		return fmt.Errorf("failed to DeleteFileMeta: %w", err)
 	}
 	if err := m.fs.DeleteByKey(meta.ID.String(), meta.Type); err != nil {
@@ -261,8 +261,8 @@ func (m *managerImpl) Delete(id uuid.UUID) error {
 	return nil
 }
 
-func (m *managerImpl) Accessible(fileID, userID uuid.UUID) (bool, error) {
-	ok, err := m.repo.IsFileAccessible(context.TODO(), fileID, userID)
+func (m *managerImpl) Accessible(ctx context.Context, fileID, userID uuid.UUID) (bool, error) {
+	ok, err := m.repo.IsFileAccessible(ctx, fileID, userID)
 	if err != nil {
 		return false, fmt.Errorf("failed to IsFileAccessible: %w", err)
 	}

--- a/service/file/manager_impl_test.go
+++ b/service/file/manager_impl_test.go
@@ -74,7 +74,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -133,7 +133,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -200,7 +200,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			Return(thumb, nil).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -267,7 +267,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			Return(thumb, nil).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -333,7 +333,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			Return(waveform, nil).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -397,7 +397,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			Return(waveform, nil).
 			Times(1)
 
-		result, err := fm.Save(args)
+		result, err := fm.Save(context.TODO(), args)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result.GetID())
 			assert.EqualValues(t, args.FileName, result.GetFileName())
@@ -445,7 +445,7 @@ func TestManagerImpl_Get(t *testing.T) {
 			Return(meta, nil).
 			Times(1)
 
-		res, err := fm.Get(meta.ID)
+		res, err := fm.Get(context.TODO(), meta.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, meta.ID, res.GetID())
 		}
@@ -462,7 +462,7 @@ func TestManagerImpl_Get(t *testing.T) {
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		_, err := fm.Get(uuid.Nil)
+		_, err := fm.Get(context.TODO(), uuid.Nil)
 		if assert.Error(t, err) {
 			assert.EqualError(t, ErrNotFound, err.Error())
 		}
@@ -479,7 +479,7 @@ func TestManagerImpl_Get(t *testing.T) {
 			Return(nil, errMock).
 			Times(1)
 
-		_, err := fm.Get(uuid.Nil)
+		_, err := fm.Get(context.TODO(), uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, errMock, errors.Unwrap(err))
 		}
@@ -514,7 +514,7 @@ func TestManagerImpl_List(t *testing.T) {
 			Return([]*model.FileMeta{meta, meta, meta}, true, nil).
 			Times(1)
 
-		res, more, err := fm.List(repository.FilesQuery{})
+		res, more, err := fm.List(context.TODO(), repository.FilesQuery{})
 		if assert.NoError(t, err) {
 			assert.True(t, more)
 			assert.Len(t, res, 3)
@@ -532,7 +532,7 @@ func TestManagerImpl_List(t *testing.T) {
 			Return(nil, false, errMock).
 			Times(1)
 
-		arr, more, err := fm.List(repository.FilesQuery{})
+		arr, more, err := fm.List(context.TODO(), repository.FilesQuery{})
 		if assert.Error(t, err) {
 			assert.Nil(t, arr)
 			assert.False(t, more)
@@ -591,7 +591,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 			Return(nil).
 			Times(1)
 
-		assert.NoError(t, fm.Delete(meta.ID))
+		assert.NoError(t, fm.Delete(context.TODO(), meta.ID))
 	})
 
 	t.Run("success (no thumbnail)", func(t *testing.T) {
@@ -624,7 +624,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 			Return(nil).
 			Times(1)
 
-		assert.NoError(t, fm.Delete(meta.ID))
+		assert.NoError(t, fm.Delete(context.TODO(), meta.ID))
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -638,7 +638,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		assert.EqualError(t, ErrNotFound, fm.Delete(uuid.Nil).Error())
+		assert.EqualError(t, ErrNotFound, fm.Delete(context.TODO(), uuid.Nil).Error())
 	})
 
 	t.Run("repo error 1", func(t *testing.T) {
@@ -652,7 +652,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 			Return(nil, errMock).
 			Times(1)
 
-		err := fm.Delete(uuid.Nil)
+		err := fm.Delete(context.TODO(), uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, errMock, errors.Unwrap(err))
 		}
@@ -683,7 +683,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 			Return(errMock).
 			Times(1)
 
-		err := fm.Delete(meta.ID)
+		err := fm.Delete(context.TODO(), meta.ID)
 		if assert.Error(t, err) {
 			assert.Equal(t, errMock, errors.Unwrap(err))
 		}
@@ -703,7 +703,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, errMock).Times(1)
 
-		ok, err := fm.Accessible(fid, uid)
+		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.Error(t, err) {
 			assert.False(t, ok)
 			assert.Equal(t, errMock, errors.Unwrap(err))
@@ -720,7 +720,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(true, nil).Times(1)
 
-		ok, err := fm.Accessible(fid, uid)
+		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.NoError(t, err) {
 			assert.True(t, ok)
 		}
@@ -736,7 +736,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, nil).Times(1)
 
-		ok, err := fm.Accessible(fid, uid)
+		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.NoError(t, err) {
 			assert.False(t, ok)
 		}

--- a/service/file/manager_impl_test.go
+++ b/service/file/manager_impl_test.go
@@ -67,7 +67,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			DoAndReturn(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
@@ -126,7 +126,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			DoAndReturn(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) error {
 				meta.CreatedAt = time.Now()
 				return nil
@@ -190,7 +190,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
@@ -257,7 +257,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
@@ -323,7 +323,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
@@ -387,7 +387,7 @@ func TestManagerImpl_Save(t *testing.T) {
 			}).
 			Times(1)
 		repo.EXPECT().
-			SaveFileMeta(context.TODO(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
+			SaveFileMeta(gomock.Any(), gomock.Any(), []*model.FileACLEntry{{UserID: uuid.Nil, Allow: true}}).
 			Do(func(_ context.Context, meta *model.FileMeta, _ []*model.FileACLEntry) { meta.CreatedAt = time.Now() }).
 			Return(nil).
 			Times(1)
@@ -441,7 +441,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		}}
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), meta.ID).
+			GetFileMeta(gomock.Any(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 
@@ -458,7 +458,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), uuid.Nil).
+			GetFileMeta(gomock.Any(), uuid.Nil).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -475,7 +475,7 @@ func TestManagerImpl_Get(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), uuid.Nil).
+			GetFileMeta(gomock.Any(), uuid.Nil).
 			Return(nil, errMock).
 			Times(1)
 
@@ -510,7 +510,7 @@ func TestManagerImpl_List(t *testing.T) {
 		}}
 
 		repo.EXPECT().
-			GetFileMetas(context.TODO(), gomock.Any()).
+			GetFileMetas(gomock.Any(), gomock.Any()).
 			Return([]*model.FileMeta{meta, meta, meta}, true, nil).
 			Times(1)
 
@@ -528,7 +528,7 @@ func TestManagerImpl_List(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMetas(context.TODO(), gomock.Any()).
+			GetFileMetas(gomock.Any(), gomock.Any()).
 			Return(nil, false, errMock).
 			Times(1)
 
@@ -571,11 +571,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 			},
 		}
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), meta.ID).
+			GetFileMeta(gomock.Any(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(context.TODO(), meta.ID).
+			DeleteFileMeta(gomock.Any(), meta.ID).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
@@ -612,11 +612,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), meta.ID).
+			GetFileMeta(gomock.Any(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(context.TODO(), meta.ID).
+			DeleteFileMeta(gomock.Any(), meta.ID).
 			Return(nil).
 			Times(1)
 		fs.EXPECT().
@@ -634,7 +634,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), uuid.Nil).
+			GetFileMeta(gomock.Any(), uuid.Nil).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
@@ -648,7 +648,7 @@ func TestManagerImpl_Delete(t *testing.T) {
 		fm := initFM(t, repo, nil, nil)
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), uuid.Nil).
+			GetFileMeta(gomock.Any(), uuid.Nil).
 			Return(nil, errMock).
 			Times(1)
 
@@ -675,11 +675,11 @@ func TestManagerImpl_Delete(t *testing.T) {
 		}
 
 		repo.EXPECT().
-			GetFileMeta(context.TODO(), meta.ID).
+			GetFileMeta(gomock.Any(), meta.ID).
 			Return(meta, nil).
 			Times(1)
 		repo.EXPECT().
-			DeleteFileMeta(context.TODO(), meta.ID).
+			DeleteFileMeta(gomock.Any(), meta.ID).
 			Return(errMock).
 			Times(1)
 
@@ -701,7 +701,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, errMock).Times(1)
+		repo.EXPECT().IsFileAccessible(gomock.Any(), fid, uid).Return(false, errMock).Times(1)
 
 		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.Error(t, err) {
@@ -718,7 +718,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(true, nil).Times(1)
+		repo.EXPECT().IsFileAccessible(gomock.Any(), fid, uid).Return(true, nil).Times(1)
 
 		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.NoError(t, err) {
@@ -734,7 +734,7 @@ func TestManagerImpl_Accessible(t *testing.T) {
 
 		fid := uuid.NewV3(uuid.Nil, "f1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		repo.EXPECT().IsFileAccessible(context.TODO(), fid, uid).Return(false, nil).Times(1)
+		repo.EXPECT().IsFileAccessible(gomock.Any(), fid, uid).Return(false, nil).Times(1)
 
 		ok, err := fm.Accessible(context.TODO(), fid, uid)
 		if assert.NoError(t, err) {

--- a/service/file/utils.go
+++ b/service/file/utils.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image/png"
 
@@ -14,7 +15,7 @@ import (
 // GenerateIconFile アイコンファイルを生成します
 //
 // 成功した場合、そのファイルのUUIDとnilを返します。
-func GenerateIconFile(m Manager, salt string) (uuid.UUID, error) {
+func GenerateIconFile(ctx context.Context, m Manager, salt string) (uuid.UUID, error) {
 	var img bytes.Buffer
 	icon, err := imaging.GenerateIcon(salt)
 	if err != nil {
@@ -25,7 +26,7 @@ func GenerateIconFile(m Manager, salt string) (uuid.UUID, error) {
 		return uuid.Nil, err
 	}
 
-	file, err := m.Save(SaveArgs{
+	file, err := m.Save(ctx, SaveArgs{
 		FileName:  fmt.Sprintf("%s.png", salt),
 		FileSize:  int64(img.Len()),
 		MimeType:  "image/png",

--- a/service/message/manager.go
+++ b/service/message/manager.go
@@ -39,44 +39,44 @@ type Manager interface {
 	// 成功した場合、メッセージとnilを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	Get(id uuid.UUID) (Message, error)
+	Get(ctx context.Context, id uuid.UUID) (Message, error)
 	// GetIn 指定したIDのメッセージをすべて取得します
 	// 存在チェックはせず、存在するメッセージだけを返します。
 	// キャッシュをバイパスすることに気をつけてください。
 	//
 	// 成功した場合、メッセージとnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetIn(ids []uuid.UUID) ([]Message, error)
+	GetIn(ctx context.Context, ids []uuid.UUID) ([]Message, error)
 	// GetTimeline タイムラインを取得します
 	//
 	// 成功した場合、タイムラインとnilを返します。
 	// DBによるエラーを返すことがあります。
-	GetTimeline(query TimelineQuery) (Timeline, error)
+	GetTimeline(ctx context.Context, query TimelineQuery) (Timeline, error)
 	// Create メッセージを作成します
 	//
 	// 成功した場合、メッセージとnilを返します。
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// DBによるエラーを返すことがあります。
-	Create(channelID, userID uuid.UUID, content string) (Message, error)
+	Create(ctx context.Context, channelID, userID uuid.UUID, content string) (Message, error)
 	// CreateDM ダイレクトメッセージを作成します
 	//
 	// 成功した場合、メッセージとnilを返します。
 	// DBによるエラーを返すことがあります。
-	CreateDM(from, to uuid.UUID, content string) (Message, error)
+	CreateDM(ctx context.Context, from, to uuid.UUID, content string) (Message, error)
 	// Edit 指定したメッセージを編集します
 	//
 	// 成功した場合、nilを返します。
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	Edit(id uuid.UUID, content string) error
+	Edit(ctx context.Context, id uuid.UUID, content string) error
 	// Delete 指定したメッセージを削除します
 	//
 	// 成功した場合、nilを返します。
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// 存在しないメッセージを指定した場合、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	Delete(id uuid.UUID) error
+	Delete(ctx context.Context, id uuid.UUID) error
 	// Pin 指定したユーザーによって指定したメッセージをピン留めします
 	//
 	// 成功した場合は、ピンとnilを返します。
@@ -85,7 +85,7 @@ type Manager interface {
 	// 存在しないメッセージを指定した場合は、ErrNotFoundを返します。
 	// チャンネルに既に上限数以上のメッセージがピン留めされていた場合、ErrPinLimitExceededを返します。
 	// DBによるエラーを返すことがあります。
-	Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error)
+	Pin(ctx context.Context, id uuid.UUID, userID uuid.UUID) (*model.Pin, error)
 	// Unpin 指定したユーザーによって指定したメッセージのピン留めを外します
 	//
 	// 成功した場合は、nilを返します。
@@ -93,21 +93,21 @@ type Manager interface {
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// 存在しないメッセージを指定した場合は、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	Unpin(id uuid.UUID, userID uuid.UUID) error
+	Unpin(ctx context.Context, id uuid.UUID, userID uuid.UUID) error
 	// AddStamps 指定したメッセージに指定したユーザーの指定したスタンプを追加します
 	//
 	// 成功した場合、そのメッセージスタンプとnilを返します。
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// 存在しないメッセージを指定した場合は、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	AddStamps(id, stampID, userID uuid.UUID, n int) (*model.MessageStamp, error)
+	AddStamps(ctx context.Context, id, stampID, userID uuid.UUID, n int) (*model.MessageStamp, error)
 	// RemoveStamps 指定したメッセージから指定したユーザーの指定したスタンプを全て削除します
 	//
-	// 成功した、或いは既に削除されていた場合、nilを返します。
+	// 成功した場合、或いは既に削除されていた場合、nilを返します。
 	// アーカイブされているチャンネルを指定すると、ErrChannelArchivedを返します。
 	// 存在しないメッセージを指定した場合は、ErrNotFoundを返します。
 	// DBによるエラーを返すことがあります。
-	RemoveStamps(id, stampID, userID uuid.UUID) error
+	RemoveStamps(ctx context.Context, id, stampID, userID uuid.UUID) error
 
 	Wait(ctx context.Context) error
 }

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -106,7 +106,7 @@ func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
 
 func (m *manager) CreateDM(from, to uuid.UUID, content string) (Message, error) {
 	// DMチャンネルを取得
-	ch, err := m.CM.GetDMChannel(from, to)
+	ch, err := m.CM.GetDMChannel(context.Background(), from, to)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (m *manager) CreateDM(from, to uuid.UUID, content string) (Message, error) 
 
 func (m *manager) Create(channelID, userID uuid.UUID, content string) (Message, error) {
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(channelID) && m.CM.PublicChannelTree().IsArchivedChannel(channelID) {
+	if m.CM.IsPublicChannel(context.Background(), channelID) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(channelID) {
 		return nil, ErrChannelArchived
 	}
 
@@ -140,7 +140,7 @@ func (m *manager) Edit(id uuid.UUID, content string) error {
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return ErrChannelArchived
 	}
 
@@ -166,7 +166,7 @@ func (m *manager) Delete(id uuid.UUID) error {
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return ErrChannelArchived
 	}
 
@@ -197,7 +197,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return nil, ErrChannelArchived
 	}
 
@@ -245,7 +245,7 @@ func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return ErrChannelArchived
 	}
 
@@ -277,7 +277,7 @@ func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.Messag
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return nil, ErrChannelArchived
 	}
 
@@ -301,7 +301,7 @@ func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
 	}
 
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(msg.GetChannelID()) && m.CM.PublicChannelTree().IsArchivedChannel(msg.GetChannelID()) {
+	if m.CM.IsPublicChannel(context.Background(), msg.GetChannelID()) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(msg.GetChannelID()) {
 		return ErrChannelArchived
 	}
 

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -39,7 +39,7 @@ func NewMessageManager(repo repository.Repository, cm channel.Manager, logger *z
 		R:  repo,
 		L:  logger.Named("message_manager"),
 		cache: sc.NewMust(func(_ context.Context, key uuid.UUID) (*message, error) {
-			m, err := repo.GetMessageByID(context.TODO(), key)
+			m, err := repo.GetMessageByID(context.Background(), key)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return nil, ErrNotFound
@@ -65,7 +65,7 @@ func (m *manager) get(id uuid.UUID) (*message, error) {
 }
 
 func (m *manager) GetIn(ids []uuid.UUID) ([]Message, error) {
-	messages, _, err := m.R.GetMessages(context.TODO(), repository.MessagesQuery{IDIn: optional.From(ids)})
+	messages, _, err := m.R.GetMessages(context.Background(), repository.MessagesQuery{IDIn: optional.From(ids)})
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
 		ExcludeDMs:               query.ExcludeDMs,
 		DisablePreload:           query.DisablePreload,
 	}
-	messages, more, err := m.R.GetMessages(context.TODO(), q)
+	messages, more, err := m.R.GetMessages(context.Background(), q)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetMessages: %w", err)
 	}
@@ -125,7 +125,7 @@ func (m *manager) Create(channelID, userID uuid.UUID, content string) (Message, 
 
 func (m *manager) create(channelID, userID uuid.UUID, content string) (Message, error) {
 	// 作成
-	msg, err := m.R.CreateMessage(context.TODO(), userID, channelID, content)
+	msg, err := m.R.CreateMessage(context.Background(), userID, channelID, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateMessage: %w", err)
 	}
@@ -145,7 +145,7 @@ func (m *manager) Edit(id uuid.UUID, content string) error {
 	}
 
 	// 更新
-	if err := m.R.UpdateMessage(context.TODO(), id, content); err != nil {
+	if err := m.R.UpdateMessage(context.Background(), id, content); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -171,7 +171,7 @@ func (m *manager) Delete(id uuid.UUID) error {
 	}
 
 	// 削除
-	if err := m.R.DeleteMessage(context.TODO(), id); err != nil {
+	if err := m.R.DeleteMessage(context.Background(), id); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -202,7 +202,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// チャンネルに上限数以上のメッセージがピン留めされていないか確認
-	pins, err := m.R.GetPinnedMessageByChannelID(context.TODO(), msg.GetChannelID())
+	pins, err := m.R.GetPinnedMessageByChannelID(context.Background(), msg.GetChannelID())
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// ピン
-	pin, err := m.R.PinMessage(context.TODO(), id, userID)
+	pin, err := m.R.PinMessage(context.Background(), id, userID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -250,7 +250,7 @@ func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
 	}
 
 	// ピン外し
-	pin, err := m.R.UnpinMessage(context.TODO(), id)
+	pin, err := m.R.UnpinMessage(context.Background(), id)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -282,7 +282,7 @@ func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.Messag
 	}
 
 	// スタンプを押す
-	ms, err := m.R.AddStampToMessage(context.TODO(), id, stampID, userID, n)
+	ms, err := m.R.AddStampToMessage(context.Background(), id, stampID, userID, n)
 	if err != nil {
 		return nil, fmt.Errorf("failed to AddStampToMessage: %w", err)
 	}
@@ -306,7 +306,7 @@ func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
 	}
 
 	// スタンプを消す
-	if err := m.R.RemoveStampFromMessage(context.TODO(), id, stampID, userID); err != nil {
+	if err := m.R.RemoveStampFromMessage(context.Background(), id, stampID, userID); err != nil {
 		return fmt.Errorf("failed to RemoveStampFromMessage: %w", err)
 	}
 
@@ -326,7 +326,7 @@ func (m *manager) recordChannelEvent(channelID uuid.UUID, eventType model.Channe
 	go func() {
 		defer m.P.Done()
 
-		err := m.R.RecordChannelEvent(context.TODO(), channelID, eventType, detail, datetime)
+		err := m.R.RecordChannelEvent(context.Background(), channelID, eventType, detail, datetime)
 		if err != nil {
 			m.L.Warn("failed to record channel event", zap.Error(err), zap.Stringer("channelID", channelID), zap.Stringer("type", eventType), zap.Any("detail", detail), zap.Time("datetime", datetime))
 		}

--- a/service/message/manager_impl.go
+++ b/service/message/manager_impl.go
@@ -38,8 +38,8 @@ func NewMessageManager(repo repository.Repository, cm channel.Manager, logger *z
 		CM: cm,
 		R:  repo,
 		L:  logger.Named("message_manager"),
-		cache: sc.NewMust(func(_ context.Context, key uuid.UUID) (*message, error) {
-			m, err := repo.GetMessageByID(context.Background(), key)
+		cache: sc.NewMust(func(ctx context.Context, key uuid.UUID) (*message, error) {
+			m, err := repo.GetMessageByID(ctx, key)
 			if err != nil {
 				if err == repository.ErrNotFound {
 					return nil, ErrNotFound
@@ -51,21 +51,21 @@ func NewMessageManager(repo repository.Repository, cm channel.Manager, logger *z
 	}, nil
 }
 
-func (m *manager) Get(id uuid.UUID) (Message, error) {
-	return m.get(id)
+func (m *manager) Get(ctx context.Context, id uuid.UUID) (Message, error) {
+	return m.get(ctx, id)
 }
 
-func (m *manager) get(id uuid.UUID) (*message, error) {
+func (m *manager) get(ctx context.Context, id uuid.UUID) (*message, error) {
 	if id == uuid.Nil {
 		return nil, ErrNotFound
 	}
 
 	// メモリキャッシュから取得。キャッシュに無い場合はキャッシュの replaceFn で自動取得し、キャッシュに追加
-	return m.cache.Get(context.Background(), id)
+	return m.cache.Get(ctx, id)
 }
 
-func (m *manager) GetIn(ids []uuid.UUID) ([]Message, error) {
-	messages, _, err := m.R.GetMessages(context.Background(), repository.MessagesQuery{IDIn: optional.From(ids)})
+func (m *manager) GetIn(ctx context.Context, ids []uuid.UUID) ([]Message, error) {
+	messages, _, err := m.R.GetMessages(ctx, repository.MessagesQuery{IDIn: optional.From(ids)})
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (m *manager) GetIn(ids []uuid.UUID) ([]Message, error) {
 	return ret, nil
 }
 
-func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
+func (m *manager) GetTimeline(ctx context.Context, query TimelineQuery) (Timeline, error) {
 	q := repository.MessagesQuery{
 		User:                     query.User,
 		Channel:                  query.Channel,
@@ -89,7 +89,7 @@ func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
 		ExcludeDMs:               query.ExcludeDMs,
 		DisablePreload:           query.DisablePreload,
 	}
-	messages, more, err := m.R.GetMessages(context.Background(), q)
+	messages, more, err := m.R.GetMessages(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetMessages: %w", err)
 	}
@@ -104,37 +104,37 @@ func (m *manager) GetTimeline(query TimelineQuery) (Timeline, error) {
 	}, nil
 }
 
-func (m *manager) CreateDM(from, to uuid.UUID, content string) (Message, error) {
+func (m *manager) CreateDM(ctx context.Context, from, to uuid.UUID, content string) (Message, error) {
 	// DMチャンネルを取得
-	ch, err := m.CM.GetDMChannel(context.Background(), from, to)
+	ch, err := m.CM.GetDMChannel(ctx, from, to)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.create(ch.ID, from, content)
+	return m.create(ctx, ch.ID, from, content)
 }
 
-func (m *manager) Create(channelID, userID uuid.UUID, content string) (Message, error) {
+func (m *manager) Create(ctx context.Context, channelID, userID uuid.UUID, content string) (Message, error) {
 	// チャンネルがアーカイブされているかどうか確認
-	if m.CM.IsPublicChannel(context.Background(), channelID) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(channelID) {
+	if m.CM.IsPublicChannel(ctx, channelID) && m.CM.PublicChannelTree(context.Background()).IsArchivedChannel(channelID) {
 		return nil, ErrChannelArchived
 	}
 
-	return m.create(channelID, userID, content)
+	return m.create(ctx, channelID, userID, content)
 }
 
-func (m *manager) create(channelID, userID uuid.UUID, content string) (Message, error) {
+func (m *manager) create(ctx context.Context, channelID, userID uuid.UUID, content string) (Message, error) {
 	// 作成
-	msg, err := m.R.CreateMessage(context.Background(), userID, channelID, content)
+	msg, err := m.R.CreateMessage(ctx, userID, channelID, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateMessage: %w", err)
 	}
 	return &message{Model: msg}, nil
 }
 
-func (m *manager) Edit(id uuid.UUID, content string) error {
+func (m *manager) Edit(ctx context.Context, id uuid.UUID, content string) error {
 	// メッセージ取得
-	msg, err := m.Get(id)
+	msg, err := m.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (m *manager) Edit(id uuid.UUID, content string) error {
 	}
 
 	// 更新
-	if err := m.R.UpdateMessage(context.Background(), id, content); err != nil {
+	if err := m.R.UpdateMessage(ctx, id, content); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -158,9 +158,9 @@ func (m *manager) Edit(id uuid.UUID, content string) error {
 	return nil
 }
 
-func (m *manager) Delete(id uuid.UUID) error {
+func (m *manager) Delete(ctx context.Context, id uuid.UUID) error {
 	// メッセージ取得
-	msg, err := m.Get(id)
+	msg, err := m.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (m *manager) Delete(id uuid.UUID) error {
 	}
 
 	// 削除
-	if err := m.R.DeleteMessage(context.Background(), id); err != nil {
+	if err := m.R.DeleteMessage(ctx, id); err != nil {
 		switch err {
 		case repository.ErrNotFound:
 			return ErrNotFound
@@ -184,9 +184,9 @@ func (m *manager) Delete(id uuid.UUID) error {
 	return nil
 }
 
-func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
+func (m *manager) Pin(ctx context.Context, id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	// メッセージ取得
-	msg, err := m.Get(id)
+	msg, err := m.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// チャンネルに上限数以上のメッセージがピン留めされていないか確認
-	pins, err := m.R.GetPinnedMessageByChannelID(context.Background(), msg.GetChannelID())
+	pins, err := m.R.GetPinnedMessageByChannelID(ctx, msg.GetChannelID())
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	}
 
 	// ピン
-	pin, err := m.R.PinMessage(context.Background(), id, userID)
+	pin, err := m.R.PinMessage(ctx, id, userID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -232,9 +232,9 @@ func (m *manager) Pin(id uuid.UUID, userID uuid.UUID) (*model.Pin, error) {
 	return pin, nil
 }
 
-func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
+func (m *manager) Unpin(ctx context.Context, id uuid.UUID, userID uuid.UUID) error {
 	// メッセージ取得
-	msg, err := m.Get(id)
+	msg, err := m.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
 	}
 
 	// ピン外し
-	pin, err := m.R.UnpinMessage(context.Background(), id)
+	pin, err := m.R.UnpinMessage(ctx, id)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -269,9 +269,9 @@ func (m *manager) Unpin(id uuid.UUID, userID uuid.UUID) error {
 	return nil
 }
 
-func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.MessageStamp, error) {
+func (m *manager) AddStamps(ctx context.Context, id, stampID, userID uuid.UUID, n int) (*model.MessageStamp, error) {
 	// メッセージ取得
-	msg, err := m.get(id)
+	msg, err := m.get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.Messag
 	}
 
 	// スタンプを押す
-	ms, err := m.R.AddStampToMessage(context.Background(), id, stampID, userID, n)
+	ms, err := m.R.AddStampToMessage(ctx, id, stampID, userID, n)
 	if err != nil {
 		return nil, fmt.Errorf("failed to AddStampToMessage: %w", err)
 	}
@@ -293,9 +293,9 @@ func (m *manager) AddStamps(id, stampID, userID uuid.UUID, n int) (*model.Messag
 	return ms, nil
 }
 
-func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
+func (m *manager) RemoveStamps(ctx context.Context, id, stampID, userID uuid.UUID) error {
 	// メッセージ取得
-	msg, err := m.get(id)
+	msg, err := m.get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func (m *manager) RemoveStamps(id, stampID, userID uuid.UUID) error {
 	}
 
 	// スタンプを消す
-	if err := m.R.RemoveStampFromMessage(context.Background(), id, stampID, userID); err != nil {
+	if err := m.R.RemoveStampFromMessage(ctx, id, stampID, userID); err != nil {
 		return fmt.Errorf("failed to RemoveStampFromMessage: %w", err)
 	}
 

--- a/service/message/manager_impl_test.go
+++ b/service/message/manager_impl_test.go
@@ -18,7 +18,7 @@ import (
 func setupM(ctrl *gomock.Controller) (Manager, *mock_channel.MockManager, *Repo, *mock_channel.MockTree) {
 	cm := mock_channel.NewMockManager(ctrl)
 	tree := mock_channel.NewMockTree(ctrl)
-	cm.EXPECT().PublicChannelTree().Return(tree).AnyTimes()
+	cm.EXPECT().PublicChannelTree(gomock.Any()).Return(tree).AnyTimes()
 	repo := NewMockRepo(ctrl)
 	m, _ := NewMessageManager(repo, cm, zap.NewNop())
 	return m, cm, repo, tree
@@ -32,7 +32,7 @@ func TestManager_Get(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		m, _, _, _ := setupM(ctrl)
 
-		_, err := m.Get(uuid.Nil)
+		_, err := m.Get(context.TODO(), uuid.Nil)
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 
@@ -53,11 +53,11 @@ func TestManager_Get(t *testing.T) {
 		}
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), msg.ID).
+			GetMessageByID(gomock.Any(), msg.ID).
 			Return(msg, nil).
 			Times(1)
 
-		result, err := m.Get(msg.ID)
+		result, err := m.Get(context.TODO(), msg.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.ID, result.GetID())
 			assert.EqualValues(t, msg.ChannelID, result.GetChannelID())
@@ -70,7 +70,7 @@ func TestManager_Get(t *testing.T) {
 		}
 
 		// キャッシュからもう一度
-		result, err = m.Get(msg.ID)
+		result, err = m.Get(context.TODO(), msg.ID)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.ID, result.GetID())
 			assert.EqualValues(t, msg.ChannelID, result.GetChannelID())
@@ -91,11 +91,11 @@ func TestManager_Get(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		_, err := m.Get(id)
+		_, err := m.Get(context.TODO(), id)
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 }
@@ -110,10 +110,10 @@ func TestManager_Create(t *testing.T) {
 		m, cm, _, tree := setupM(ctrl)
 
 		cid := uuid.NewV3(uuid.Nil, "c1")
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(true).Times(1)
 
-		_, err := m.Create(cid, uuid.NewV3(uuid.Nil, "u1"), content)
+		_, err := m.Create(context.TODO(), cid, uuid.NewV3(uuid.Nil, "u1"), content)
 		assert.EqualError(t, err, ErrChannelArchived.Error())
 	})
 
@@ -124,15 +124,15 @@ func TestManager_Create(t *testing.T) {
 
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		uid := uuid.NewV3(uuid.Nil, "u1")
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(context.Background(), uid, cid, content).
+			CreateMessage(gomock.Any(), uid, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: uid, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
-		msg, err := m.Create(cid, uid, content)
+		msg, err := m.Create(context.TODO(), cid, uid, content)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, cid, msg.GetChannelID())
 			assert.EqualValues(t, uid, msg.GetUserID())
@@ -142,10 +142,10 @@ func TestManager_Create(t *testing.T) {
 		// キャッシュに取得
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), msg.GetID()).
+			GetMessageByID(gomock.Any(), msg.GetID()).
 			Return(msg.(*message).Model, nil).
 			Times(1)
-		result, err := m.Get(msg.GetID())
+		result, err := m.Get(context.TODO(), msg.GetID())
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.GetID(), result.GetID())
 			assert.EqualValues(t, cid, result.GetChannelID())
@@ -154,7 +154,7 @@ func TestManager_Create(t *testing.T) {
 		}
 
 		// キャッシュからもう一度
-		result, err = m.Get(msg.GetID())
+		result, err = m.Get(context.TODO(), msg.GetID())
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.GetID(), result.GetID())
 			assert.EqualValues(t, cid, result.GetChannelID())
@@ -176,14 +176,14 @@ func TestManager_CreateDM(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		from := uuid.NewV3(uuid.Nil, "u1")
 		to := uuid.NewV3(uuid.Nil, "u2")
-		cm.EXPECT().GetDMChannel(from, to).Return(&model.Channel{ID: cid}, nil).Times(1)
+		cm.EXPECT().GetDMChannel(gomock.Any(), from, to).Return(&model.Channel{ID: cid}, nil).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(context.Background(), from, cid, content).
+			CreateMessage(gomock.Any(), from, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: from, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
-		msg, err := m.CreateDM(from, to, content)
+		msg, err := m.CreateDM(context.TODO(), from, to, content)
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, cid, msg.GetChannelID())
 			assert.EqualValues(t, from, msg.GetUserID())
@@ -193,10 +193,10 @@ func TestManager_CreateDM(t *testing.T) {
 		// キャッシュに取得
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), msg.GetID()).
+			GetMessageByID(gomock.Any(), msg.GetID()).
 			Return(msg.(*message).Model, nil).
 			Times(1)
-		result, err := m.Get(msg.GetID())
+		result, err := m.Get(context.TODO(), msg.GetID())
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.GetID(), result.GetID())
 			assert.EqualValues(t, cid, result.GetChannelID())
@@ -205,7 +205,7 @@ func TestManager_CreateDM(t *testing.T) {
 		}
 
 		// キャッシュからもう一度
-		result, err = m.Get(msg.GetID())
+		result, err = m.Get(context.TODO(), msg.GetID())
 		if assert.NoError(t, err) {
 			assert.EqualValues(t, msg.GetID(), result.GetID())
 			assert.EqualValues(t, cid, result.GetChannelID())
@@ -227,11 +227,11 @@ func TestManager_Edit(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		err := m.Edit(id, newContent)
+		err := m.Edit(context.TODO(), id, newContent)
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 
@@ -244,13 +244,13 @@ func TestManager_Edit(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(true).Times(1)
 
-		err := m.Edit(id, newContent)
+		err := m.Edit(context.TODO(), id, newContent)
 		assert.EqualError(t, err, ErrChannelArchived.Error())
 	})
 
@@ -263,18 +263,18 @@ func TestManager_Edit(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			UpdateMessage(context.Background(), id, newContent).
+			UpdateMessage(gomock.Any(), id, newContent).
 			Return(nil).
 			Times(1)
 
-		err := m.Edit(id, newContent)
+		err := m.Edit(context.TODO(), id, newContent)
 		assert.NoError(t, err)
 	})
 }
@@ -290,11 +290,11 @@ func TestManager_Delete(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		err := m.Delete(id)
+		err := m.Delete(context.TODO(), id)
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 
@@ -307,13 +307,13 @@ func TestManager_Delete(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(true).Times(1)
 
-		err := m.Delete(id)
+		err := m.Delete(context.TODO(), id)
 		assert.EqualError(t, err, ErrChannelArchived.Error())
 	})
 
@@ -326,18 +326,18 @@ func TestManager_Delete(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			DeleteMessage(context.Background(), id).
+			DeleteMessage(gomock.Any(), id).
 			Return(nil).
 			Times(1)
 
-		err := m.Delete(id)
+		err := m.Delete(context.TODO(), id)
 		assert.NoError(t, err)
 	})
 }
@@ -353,11 +353,11 @@ func TestManager_AddStamps(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		_, err := m.AddStamps(id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"), 1)
+		_, err := m.AddStamps(context.TODO(), id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"), 1)
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 
@@ -370,13 +370,13 @@ func TestManager_AddStamps(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(true).Times(1)
 
-		_, err := m.AddStamps(id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"), 1)
+		_, err := m.AddStamps(context.TODO(), id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"), 1)
 		assert.EqualError(t, err, ErrChannelArchived.Error())
 	})
 
@@ -392,7 +392,7 @@ func TestManager_AddStamps(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{{
 				MessageID: id,
 				StampID:   sid2,
@@ -402,7 +402,7 @@ func TestManager_AddStamps(t *testing.T) {
 			Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -418,11 +418,11 @@ func TestManager_AddStamps(t *testing.T) {
 				},
 			}}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			AddStampToMessage(context.Background(), id, sid, uid, 1).
+			AddStampToMessage(gomock.Any(), id, sid, uid, 1).
 			Return(&model.MessageStamp{
 				MessageID: id,
 				StampID:   sid,
@@ -431,9 +431,9 @@ func TestManager_AddStamps(t *testing.T) {
 			}, nil).
 			Times(1)
 
-		_, err := m.AddStamps(id, sid, uid, 1)
+		_, err := m.AddStamps(context.TODO(), id, sid, uid, 1)
 		if assert.NoError(t, err) {
-			msg, err := m.Get(id)
+			msg, err := m.Get(context.TODO(), id)
 			if assert.NoError(t, err) {
 				assert.ElementsMatch(t, []model.MessageStamp{
 					{
@@ -465,11 +465,11 @@ func TestManager_RemoveStamps(t *testing.T) {
 		id := uuid.NewV3(uuid.Nil, "m1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(nil, repository.ErrNotFound).
 			Times(1)
 
-		err := m.RemoveStamps(id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"))
+		err := m.RemoveStamps(context.TODO(), id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"))
 		assert.EqualError(t, err, ErrNotFound.Error())
 	})
 
@@ -482,13 +482,13 @@ func TestManager_RemoveStamps(t *testing.T) {
 		cid := uuid.NewV3(uuid.Nil, "c1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(true).Times(1)
 
-		err := m.RemoveStamps(id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"))
+		err := m.RemoveStamps(context.TODO(), id, uuid.NewV3(uuid.Nil, "s1"), uuid.NewV3(uuid.Nil, "u1"))
 		assert.EqualError(t, err, ErrChannelArchived.Error())
 	})
 
@@ -504,7 +504,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		uid := uuid.NewV3(uuid.Nil, "u1")
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -522,7 +522,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 			Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			GetMessageByID(context.TODO(), id).
+			GetMessageByID(gomock.Any(), id).
 			Return(&model.Message{ID: id, ChannelID: cid, Stamps: []model.MessageStamp{
 				{
 					MessageID: id,
@@ -532,17 +532,17 @@ func TestManager_RemoveStamps(t *testing.T) {
 				},
 			}}, nil).
 			Times(1)
-		cm.EXPECT().IsPublicChannel(cid).Return(true).Times(1)
+		cm.EXPECT().IsPublicChannel(gomock.Any(), cid).Return(true).Times(1)
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			RemoveStampFromMessage(context.Background(), id, sid, uid).
+			RemoveStampFromMessage(gomock.Any(), id, sid, uid).
 			Return(nil).
 			Times(1)
 
-		err := m.RemoveStamps(id, sid, uid)
+		err := m.RemoveStamps(context.TODO(), id, sid, uid)
 		if assert.NoError(t, err) {
-			msg, err := m.Get(id)
+			msg, err := m.Get(context.TODO(), id)
 			if assert.NoError(t, err) {
 				assert.ElementsMatch(t, []model.MessageStamp{
 					{

--- a/service/message/manager_impl_test.go
+++ b/service/message/manager_impl_test.go
@@ -128,7 +128,7 @@ func TestManager_Create(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(context.TODO(), uid, cid, content).
+			CreateMessage(context.Background(), uid, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: uid, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
@@ -179,7 +179,7 @@ func TestManager_CreateDM(t *testing.T) {
 		cm.EXPECT().GetDMChannel(from, to).Return(&model.Channel{ID: cid}, nil).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			CreateMessage(context.TODO(), from, cid, content).
+			CreateMessage(context.Background(), from, cid, content).
 			Return(&model.Message{ID: uuid.NewV3(uuid.Nil, "m1"), UserID: from, ChannelID: cid, Text: content}, nil).
 			Times(1)
 
@@ -270,7 +270,7 @@ func TestManager_Edit(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			UpdateMessage(context.TODO(), id, newContent).
+			UpdateMessage(context.Background(), id, newContent).
 			Return(nil).
 			Times(1)
 
@@ -333,7 +333,7 @@ func TestManager_Delete(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			DeleteMessage(context.TODO(), id).
+			DeleteMessage(context.Background(), id).
 			Return(nil).
 			Times(1)
 
@@ -422,7 +422,7 @@ func TestManager_AddStamps(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			AddStampToMessage(context.TODO(), id, sid, uid, 1).
+			AddStampToMessage(context.Background(), id, sid, uid, 1).
 			Return(&model.MessageStamp{
 				MessageID: id,
 				StampID:   sid,
@@ -536,7 +536,7 @@ func TestManager_RemoveStamps(t *testing.T) {
 		tree.EXPECT().IsArchivedChannel(cid).Return(false).Times(1)
 		repo.MockMessageRepository.
 			EXPECT().
-			RemoveStampFromMessage(context.TODO(), id, sid, uid).
+			RemoveStampFromMessage(context.Background(), id, sid, uid).
 			Return(nil).
 			Times(1)
 

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -129,7 +129,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	}
 
 	if len(parsed.Attachments) > 0 {
-		if f, _ := ns.fm.Get(parsed.Attachments[0]); f != nil {
+		if f, _ := ns.fm.Get(context.Background(), parsed.Attachments[0]); f != nil {
 			if ok, _ := f.GetThumbnail(model.ThumbnailTypeImage); ok {
 				fcmPayload.Image = optional.From(fmt.Sprintf("%s/api/v3/files/%s/thumbnail", ns.origin, f.GetID()))
 			}

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -728,7 +728,7 @@ func channelViewerMulticast(ns *Service, cid uuid.UUID, wsEventType string, wsPa
 }
 
 func messageViewerMulticast(ns *Service, mid uuid.UUID, wsEventType string, wsPayload interface{}) {
-	m, err := ns.mm.Get(mid)
+	m, err := ns.mm.Get(context.Background(), mid)
 	if err != nil {
 		ns.logger.Error("failed to GetMessageByID", zap.Error(err), zap.Stringer("messageId", mid)) // 失敗
 		return

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -80,7 +80,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	parsed := ev.Fields["parse_result"].(*message.ParseResult)
 	logger := ns.logger.With(zap.Stringer("messageId", m.ID))
 
-	chTree := ns.cm.PublicChannelTree()
+	chTree := ns.cm.PublicChannelTree(context.Background())
 	chID := m.ChannelID
 	isDM := !chTree.IsChannelPresent(chID)
 	forceNotify := chTree.IsForceChannel(chID)
@@ -290,7 +290,7 @@ func messageUpdatedHandler(ns *Service, ev hub.Message) {
 	}
 
 	var targetFunc ws.TargetFunc
-	if ns.cm.IsPublicChannel(cid) {
+	if ns.cm.IsPublicChannel(context.Background(), cid) {
 		// 公開チャンネル
 		targetFunc = ws.Or(
 			ws.TargetChannelViewers(cid),
@@ -312,7 +312,7 @@ func messageDeletedHandler(ns *Service, ev hub.Message) {
 	}
 
 	var targetFunc ws.TargetFunc
-	if ns.cm.IsPublicChannel(cid) {
+	if ns.cm.IsPublicChannel(context.Background(), cid) {
 		// 公開チャンネル
 		targetFunc = ws.Or(
 			ws.TargetChannelViewers(cid),
@@ -692,7 +692,7 @@ func channelHandler(ns *Service, ev hub.Message, eventType string) {
 	cid := ev.Fields["channel_id"].(uuid.UUID)
 	private := ev.Fields["private"].(bool)
 	if private {
-		members, err := ns.cm.GetDMChannelMembers(cid)
+		members, err := ns.cm.GetDMChannelMembers(context.Background(), cid)
 		if err != nil {
 			ns.logger.Error("failed to GetDMChannelMembers", zap.Error(err), zap.Stringer("channelId", cid))
 			return

--- a/service/notification/handlers.go
+++ b/service/notification/handlers.go
@@ -86,7 +86,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	forceNotify := chTree.IsForceChannel(chID)
 
 	// 投稿ユーザー情報を取得
-	mUser, err := ns.repo.GetUser(context.TODO(), m.UserID, false)
+	mUser, err := ns.repo.GetUser(context.Background(), m.UserID, false)
 	if err != nil {
 		logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", m.UserID)) // 失敗
 		return
@@ -140,7 +140,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	q := repository.UsersQuery{}.Active().NotBot()
 	switch {
 	case forceNotify: // 強制通知チャンネル
-		users, err := ns.repo.GetUserIDs(context.TODO(), q)
+		users, err := ns.repo.GetUserIDs(context.Background(), q)
 		if err != nil {
 			logger.Error("failed to GetUsers", zap.Error(err)) // 失敗
 			return
@@ -150,7 +150,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		noticeable.Add(users...)
 
 	case isDM: // DM
-		users, err := ns.repo.GetUserIDs(context.TODO(), q.CMemberOf(chID))
+		users, err := ns.repo.GetUserIDs(context.Background(), q.CMemberOf(chID))
 		if err != nil {
 			logger.Error("failed to GetPrivateChannelMemberIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -161,7 +161,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 
 	default: // 通常チャンネルメッセージ
 		// チャンネル通知購読者取得
-		notify, err := ns.repo.GetUserIDs(context.TODO(), q.SubscriberAtNotifyLevelOf(chID))
+		notify, err := ns.repo.GetUserIDs(context.Background(), q.SubscriberAtNotifyLevelOf(chID))
 		if err != nil {
 			logger.Error("failed to GetUserIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -169,7 +169,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		notifiedUsers.Add(notify...)
 
 		// チャンネル未読管理購読者取得
-		mark, err := ns.repo.GetUserIDs(context.TODO(), q.SubscriberAtMarkLevelOf(chID))
+		mark, err := ns.repo.GetUserIDs(context.Background(), q.SubscriberAtMarkLevelOf(chID))
 		if err != nil {
 			logger.Error("failed to GetUserIDs", zap.Error(err), zap.Stringer("channelId", m.ChannelID)) // 失敗
 			return
@@ -178,7 +178,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 
 		// ユーザーグループ・メンションユーザー取得
 		for _, uid := range parsed.Mentions {
-			user, err := ns.repo.GetUser(context.TODO(), uid, false)
+			user, err := ns.repo.GetUser(context.Background(), uid, false)
 			if err != nil {
 				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue
@@ -193,7 +193,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 			noticeable.Add(uid)
 		}
 		for _, gid := range parsed.GroupMentions {
-			gs, err := ns.repo.GetUserIDs(context.TODO(), q.GMemberOf(gid))
+			gs, err := ns.repo.GetUserIDs(context.Background(), q.GMemberOf(gid))
 			if err != nil {
 				logger.Error("failed to GetUserGroupMemberIDs", zap.Error(err), zap.Stringer("groupId", gid)) // 失敗
 				return
@@ -204,14 +204,14 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 		}
 		// メッセージを引用されたユーザーへの通知
 		for _, mid := range parsed.Citation {
-			m, err := ns.repo.GetMessageByID(context.TODO(), mid)
+			m, err := ns.repo.GetMessageByID(context.Background(), mid)
 			if err != nil {
 				logger.Error("failed to GetMessageByID", zap.Error(err), zap.Stringer("citedMessageId", mid)) // 失敗
 				continue
 			}
 			uid := m.UserID
 
-			user, err := ns.repo.GetUser(context.TODO(), uid, false)
+			user, err := ns.repo.GetUser(context.Background(), uid, false)
 			if err != nil {
 				logger.Error("failed to GetUser", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue
@@ -221,7 +221,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 				continue
 			}
 
-			us, err := ns.repo.GetNotifyCitation(context.TODO(), uid)
+			us, err := ns.repo.GetNotifyCitation(context.Background(), uid)
 			if err != nil {
 				logger.Error("failed to GetNotifyCitation", zap.Error(err), zap.Stringer("userId", uid)) // 失敗
 				continue
@@ -253,7 +253,7 @@ func messageCreatedHandler(ns *Service, ev hub.Message) {
 	for uid := range markedUsers {
 		userNoticeableMap[uid] = noticeable.Contains(uid)
 	}
-	if err := ns.repo.SetMessageUnreads(context.TODO(), userNoticeableMap, m.ID); err != nil {
+	if err := ns.repo.SetMessageUnreads(context.Background(), userNoticeableMap, m.ID); err != nil {
 		logger.Error("failed to SetMessageUnreads", zap.Error(err), zap.Stringer("message_id", m.ID)) // 失敗
 	}
 

--- a/service/ogp/service.go
+++ b/service/ogp/service.go
@@ -1,6 +1,7 @@
 package ogp
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -21,8 +22,8 @@ type Service interface {
 	// 情報が存在する場合としない場合両方において expiresAt までキャッシュが可能です。
 	//
 	// 内部エラーが発生した場合、nil, 0, err を返します。
-	GetMeta(url *url.URL) (ogp *model.Ogp, expiresAt time.Time, err error)
+	GetMeta(ctx context.Context, url *url.URL) (ogp *model.Ogp, expiresAt time.Time, err error)
 
 	// DeleteCache 指定したURLのキャッシュを削除します。
-	DeleteCache(url *url.URL) error
+	DeleteCache(ctx context.Context, url *url.URL) error
 }

--- a/service/ogp/service_impl.go
+++ b/service/ogp/service_impl.go
@@ -64,7 +64,7 @@ func (s *ServiceImpl) start() error {
 				if !ok {
 					return
 				}
-				if err := s.repo.DeleteStaleOgpCache(context.TODO()); err != nil {
+				if err := s.repo.DeleteStaleOgpCache(context.Background()); err != nil {
 					s.logger.Error("an error occurred while deleting stale ogp caches", zap.Error(err))
 				}
 			case <-s.serviceDone:
@@ -84,8 +84,8 @@ func (s *ServiceImpl) Shutdown() error {
 	return nil
 }
 
-func (s *ServiceImpl) GetMeta(url *url.URL) (ogp *model.Ogp, expiresAt time.Time, err error) {
-	res, err := s.inMemCache.Get(context.Background(), url.String())
+func (s *ServiceImpl) GetMeta(ctx context.Context, url *url.URL) (ogp *model.Ogp, expiresAt time.Time, err error) {
+	res, err := s.inMemCache.Get(ctx, url.String())
 	if err != nil {
 		return nil, time.Time{}, err
 	}
@@ -93,8 +93,8 @@ func (s *ServiceImpl) GetMeta(url *url.URL) (ogp *model.Ogp, expiresAt time.Time
 }
 
 // getMetaOrCreate OGP情報をDBのキャッシュから取得し、存在しなかった場合はリクエストを飛ばし新たに作成します。
-func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fetchResult, err error) {
-	cache, err := s.repo.GetOgpCache(context.TODO(), urlStr)
+func (s *ServiceImpl) getMetaOrCreate(ctx context.Context, urlStr string) (res fetchResult, err error) {
+	cache, err := s.repo.GetOgpCache(ctx, urlStr)
 	if err != nil && err != repository.ErrNotFound {
 		return fetchResult{}, err
 	}
@@ -112,7 +112,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 		return fetchResult{nil, cache.ExpiresAt}, nil
 	}
 	if isCacheExpired {
-		if err := s.repo.DeleteOgpCache(context.TODO(), urlStr); err != nil && err != repository.ErrNotFound {
+		if err := s.repo.DeleteOgpCache(ctx, urlStr); err != nil && err != repository.ErrNotFound {
 			return fetchResult{}, err
 		}
 	}
@@ -128,7 +128,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 		switch err {
 		case parser.ErrClient, parser.ErrParse, parser.ErrNetwork, parser.ErrContentTypeNotSupported:
 			// 4xxエラー、パースエラー、名前解決などのネットワークエラーの場合はネガティブキャッシュを作成
-			cache, createErr := s.repo.CreateOgpCache(context.TODO(), urlStr, nil, DefaultCacheDuration)
+			cache, createErr := s.repo.CreateOgpCache(ctx, urlStr, nil, DefaultCacheDuration)
 			if createErr != nil {
 				return fetchResult{}, createErr
 			}
@@ -141,7 +141,7 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 
 	// リクエストが成功した場合はキャッシュを作成
 	content := parser.MergeDefaultPageMetaAndOpenGraph(og, meta)
-	cache, err = s.repo.CreateOgpCache(context.TODO(), urlStr, content, DefaultCacheDuration)
+	cache, err = s.repo.CreateOgpCache(ctx, urlStr, content, DefaultCacheDuration)
 	if err != nil {
 		return fetchResult{}, err
 	}
@@ -149,8 +149,8 @@ func (s *ServiceImpl) getMetaOrCreate(_ context.Context, urlStr string) (res fet
 	return fetchResult{content, cache.ExpiresAt}, nil
 }
 
-func (s *ServiceImpl) DeleteCache(url *url.URL) error {
-	err := s.repo.DeleteOgpCache(context.TODO(), url.String())
+func (s *ServiceImpl) DeleteCache(ctx context.Context, url *url.URL) error {
+	err := s.repo.DeleteOgpCache(ctx, url.String())
 	// キャッシュが見つからなかった場合でも、削除されてはいるので正常とみなす
 	if err != nil && err != repository.ErrNotFound {
 		return err

--- a/service/oidc/userinfo.go
+++ b/service/oidc/userinfo.go
@@ -33,16 +33,16 @@ type ScopeChecker interface {
 	Contains(scope model.AccessScope) bool
 }
 
-func (s *Service) GetUserInfo(userID uuid.UUID, scopes ScopeChecker) (map[string]any, error) {
-	user, err := s.repo.GetUser(context.TODO(), userID, true)
+func (s *Service) GetUserInfo(ctx context.Context, userID uuid.UUID, scopes ScopeChecker) (map[string]any, error) {
+	user, err := s.repo.GetUser(ctx, userID, true)
 	if err != nil {
 		return nil, err
 	}
-	tags, err := s.repo.GetUserTagsByUserID(context.TODO(), user.GetID())
+	tags, err := s.repo.GetUserTagsByUserID(ctx, user.GetID())
 	if err != nil {
 		return nil, err
 	}
-	groups, err := s.repo.GetUserBelongingGroupIDs(context.TODO(), user.GetID())
+	groups, err := s.repo.GetUserBelongingGroupIDs(ctx, user.GetID())
 	if err != nil {
 		return nil, err
 	}

--- a/service/qall/soundboard.go
+++ b/service/qall/soundboard.go
@@ -1,6 +1,7 @@
 package qall
 
 import (
+	"context"
 	"io"
 
 	"github.com/gofrs/uuid"
@@ -11,7 +12,7 @@ type Soundboard interface {
 	// SaveSoundboardItem サウンドボードアイテムを保存します
 	// 成功した場合、nilを返します
 	// イベント通知機能が実装されている場合、アイテム作成時にQallSoundboardItemCreatedイベントが発行されます
-	SaveSoundboardItem(soundID uuid.UUID, soundName string, contentType string, fileType model.FileType, src io.Reader, stampID *uuid.UUID, creatorID uuid.UUID) error
+	SaveSoundboardItem(ctx context.Context, soundID uuid.UUID, soundName string, contentType string, fileType model.FileType, src io.Reader, stampID *uuid.UUID, creatorID uuid.UUID) error
 	// GetURL Pre-signed URLを取得します
 	// 有効期限は5分です
 	// 成功した場合、URLとnilを返します
@@ -19,5 +20,5 @@ type Soundboard interface {
 	// DeleteSoundboardItem サウンドボードアイテムを削除します
 	// 成功した場合、nilを返します
 	// イベント通知機能が実装されている場合、アイテム削除時にQallSoundboardItemDeletedイベントが発行されます
-	DeleteSoundboardItem(soundID uuid.UUID) error
+	DeleteSoundboardItem(ctx context.Context, soundID uuid.UUID) error
 }

--- a/service/qall/soundboard_impl.go
+++ b/service/qall/soundboard_impl.go
@@ -35,7 +35,7 @@ func NewSoundboardManager(repo repository.SoundboardRepository, fs storage.FileS
 	}, nil
 }
 
-func (m *soundboardManager) SaveSoundboardItem(soundID uuid.UUID, soundName string, contentType string, fileType model.FileType, src io.Reader, stampID *uuid.UUID, creatorID uuid.UUID) error {
+func (m *soundboardManager) SaveSoundboardItem(ctx context.Context, soundID uuid.UUID, soundName string, contentType string, fileType model.FileType, src io.Reader, stampID *uuid.UUID, creatorID uuid.UUID) error {
 	// ファイルを全読み込み
 	b, err := io.ReadAll(src)
 	if err != nil {
@@ -65,7 +65,7 @@ func (m *soundboardManager) SaveSoundboardItem(soundID uuid.UUID, soundName stri
 		CreatorID: creatorID,
 	}
 
-	err = m.repo.CreateSoundboardItem(context.TODO(), args)
+	err = m.repo.CreateSoundboardItem(ctx, args)
 	if err != nil {
 		return err
 	}
@@ -89,14 +89,14 @@ func (m *soundboardManager) GetURL(soundID uuid.UUID) (string, error) {
 	return m.fs.GenerateAccessURL(soundID.String(), model.FileTypeSoundboardItem)
 }
 
-func (m *soundboardManager) DeleteSoundboardItem(soundID uuid.UUID) error {
+func (m *soundboardManager) DeleteSoundboardItem(ctx context.Context, soundID uuid.UUID) error {
 	err := m.fs.DeleteByKey(soundID.String(), model.FileTypeSoundboardItem)
 	if err != nil {
 		m.l.Error("failed to delete soundboard item", zap.Error(err))
 		return err
 	}
 
-	err = m.repo.DeleteSoundboardItem(context.TODO(), soundID)
+	err = m.repo.DeleteSoundboardItem(ctx, soundID)
 	if err != nil {
 		return err
 	}

--- a/service/qall/soundboard_test.go
+++ b/service/qall/soundboard_test.go
@@ -1,6 +1,7 @@
 package qall
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -94,7 +95,7 @@ func TestSoundboardManager_DeleteSoundboardItem(t *testing.T) {
 			Times(1)
 
 		// テスト実行
-		err := manager.DeleteSoundboardItem(soundID)
+		err := manager.DeleteSoundboardItem(context.TODO(), soundID)
 		assert.NoError(t, err)
 	})
 
@@ -117,7 +118,7 @@ func TestSoundboardManager_DeleteSoundboardItem(t *testing.T) {
 			Times(1)
 
 		// テスト実行
-		err := manager.DeleteSoundboardItem(soundID)
+		err := manager.DeleteSoundboardItem(context.TODO(), soundID)
 		assert.Error(t, err)
 		assert.Equal(t, mockErr, err)
 	})
@@ -136,7 +137,7 @@ func TestSoundboardManager_DeleteSoundboardItem(t *testing.T) {
 			Times(1)
 
 		// テスト実行
-		err := manager.DeleteSoundboardItem(soundID)
+		err := manager.DeleteSoundboardItem(context.TODO(), soundID)
 		assert.Error(t, err)
 		assert.Equal(t, mockErr, err)
 	})

--- a/service/rbac/rbac_impl.go
+++ b/service/rbac/rbac_impl.go
@@ -69,7 +69,7 @@ func (r *rbacImpl) Reload() error {
 }
 
 func (r *rbacImpl) reload() error {
-	rs, err := r.repo.GetAllUserRoles(context.TODO())
+	rs, err := r.repo.GetAllUserRoles(context.Background())
 	if err != nil {
 		return err
 	}

--- a/service/search/es_result.go
+++ b/service/search/es_result.go
@@ -1,6 +1,8 @@
 package search
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/samber/lo"
 
@@ -55,7 +57,7 @@ func (e *esEngine) parseResultFromResponse(searchRes esSearchResponse) (Result, 
 		return uuid.Must(uuid.FromString(hit.ID))
 	})
 
-	messages, err := e.mm.GetIn(messageIDs)
+	messages, err := e.mm.GetIn(context.Background(), messageIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -41,7 +41,7 @@ func (e *esEngine) convertMessageCreated(m *model.Message, parseResult *message.
 	var isBot, ok bool
 	if isBot, ok = userCache[m.UserID]; !ok {
 		// 新規ユーザー or キャッシュが存在しない
-		user, err := e.repo.GetUser(context.TODO(), m.UserID, false)
+		user, err := e.repo.GetUser(context.Background(), m.UserID, false)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +93,7 @@ func (e *esEngine) getAttributes(m *model.Message, parseResult *message.ParseRes
 	attr.HasAttachments = len(parseResult.Attachments) != 0
 
 	for _, attachmentID := range parseResult.Attachments {
-		meta, err := e.repo.GetFileMeta(context.TODO(), attachmentID)
+		meta, err := e.repo.GetFileMeta(context.Background(), attachmentID)
 		if err != nil {
 			e.l.Warn(err.Error(), zap.Error(err))
 			continue
@@ -129,7 +129,7 @@ loop:
 }
 
 func (e *esEngine) newUserCache() (userCache, error) {
-	users, err := e.repo.GetUsers(context.TODO(), repository.UsersQuery{})
+	users, err := e.repo.GetUsers(context.Background(), repository.UsersQuery{})
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (e *esEngine) sync() error {
 	var userCache userCache
 	lastInsert := lastSynced
 	for {
-		messages, more, err := e.repo.GetUpdatedMessagesAfter(context.TODO(), lastInsert, syncMessageBulk)
+		messages, more, err := e.repo.GetUpdatedMessagesAfter(context.Background(), lastInsert, syncMessageBulk)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func (e *esEngine) sync() error {
 
 	lastDelete := lastSynced
 	for {
-		messages, more, err := e.repo.GetDeletedMessagesAfter(context.TODO(), lastDelete, syncMessageBulk)
+		messages, more, err := e.repo.GetDeletedMessagesAfter(context.Background(), lastDelete, syncMessageBulk)
 		if err != nil {
 			return err
 		}

--- a/service/search/es_sync.go
+++ b/service/search/es_sync.go
@@ -53,7 +53,7 @@ func (e *esEngine) convertMessageCreated(m *model.Message, parseResult *message.
 	return &esMessageDoc{
 		UserID:         m.UserID,
 		ChannelID:      m.ChannelID,
-		IsPublic:       e.cm.IsPublicChannel(m.ChannelID),
+		IsPublic:       e.cm.IsPublicChannel(context.Background(), m.ChannelID),
 		Bot:            isBot,
 		Text:           m.Text,
 		CreatedAt:      m.CreatedAt,

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -92,7 +92,7 @@ func NewTestRepository() *TestRepository {
 		Webhooks:              map[uuid.UUID]model.WebhookBot{},
 		OgpCache:              map[int]model.OgpCache{},
 	}
-	_, _ = r.CreateUser(context.TODO(), repository.CreateUserArgs{Name: "traq", Password: "traq", Role: role.Admin})
+	_, _ = r.CreateUser(context.Background(), repository.CreateUserArgs{Name: "traq", Password: "traq", Role: role.Admin})
 	return r
 }
 

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -123,7 +123,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 			name = replacedName
 		}
 
-		s, err := repo.GetStampByName(context.TODO(), name)
+		s, err := repo.GetStampByName(context.Background(), name)
 		if err != nil && err != repository.ErrNotFound {
 			return err
 		}
@@ -135,7 +135,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 				return err
 			}
 
-			s, err := repo.CreateStamp(context.TODO(), repository.CreateStampArgs{
+			s, err := repo.CreateStamp(context.Background(), repository.CreateStampArgs{
 				Name:      name,
 				FileID:    meta.GetID(),
 				CreatorID: uuid.Nil,
@@ -157,7 +157,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 				return err
 			}
 
-			if err := repo.UpdateStamp(context.TODO(), s.ID, repository.UpdateStampArgs{
+			if err := repo.UpdateStamp(context.Background(), s.ID, repository.UpdateStampArgs{
 				FileID: optional.From(meta.GetID()),
 			}); err != nil {
 				return err

--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -90,7 +90,7 @@ func Install(repo repository.Repository, fm file.Manager, logger *zap.Logger, up
 		}
 		defer r.Close()
 
-		return fm.Save(file.SaveArgs{
+		return fm.Save(context.Background(), file.SaveArgs{
 			FileName: filename,
 			FileSize: f.FileInfo().Size(),
 			FileType: model.FileTypeStamp,


### PR DESCRIPTION
#2932 の続きです。`context.TODO`を適切なctxに置き換えました。
testについては`context.TODO`のままです。`t.Context`を使うか、`context.Background`にするかなどは相談したいです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced request lifecycle management throughout the application by updating core operations to properly propagate context across file handling, channel management, messaging, authentication, and user management systems. This improves the system's ability to handle request timeouts and cancellations consistently across all services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->