### PR TITLE
fix: `/channels/:id/path` のレスポンスの `pattern` が誤っているのを修正

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -7821,11 +7821,11 @@ components:
         path:
           type: string
           description: チャンネルパス
-          pattern: '^(\/[a-zA-Z0-9-_]+)+$'
+          pattern: '^[a-zA-Z0-9-_]+(\/[a-zA-Z0-9-_]+)*$'
       required:
         - path
       example:
-        path: "/general"
+        path: "general/sub-channel"
     Session:
       type: object
       properties:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * チャネルパスの形式を更新しました。先頭のスラッシュが不要になり、より柔軟な指定が可能になります。例えば、`general/sub-channel` のようなパス形式に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->