### PR TITLE
session store周りでcontextを伝播させるように

### DIFF
--- a/router/auth/provider.go
+++ b/router/auth/provider.go
@@ -65,7 +65,7 @@ func defaultLoginHandler(sessStore session.Store, oac *oauth2.Config) echo.Handl
 			if sess == nil || sess.UserID() == uuid.Nil {
 				return herror.Unauthorized("You are not logged in. Please login.")
 			}
-			if err := sess.Set(accountLinkingFlag, true); err != nil {
+			if err := sess.Set(c.Request().Context(), accountLinkingFlag, true); err != nil {
 				return herror.InternalServerError(err)
 			}
 		} else {
@@ -90,6 +90,8 @@ func defaultLoginHandler(sessStore session.Store, oac *oauth2.Config) echo.Handl
 
 func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repository, fm file.Manager, sessStore session.Store, allowSignUp bool) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		ctx := c.Request().Context()
+
 		if len(c.Request().Header.Get(echo.HeaderAuthorization)) > 0 {
 			return herror.BadRequest("Authorization Header must not be set.")
 		}
@@ -127,11 +129,11 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 			return herror.InternalServerError(err)
 		}
 		if sess != nil {
-			if v, err := sess.Get(accountLinkingFlag); err != nil {
+			if v, err := sess.Get(ctx, accountLinkingFlag); err != nil {
 				return herror.InternalServerError(err)
 			} else if v == true {
 				// アカウント関連付けモード
-				if err := sess.Delete(accountLinkingFlag); err != nil {
+				if err := sess.Delete(ctx, accountLinkingFlag); err != nil {
 					return herror.InternalServerError(err)
 				}
 				if sess.UserID() == uuid.Nil {
@@ -139,7 +141,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// ユーザーアカウント状態を確認
-				user, err := repo.GetUser(c.Request().Context(), sess.UserID(), false)
+				user, err := repo.GetUser(ctx, sess.UserID(), false)
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
@@ -148,7 +150,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 
 				// アカウントにリンク
-				if err := repo.LinkExternalUserAccount(c.Request().Context(), user.GetID(), repository.LinkExternalUserAccountArgs{
+				if err := repo.LinkExternalUserAccount(ctx, user.GetID(), repository.LinkExternalUserAccountArgs{
 					ProviderName: tu.GetProviderName(),
 					ExternalID:   tu.GetID(),
 					Extra:        model.JSON{"externalName": tu.GetRawName()},
@@ -178,7 +180,7 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 			return herror.BadRequest("You have already logged in. Please logout once.")
 		}
 
-		user, err := repo.GetUserByExternalID(c.Request().Context(), tu.GetProviderName(), tu.GetID(), false)
+		user, err := repo.GetUserByExternalID(ctx, tu.GetProviderName(), tu.GetID(), false)
 		if err != nil {
 			if err != repository.ErrNotFound {
 				return herror.InternalServerError(err)
@@ -209,14 +211,14 @@ func defaultCallbackHandler(p Provider, oac *oauth2.Config, repo repository.Repo
 				}
 			}
 			if args.IconFileID == uuid.Nil {
-				fid, err := file.GenerateIconFile(c.Request().Context(), fm, tu.GetName())
+				fid, err := file.GenerateIconFile(ctx, fm, tu.GetName())
 				if err != nil {
 					return herror.InternalServerError(err)
 				}
 				args.IconFileID = fid
 			}
 
-			user, err = repo.CreateUser(c.Request().Context(), args)
+			user, err = repo.CreateUser(ctx, args)
 			if err != nil {
 				if err == repository.ErrAlreadyExists {
 					return herror.Conflict("name conflicts") // TODO 名前被りをどうするか

--- a/router/oauth2/authorization_endpoint.go
+++ b/router/oauth2/authorization_endpoint.go
@@ -69,6 +69,8 @@ func (t responseType) valid() bool {
 
 // AuthorizationEndpointHandler 認可エンドポイントのハンドラ
 func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
 	c.Response().Header().Set("Cache-Control", "no-store")
 	c.Response().Header().Set("Pragma", "no-cache")
 
@@ -79,7 +81,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 	req.AccessTime = time.Now()
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(c.Request().Context(), req.ClientID)
+	client, err := h.Repo.GetClient(ctx, req.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:
@@ -168,7 +170,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 		return c.Redirect(http.StatusFound, redirectURI.String())
 	}
 	if se != nil {
-		u, err := h.Repo.GetUser(c.Request().Context(), se.UserID(), false)
+		u, err := h.Repo.GetUser(ctx, se.UserID(), false)
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
@@ -193,7 +195,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			redirectURI.RawQuery = q.Encode()
 			return c.Redirect(http.StatusFound, redirectURI.String())
 		}
-		tokens, err := h.Repo.GetTokensByUser(c.Request().Context(), se.UserID())
+		tokens, err := h.Repo.GetTokensByUser(ctx, se.UserID())
 		if err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
@@ -235,7 +237,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			CodeChallengeMethod: req.CodeChallengeMethod,
 			Nonce:               req.Nonce,
 		}
-		if err := h.Repo.SaveAuthorize(c.Request().Context(), data); err != nil {
+		if err := h.Repo.SaveAuthorize(ctx, data); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()
@@ -268,7 +270,7 @@ func (h *Handler) AuthorizationEndpointHandler(c echo.Context) error {
 			return c.Redirect(http.StatusFound, loginURL.String())
 		}
 
-		if err := se.Set(oauth2ContextSession, req); err != nil {
+		if err := se.Set(ctx, oauth2ContextSession, req); err != nil {
 			h.L(c).Error(err.Error(), zap.Error(err))
 			q.Set("error", errServerError)
 			redirectURI.RawQuery = q.Encode()
@@ -297,6 +299,8 @@ func (r authorizationDecideHandlerRequest) Validate() error {
 
 // AuthorizationDecideHandler 認可エンドポイントの確認フォームのハンドラ
 func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
 	c.Response().Header().Set("Cache-Control", "no-store")
 	c.Response().Header().Set("Pragma", "no-cache")
 
@@ -314,7 +318,7 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 		return herror.Forbidden("bad session")
 	}
 
-	_reqAuth, err := se.Get(oauth2ContextSession)
+	_reqAuth, err := se.Get(ctx, oauth2ContextSession)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -322,12 +326,12 @@ func (h *Handler) AuthorizationDecideHandler(c echo.Context) error {
 		return herror.Forbidden("bad session")
 	}
 	reqAuth := _reqAuth.(authorizeRequest)
-	if err := se.Delete(oauth2ContextSession); err != nil {
+	if err := se.Delete(ctx, oauth2ContextSession); err != nil {
 		return herror.InternalServerError(err)
 	}
 
 	// クライアント確認
-	client, err := h.Repo.GetClient(c.Request().Context(), reqAuth.ClientID)
+	client, err := h.Repo.GetClient(ctx, reqAuth.ClientID)
 	if err != nil {
 		switch err {
 		case repository.ErrNotFound:

--- a/router/oauth2/authorization_endpoint_test.go
+++ b/router/oauth2/authorization_endpoint_test.go
@@ -137,7 +137,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 			assert.Equal("read", loc.Query().Get("scopes"))
 		}
 
-		se, err := env.SessStore.GetSessionByToken(s)
+		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
 			v, err := se.Get(oauth2ContextSession)
 			assert.NoError(err)
@@ -171,7 +171,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 			assert.Equal("read", loc.Query().Get("scopes"))
 		}
 
-		se, err := env.SessStore.GetSessionByToken(s)
+		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
 			v, err := se.Get(oauth2ContextSession)
 			assert.NoError(err)
@@ -207,7 +207,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 			assert.Equal("read", loc.Query().Get("scopes"))
 		}
 
-		se, err := env.SessStore.GetSessionByToken(s)
+		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
 			v, err := se.Get(oauth2ContextSession)
 			assert.NoError(err)
@@ -597,7 +597,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 	require.NoError(t, env.Repository.SaveClient(context.TODO(), client))
 
 	MakeDecideSession := func(t *testing.T, uid uuid.UUID, client *model.OAuth2Client) string {
-		s, err := env.SessStore.IssueSession(uid, map[string]interface{}{
+		s, err := env.SessStore.IssueSession(context.TODO(), uid, map[string]interface{}{
 			oauth2ContextSession: authorizeRequest{
 				ResponseType: "code",
 				ClientID:     client.ID,
@@ -729,7 +729,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 	t.Run("Found (unsupported response type)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		s, err := env.SessStore.IssueSession(user.GetID(), map[string]interface{}{
+		s, err := env.SessStore.IssueSession(context.TODO(), user.GetID(), map[string]interface{}{
 			oauth2ContextSession: authorizeRequest{
 				ResponseType: "code",
 				ClientID:     client.ID,
@@ -760,7 +760,7 @@ func runAuthorizationDecideHandlerTests(t *testing.T, useUUIDV4 bool) {
 	t.Run("Found (timeout)", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		s, err := env.SessStore.IssueSession(user.GetID(), map[string]interface{}{
+		s, err := env.SessStore.IssueSession(context.TODO(), user.GetID(), map[string]interface{}{
 			oauth2ContextSession: authorizeRequest{
 				ResponseType: "code",
 				ClientID:     client.ID,

--- a/router/oauth2/authorization_endpoint_test.go
+++ b/router/oauth2/authorization_endpoint_test.go
@@ -139,7 +139,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 
 		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
-			v, err := se.Get(oauth2ContextSession)
+			v, err := se.Get(context.TODO(), oauth2ContextSession)
 			assert.NoError(err)
 			assert.Equal("state", v.(authorizeRequest).State)
 		}
@@ -173,7 +173,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 
 		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
-			v, err := se.Get(oauth2ContextSession)
+			v, err := se.Get(context.TODO(), oauth2ContextSession)
 			assert.NoError(err)
 			assert.Equal("state", v.(authorizeRequest).State)
 		}
@@ -209,7 +209,7 @@ func runAuthorizationEndpointTests(t *testing.T, useUUIDV4 bool) {
 
 		se, err := env.SessStore.GetSessionByToken(context.TODO(), s)
 		if assert.NoError(err) {
-			v, err := se.Get(oauth2ContextSession)
+			v, err := se.Get(context.TODO(), oauth2ContextSession)
 			assert.NoError(err)
 			assert.Equal("state", v.(authorizeRequest).State)
 			assert.Equal("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", v.(authorizeRequest).CodeChallenge)

--- a/router/oauth2/oauth2_test.go
+++ b/router/oauth2/oauth2_test.go
@@ -158,7 +158,7 @@ func Setup(t *testing.T, server string) *Env {
 // S 指定ユーザーのAPIセッショントークンを発行
 func (env *Env) S(t *testing.T, userID uuid.UUID) string {
 	t.Helper()
-	s, err := env.SessStore.IssueSession(userID, nil)
+	s, err := env.SessStore.IssueSession(context.TODO(), userID, nil)
 	require.NoError(t, err)
 	return s.Token()
 }

--- a/router/session/gorm.go
+++ b/router/session/gorm.go
@@ -63,25 +63,25 @@ func (s *session) LoggedIn() bool {
 	return s.userID != uuid.Nil
 }
 
-func (s *session) Get(key string) (interface{}, error) {
+func (s *session) Get(_ context.Context, key string) (interface{}, error) {
 	s.Lock()
 	defer s.Unlock()
 	v := s.data[key]
 	return v, nil
 }
 
-func (s *session) Set(key string, value interface{}) error {
+func (s *session) Set(ctx context.Context, key string, value interface{}) error {
 	s.Lock()
 	defer s.Unlock()
 	s.data[key] = value
-	return s.save()
+	return s.save(ctx)
 }
 
-func (s *session) Delete(key string) error {
+func (s *session) Delete(ctx context.Context, key string) error {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.data, key)
-	return s.save()
+	return s.save(ctx)
 }
 
 func (s *session) Expired() bool {
@@ -92,12 +92,12 @@ func (s *session) Refreshable() bool {
 	return time.Since(s.createdAt) <= time.Duration(sessionMaxAge+sessionKeepAge)*time.Second
 }
 
-func (s *session) save() error {
+func (s *session) save(ctx context.Context) error {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(s.data); err != nil {
 		panic(err) // gobにdataの中身の構造体が登録されていない
 	}
-	return s.db.Model(&model.SessionRecord{Token: s.t}).Update("data", buf.Bytes()).Error
+	return s.db.WithContext(ctx).Model(&model.SessionRecord{Token: s.t}).Update("data", buf.Bytes()).Error
 }
 
 type sessionStore struct {

--- a/router/session/gorm.go
+++ b/router/session/gorm.go
@@ -120,7 +120,7 @@ func (ss *sessionStore) GetSession(c echo.Context) (Session, error) {
 
 	var s Session
 	if len(token) > 0 {
-		s, err = ss.GetSessionByToken(token)
+		s, err = ss.GetSessionByToken(c.Request().Context(), token)
 		if err != nil && err != ErrSessionNotFound {
 			return nil, err
 		}
@@ -138,16 +138,16 @@ func (ss *sessionStore) GetSession(c echo.Context) (Session, error) {
 	return nil, ss.RevokeSession(c)
 }
 
-func (ss *sessionStore) GetSessionByToken(token string) (Session, error) {
+func (ss *sessionStore) GetSessionByToken(ctx context.Context, token string) (Session, error) {
 	if len(token) == 0 {
 		return nil, ErrSessionNotFound
 	}
-	return ss.cache.Get(context.Background(), token)
+	return ss.cache.Get(ctx, token)
 }
 
-func (ss *sessionStore) getSessionByToken(_ context.Context, token string) (Session, error) {
+func (ss *sessionStore) getSessionByToken(ctx context.Context, token string) (Session, error) {
 	var r model.SessionRecord
-	err := ss.db.First(&r, &model.SessionRecord{Token: token}).Error
+	err := ss.db.WithContext(ctx).First(&r, &model.SessionRecord{Token: token}).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, ErrSessionNotFound
@@ -162,13 +162,13 @@ func (ss *sessionStore) getSessionByToken(_ context.Context, token string) (Sess
 	return newSession(ss.db, r.Token, r.ReferenceID, r.UserID, r.Created, data), nil
 }
 
-func (ss *sessionStore) GetSessionsByUserID(userID uuid.UUID) ([]Session, error) {
+func (ss *sessionStore) GetSessionsByUserID(ctx context.Context, userID uuid.UUID) ([]Session, error) {
 	if userID == uuid.Nil {
 		return []Session{}, nil
 	}
 
 	var records []*model.SessionRecord
-	if err := ss.db.Find(&records, &model.SessionRecord{UserID: userID}).Error; err != nil {
+	if err := ss.db.WithContext(ctx).Find(&records, &model.SessionRecord{UserID: userID}).Error; err != nil {
 		return nil, err
 	}
 
@@ -195,7 +195,7 @@ func (ss *sessionStore) RevokeSession(c echo.Context) error {
 		return nil
 	}
 
-	if err := ss.db.Delete(&model.SessionRecord{Token: cookie.Value}).Error; err != nil {
+	if err := ss.db.WithContext(c.Request().Context()).Delete(&model.SessionRecord{Token: cookie.Value}).Error; err != nil {
 		return err
 	}
 	ss.cache.Forget(cookie.Value)
@@ -207,19 +207,19 @@ func (ss *sessionStore) RevokeSession(c echo.Context) error {
 	return nil
 }
 
-func (ss *sessionStore) RevokeSessionByRefID(refID uuid.UUID) error {
+func (ss *sessionStore) RevokeSessionByRefID(ctx context.Context, refID uuid.UUID) error {
 	if refID == uuid.Nil {
 		return nil
 	}
 
 	var r model.SessionRecord
-	if err := ss.db.First(&r, &model.SessionRecord{ReferenceID: refID}).Error; err != nil {
+	if err := ss.db.WithContext(ctx).First(&r, &model.SessionRecord{ReferenceID: refID}).Error; err != nil {
 		if gorm.ErrRecordNotFound == err {
 			return nil
 		}
 		return err
 	}
-	if err := ss.db.Delete(&model.SessionRecord{Token: r.Token}).Error; err != nil {
+	if err := ss.db.WithContext(ctx).Delete(&model.SessionRecord{Token: r.Token}).Error; err != nil {
 		return err
 	}
 	ss.cache.Forget(r.Token)
@@ -227,16 +227,16 @@ func (ss *sessionStore) RevokeSessionByRefID(refID uuid.UUID) error {
 	return nil
 }
 
-func (ss *sessionStore) RevokeSessionsByUserID(userID uuid.UUID) error {
+func (ss *sessionStore) RevokeSessionsByUserID(ctx context.Context, userID uuid.UUID) error {
 	if userID == uuid.Nil {
 		return nil
 	}
 
 	var rs []*model.SessionRecord
-	if err := ss.db.Find(&rs, &model.SessionRecord{UserID: userID}).Error; err != nil {
+	if err := ss.db.WithContext(ctx).Find(&rs, &model.SessionRecord{UserID: userID}).Error; err != nil {
 		return err
 	}
-	if err := ss.db.Delete(&model.SessionRecord{}, "user_id = ?", userID).Error; err != nil {
+	if err := ss.db.WithContext(ctx).Delete(&model.SessionRecord{}, "user_id = ?", userID).Error; err != nil {
 		return err
 	}
 
@@ -247,9 +247,10 @@ func (ss *sessionStore) RevokeSessionsByUserID(userID uuid.UUID) error {
 }
 
 func (ss *sessionStore) RenewSession(c echo.Context, userID uuid.UUID) (Session, error) {
+	ctx := c.Request().Context()
 	cookie, _ := c.Cookie(CookieName)
 	if cookie != nil && len(cookie.Value) > 0 {
-		if err := ss.db.Delete(&model.SessionRecord{Token: cookie.Value}).Error; err != nil {
+		if err := ss.db.WithContext(ctx).Delete(&model.SessionRecord{Token: cookie.Value}).Error; err != nil {
 			return nil, err
 		}
 		ss.cache.Forget(cookie.Value)
@@ -257,7 +258,7 @@ func (ss *sessionStore) RenewSession(c echo.Context, userID uuid.UUID) (Session,
 		cookie = &http.Cookie{}
 	}
 
-	s, err := ss.IssueSession(userID, nil)
+	s, err := ss.IssueSession(ctx, userID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (ss *sessionStore) RenewSession(c echo.Context, userID uuid.UUID) (Session,
 	return s, nil
 }
 
-func (ss *sessionStore) IssueSession(userID uuid.UUID, data map[string]interface{}) (Session, error) {
+func (ss *sessionStore) IssueSession(ctx context.Context, userID uuid.UUID, data map[string]interface{}) (Session, error) {
 	if data == nil {
 		data = map[string]interface{}{}
 	}
@@ -286,7 +287,7 @@ func (ss *sessionStore) IssueSession(userID uuid.UUID, data map[string]interface
 	}
 	s.SetData(data)
 
-	if err := ss.db.Create(s).Error; err != nil {
+	if err := ss.db.WithContext(ctx).Create(s).Error; err != nil {
 		return nil, err
 	}
 	return newSession(ss.db, s.Token, s.ReferenceID, s.UserID, s.Created, data), nil

--- a/router/session/memory.go
+++ b/router/session/memory.go
@@ -51,20 +51,20 @@ func (s *memorySession) LoggedIn() bool {
 	return s.userID != uuid.Nil
 }
 
-func (s *memorySession) Get(key string) (interface{}, error) {
+func (s *memorySession) Get(_ context.Context, key string) (interface{}, error) {
 	s.Lock()
 	defer s.Unlock()
 	return s.data[key], nil
 }
 
-func (s *memorySession) Set(key string, value interface{}) error {
+func (s *memorySession) Set(_ context.Context, key string, value interface{}) error {
 	s.Lock()
 	defer s.Unlock()
 	s.data[key] = value
 	return nil
 }
 
-func (s *memorySession) Delete(key string) error {
+func (s *memorySession) Delete(_ context.Context, key string) error {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.data, key)

--- a/router/session/memory.go
+++ b/router/session/memory.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -98,7 +99,7 @@ func (ms *memoryStore) GetSession(c echo.Context) (Session, error) {
 
 	var s Session
 	if len(token) > 0 {
-		s, err = ms.GetSessionByToken(token)
+		s, err = ms.GetSessionByToken(c.Request().Context(), token)
 		if err != nil && err != ErrSessionNotFound {
 			return nil, err
 		}
@@ -116,7 +117,7 @@ func (ms *memoryStore) GetSession(c echo.Context) (Session, error) {
 	return nil, ms.RevokeSession(c)
 }
 
-func (ms *memoryStore) GetSessionByToken(token string) (Session, error) {
+func (ms *memoryStore) GetSessionByToken(_ context.Context, token string) (Session, error) {
 	if len(token) == 0 {
 		return nil, ErrSessionNotFound
 	}
@@ -130,7 +131,7 @@ func (ms *memoryStore) GetSessionByToken(token string) (Session, error) {
 	return s, nil
 }
 
-func (ms *memoryStore) GetSessionsByUserID(userID uuid.UUID) ([]Session, error) {
+func (ms *memoryStore) GetSessionsByUserID(_ context.Context, userID uuid.UUID) ([]Session, error) {
 	if userID == uuid.Nil {
 		return []Session{}, nil
 	}
@@ -166,7 +167,7 @@ func (ms *memoryStore) RevokeSession(c echo.Context) error {
 	return nil
 }
 
-func (ms *memoryStore) RevokeSessionByRefID(refID uuid.UUID) error {
+func (ms *memoryStore) RevokeSessionByRefID(_ context.Context, refID uuid.UUID) error {
 	if refID == uuid.Nil {
 		return nil
 	}
@@ -181,7 +182,7 @@ func (ms *memoryStore) RevokeSessionByRefID(refID uuid.UUID) error {
 	return nil
 }
 
-func (ms *memoryStore) RevokeSessionsByUserID(userID uuid.UUID) error {
+func (ms *memoryStore) RevokeSessionsByUserID(_ context.Context, userID uuid.UUID) error {
 	if userID == uuid.Nil {
 		return nil
 	}
@@ -196,6 +197,7 @@ func (ms *memoryStore) RevokeSessionsByUserID(userID uuid.UUID) error {
 }
 
 func (ms *memoryStore) RenewSession(c echo.Context, userID uuid.UUID) (Session, error) {
+	ctx := c.Request().Context()
 	cookie, _ := c.Cookie(CookieName)
 	if cookie != nil && len(cookie.Value) > 0 {
 		ms.Lock()
@@ -205,7 +207,7 @@ func (ms *memoryStore) RenewSession(c echo.Context, userID uuid.UUID) (Session, 
 		cookie = &http.Cookie{}
 	}
 
-	s, err := ms.IssueSession(userID, nil)
+	s, err := ms.IssueSession(ctx, userID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +223,7 @@ func (ms *memoryStore) RenewSession(c echo.Context, userID uuid.UUID) (Session, 
 	return s, nil
 }
 
-func (ms *memoryStore) IssueSession(userID uuid.UUID, data map[string]interface{}) (Session, error) {
+func (ms *memoryStore) IssueSession(_ context.Context, userID uuid.UUID, data map[string]interface{}) (Session, error) {
 	if data == nil {
 		data = map[string]interface{}{}
 	}

--- a/router/session/session.go
+++ b/router/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -35,11 +36,11 @@ type Session interface {
 
 type Store interface {
 	GetSession(c echo.Context) (Session, error)
-	GetSessionByToken(token string) (Session, error)
-	GetSessionsByUserID(userID uuid.UUID) ([]Session, error)
+	GetSessionByToken(ctx context.Context, token string) (Session, error)
+	GetSessionsByUserID(ctx context.Context, userID uuid.UUID) ([]Session, error)
 	RevokeSession(c echo.Context) error
-	RevokeSessionByRefID(refID uuid.UUID) error
-	RevokeSessionsByUserID(userID uuid.UUID) error
+	RevokeSessionByRefID(ctx context.Context, refID uuid.UUID) error
+	RevokeSessionsByUserID(ctx context.Context, userID uuid.UUID) error
 	RenewSession(c echo.Context, userID uuid.UUID) (Session, error)
-	IssueSession(userID uuid.UUID, data map[string]interface{}) (Session, error)
+	IssueSession(ctx context.Context, userID uuid.UUID, data map[string]interface{}) (Session, error)
 }

--- a/router/session/session.go
+++ b/router/session/session.go
@@ -26,9 +26,9 @@ type Session interface {
 	CreatedAt() time.Time
 	LoggedIn() bool
 
-	Get(key string) (interface{}, error)
-	Set(key string, value interface{}) error
-	Delete(key string) error
+	Get(ctx context.Context, key string) (interface{}, error)
+	Set(ctx context.Context, key string, value interface{}) error
+	Delete(ctx context.Context, key string) error
 
 	Expired() bool
 	Refreshable() bool

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -69,7 +69,9 @@ func ChangeUserPassword(c echo.Context, repo repository.Repository, seStore sess
 	}
 
 	// ユーザーの全セッションを破棄(強制ログアウト)
-	_ = seStore.RevokeSessionsByUserID(c.Request().Context(), userID)
+	if err := seStore.RevokeSessionsByUserID(c.Request().Context(), userID); err != nil {
+		return herror.InternalServerError(err)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/router/utils/common.go
+++ b/router/utils/common.go
@@ -69,7 +69,7 @@ func ChangeUserPassword(c echo.Context, repo repository.Repository, seStore sess
 	}
 
 	// ユーザーの全セッションを破棄(強制ログアウト)
-	_ = seStore.RevokeSessionsByUserID(userID)
+	_ = seStore.RevokeSessionsByUserID(c.Request().Context(), userID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/router/v1/router_test.go
+++ b/router/v1/router_test.go
@@ -127,7 +127,7 @@ func assertAndRequire(t *testing.T) (*assert.Assertions, *require.Assertions) {
 
 func (env *Env) generateSession(t *testing.T, userID uuid.UUID) string {
 	t.Helper()
-	sess, err := env.SessStore.IssueSession(userID, nil)
+	sess, err := env.SessStore.IssueSession(context.TODO(), userID, nil)
 	require.NoError(t, err)
 	return sess.Token()
 }

--- a/router/v3/router_test.go
+++ b/router/v3/router_test.go
@@ -201,7 +201,7 @@ func Setup(t *testing.T, server string) *Env {
 // S 指定ユーザーのAPIセッショントークンを発行
 func (env *Env) S(t *testing.T, userID uuid.UUID) string {
 	t.Helper()
-	s, err := env.SessStore.IssueSession(userID, nil)
+	s, err := env.SessStore.IssueSession(context.TODO(), userID, nil)
 	require.NoError(t, err)
 	return s.Token()
 }

--- a/router/v3/sessions.go
+++ b/router/v3/sessions.go
@@ -79,7 +79,7 @@ func (h *Handlers) Logout(c echo.Context) error {
 		return herror.InternalServerError(err)
 	}
 	if sess != nil && isTrue(c.QueryParam("all")) && sess.LoggedIn() {
-		if err := h.SessStore.RevokeSessionsByUserID(sess.UserID()); err != nil {
+		if err := h.SessStore.RevokeSessionsByUserID(c.Request().Context(), sess.UserID()); err != nil {
 			return herror.InternalServerError(err)
 		}
 	}
@@ -98,7 +98,7 @@ func (h *Handlers) Logout(c echo.Context) error {
 func (h *Handlers) GetMySessions(c echo.Context) error {
 	userID := getRequestUserID(c)
 
-	ses, err := h.SessStore.GetSessionsByUserID(userID)
+	ses, err := h.SessStore.GetSessionsByUserID(c.Request().Context(), userID)
 	if err != nil {
 		return herror.InternalServerError(err)
 	}
@@ -123,7 +123,7 @@ func (h *Handlers) GetMySessions(c echo.Context) error {
 func (h *Handlers) RevokeMySession(c echo.Context) error {
 	referenceID := getParamAsUUID(c, consts.ParamReferenceID)
 
-	if err := h.SessStore.RevokeSessionByRefID(referenceID); err != nil {
+	if err := h.SessStore.RevokeSessionByRefID(c.Request().Context(), referenceID); err != nil {
 		return herror.InternalServerError(err)
 	}
 

--- a/router/v3/sessions_test.go
+++ b/router/v3/sessions_test.go
@@ -235,7 +235,7 @@ func TestHandlers_Logout(t *testing.T) {
 		c.Name().IsEqual(session.CookieName)
 		c.Value().IsEmpty()
 
-		sess, err := env.SessStore.GetSessionsByUserID(user3.GetID())
+		sess, err := env.SessStore.GetSessionsByUserID(context.TODO(), user3.GetID())
 		require.NoError(t, err)
 		assert.Len(t, sess, 0)
 	})
@@ -283,10 +283,10 @@ func TestHandlers_RevokeMySession(t *testing.T) {
 	user := env.CreateUser(t, rand)
 	s := env.S(t, user.GetID())
 	s2 := env.S(t, user.GetID())
-	sess2, err := env.SessStore.GetSessionByToken(s2)
+	sess2, err := env.SessStore.GetSessionByToken(context.TODO(), s2)
 	require.NoError(t, err)
 	s3 := env.S(t, user.GetID())
-	sess3, err := env.SessStore.GetSessionByToken(s3)
+	sess3, err := env.SessStore.GetSessionByToken(context.TODO(), s3)
 	require.NoError(t, err)
 
 	t.Run("not logged in", func(t *testing.T) {
@@ -314,7 +314,7 @@ func TestHandlers_RevokeMySession(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err := env.SessStore.GetSessionByToken(s2)
+		_, err := env.SessStore.GetSessionByToken(context.TODO(), s2)
 		assert.ErrorIs(t, err, session.ErrSessionNotFound)
 
 		// already deleted
@@ -323,7 +323,7 @@ func TestHandlers_RevokeMySession(t *testing.T) {
 			Expect().
 			Status(http.StatusNoContent)
 
-		_, err = env.SessStore.GetSessionByToken(s2)
+		_, err = env.SessStore.GetSessionByToken(context.TODO(), s2)
 		assert.ErrorIs(t, err, session.ErrSessionNotFound)
 	})
 }

--- a/router/v3/users.go
+++ b/router/v3/users.go
@@ -436,7 +436,7 @@ func (h *Handlers) EditUser(c echo.Context) error {
 	// 凍結の際
 	if deactivate {
 		// 1. 有効なセッションを削除
-		if err := h.SessStore.RevokeSessionsByUserID(userID); err != nil {
+		if err := h.SessStore.RevokeSessionsByUserID(c.Request().Context(), userID); err != nil {
 			return herror.InternalServerError(err)
 		}
 		// 2. 未読を削除（重いので一時的にコメントアウトしている; Hubのイベント経由などで非同期処理にすべき）


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * セッション操作でリクエスト固有のコンテキストを明示的に伝播するように統一し、セッションのDB/キャッシュ操作やハンドラ間のコンテキスト扱いを一貫化しました。
  * パスワード変更時のセッション撤回エラーを無視せず適切にエラー応答するよう強化しました。
* **Tests**
  * テスト群をコンテキスト対応に更新し、セッション発行／照会の呼び出しパターンを整備しました。

注：公開APIやユーザー機能の仕様変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->