### PR TITLE
otel propagatorを削除

### DIFF
--- a/utils/tracing/tracing.go
+++ b/utils/tracing/tracing.go
@@ -8,7 +8,6 @@ import (
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
@@ -40,11 +39,6 @@ func InitTracer(ctx context.Context, serviceName string) (func(context.Context) 
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(tp)
-
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
 
 	return func(ctx context.Context) error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)


### PR DESCRIPTION
デフォルトでは外からのtraceを無視するようにした。
環境変数`OTEL_PROPAGATORS`で変更可能です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal tracing setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->