### PR TITLE
絵文字のリネームを修正

### DIFF
--- a/utils/twemoji/installer.go
+++ b/utils/twemoji/installer.go
@@ -52,7 +52,7 @@ var replaceNameMap = map[string]string{
 	"woman_in_manual_wheelchair_facing_right":     "woman_manual_wheelchair_right",
 	"woman_in_motorized_wheelchair_facing_right":  "woman_powered_wheelchair_right",
 	"person_in_motorized_wheelchair_facing_right": "person_powered_wheelchair_right",
-	"person_in_manual_wheelchair_facing_right":    "woman_manual_wheelchair_right",
+	"person_in_manual_wheelchair_facing_right":    "person_manual_wheelchair_right",
 	"woman_with_white_cane_facing_right":          "woman_white_cane_facing_right",
 	"person_with_white_cane_facing_right":         "person_white_cane_facing_right",
 }


### PR DESCRIPTION
文脈：https://q.trap.jp/messages/019df495-5e89-79ca-aa07-57dd3b407b79

person_in_manual_wheelchair_facing_rightのリネームの結果スタンプ名が衝突しているため、直す
既に誤った名前で絵文字が作成されたインスタンスでは`./traQ stamp install-emojis --update` が必要（本番 / ステージ環境はkubectlを打つだけだが、外部インスタンス向けにリリースノートに説明を書く必要がある）
参考：https://q.trap.jp/messages/0199c1b2-7f30-73ba-87ab-7cdd2016d3d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected emoji naming for person in manual wheelchair facing right to use accurate, gender-neutral representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->