### PR TITLE
Fix Renovate Configuration

### DIFF
--- a/.github/renovate/regex-manager.json5
+++ b/.github/renovate/regex-manager.json5
@@ -51,7 +51,7 @@
       ],
       "matchStrings": [
         // Example: kustomize build https://github.com/argoproj/argo-cd//manifests/crds?ref=v2.7.6 | kubectl create -f -
-        "https://github\\.com/(?<depName>[^/]+/[^/]+)//.*?\\?ref=(?<currentValue>[^\\s\"']+)(?=[\\s\"']|$)",
+        "https://github\\.com/(?<depName>[^/]+/[^/]+)//.*?\\?ref=(?<currentValue>[^\\s\"']+)",
         // Example: - https://raw.githubusercontent.com/traefik/traefik/v2.10.3/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
         "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentValue>[^/]+)",
         // Example: - https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml


### PR DESCRIPTION
resolves #2976

https://github.com/traPtitech/traQ/pull/2947#discussion_r2869812254 で混入した修正により、renovateが壊れているので直す。
`[^\\s\"']+`の時点でダブルクォーテーション等が入らないことは保証されているので、`(?=[\\s\"']|$)`で終端チェックをする必要はない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration for improved regex pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->