### PR TITLE
hotfix: revival of qall websocket schemas

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -16,6 +16,15 @@ servers:
     description: staging
   - url: "http://localhost:3000/api/v3"
     description: local
+x-traq-codegen-schemas:
+  description: HTTPエンドポイントから参照されていないが、クライアントがWebSocketイベントの型を生成するために使用するコンポーネント
+  schemas:
+    QallRoomStateChangedEvent:
+      $ref: "#/components/schemas/QallRoomStateChangedEvent"
+    QallSoundboardItemCreatedEvent:
+      $ref: "#/components/schemas/QallSoundboardItemCreatedEvent"
+    QallSoundboardItemDeletedEvent:
+      $ref: "#/components/schemas/QallSoundboardItemDeletedEvent"
 paths:
   "/channels/{channelId}/messages":
     parameters:
@@ -7063,6 +7072,91 @@ components:
       required:
         - userId
         - channelId
+    QallRoomStateChangedEvent:
+      title: QallRoomStateChangedEvent
+      type: object
+      description: Qallのルーム状態が変更された
+      properties:
+        roomStates:
+          type: array
+          items:
+            type: object
+            properties:
+              roomId:
+                type: string
+                format: uuid
+                description: ルームのID
+              participants:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    identity:
+                      type: string
+                      description: ユーザーID_RandomUUID
+                    name:
+                      type: string
+                      description: 表示名
+                    joinedAt:
+                      type: string
+                      format: date-time
+                      description: 参加した時刻
+                    attributes:
+                      type: object
+                      additionalProperties:
+                        type: string
+                        description: ユーザーに関連付けられたカスタム属性
+                    canPublish:
+                      type: boolean
+                      description: 発言権限
+                  required:
+                    - identity
+                    - name
+                    - joinedAt
+                    - canPublish
+              isWebinar:
+                type: boolean
+                description: ウェビナールームかどうか
+              metadata:
+                type: string
+                description: ルームに関連付けられたカスタム属性
+            required:
+              - roomId
+              - participants
+              - isWebinar
+      required:
+        - roomStates
+    QallSoundboardItemCreatedEvent:
+      title: QallSoundboardItemCreatedEvent
+      type: object
+      description: Qallのサウンドボードアイテムが作成された
+      properties:
+        soundId:
+          type: string
+          format: uuid
+          description: 作成されたサウンドボードアイテムのId
+        name:
+          type: string
+          description: 作成されたサウンドボードアイテムの名前
+        creatorId:
+          type: string
+          format: uuid
+          description: 作成者のId
+      required:
+        - soundId
+        - name
+        - creatorId
+    QallSoundboardItemDeletedEvent:
+      title: QallSoundboardItemDeletedEvent
+      type: object
+      description: Qallのサウンドボードアイテムが削除された
+      properties:
+        soundId:
+          type: string
+          format: uuid
+          description: 削除されたサウンドボードアイテムのId
+      required:
+        - soundId
     StampPalette:
       title: StampPalette
       type: object


### PR DESCRIPTION
hotfixとして、Qall websocket schemasを復活させる
https://q.trap.jp/messages/019e311f-cbbf-76c9-8d1e-267cce5f172c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API schemas for new WebSocket events enabling real-time notifications for room state changes and soundboard item management (creation and deletion).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/traQ/pull/3013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->