### PR TITLE
POST /threads の実装

### DIFF
--- a/repository/channel.go
+++ b/repository/channel.go
@@ -82,7 +82,7 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// channelType が repository.ChannelTypePublic の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	// channelType が repository.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
 	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -39,7 +39,6 @@ type ChannelEventsQuery struct {
 	Asc       bool
 }
 
-
 // ChannelSubscriptionQuery GetChannelSubscriptions用クエリ
 type ChannelSubscriptionQuery struct {
 	UserID    optional.Of[uuid.UUID]

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -82,7 +82,7 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// channelType が repository.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	// channelType が model.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
 	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -39,6 +39,7 @@ type ChannelEventsQuery struct {
 	Asc       bool
 }
 
+
 // ChannelSubscriptionQuery GetChannelSubscriptions用クエリ
 type ChannelSubscriptionQuery struct {
 	UserID    optional.Of[uuid.UUID]
@@ -82,8 +83,8 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// dmがtrueの場合、privateMembersに1人または2人のユーザーが入っている必要があります。
-	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error)
+	// channelType が repository.ChannelTypePublic の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//
 	// 存在しないチャンネルを指定した場合、ErrNotFoundを返します。

--- a/repository/gorm/channel.go
+++ b/repository/gorm/channel.go
@@ -19,7 +19,7 @@ import (
 var dmChannelRootUUID = uuid.Must(uuid.FromString(model.DirectMessageChannelRootID))
 
 // CreateChannel implements ChannelRepository interface.
-func (repo *Repository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
+func (repo *Repository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error) {
 	arr := []interface{}{&ch}
 
 	ch.ID = uuid.Must(uuid.NewV7())
@@ -37,7 +37,11 @@ func (repo *Repository) CreateChannel(ctx context.Context, ch model.Channel, pri
 		}
 	}
 
-	if dm {
+	if channelType == model.ChannelTypeThread {
+		ch.Type = model.ChannelTypeThread
+	}
+
+	if channelType == model.ChannelTypeDM {
 		ch.ParentID = dmChannelRootUUID
 		ch.Type = model.ChannelTypeDM
 		ch.IsForced = false

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -164,7 +164,7 @@ func mustMakeChannel(t *testing.T, repo repository.Repository, name string) *mod
 		Name:      name,
 		IsForced:  false,
 		IsVisible: true,
-	}, nil, false)
+	}, nil, model.ChannelTypePublic)
 	require.NoError(t, err)
 	return ch
 }

--- a/repository/mock_repository/mock_channel.go
+++ b/repository/mock_repository/mock_channel.go
@@ -71,18 +71,18 @@ func (mr *MockChannelRepositoryMockRecorder) ChangeChannelSubscription(ctx, chan
 }
 
 // CreateChannel mocks base method.
-func (m *MockChannelRepository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, dm bool) (*model.Channel, error) {
+func (m *MockChannelRepository) CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateChannel", ctx, ch, privateMembers, dm)
+	ret := m.ctrl.Call(m, "CreateChannel", ctx, ch, privateMembers, channelType)
 	ret0, _ := ret[0].(*model.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateChannel indicates an expected call of CreateChannel.
-func (mr *MockChannelRepositoryMockRecorder) CreateChannel(ctx, ch, privateMembers, dm interface{}) *gomock.Call {
+func (mr *MockChannelRepositoryMockRecorder) CreateChannel(ctx, ch, privateMembers, channelType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannel", reflect.TypeOf((*MockChannelRepository)(nil).CreateChannel), ctx, ch, privateMembers, dm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannel", reflect.TypeOf((*MockChannelRepository)(nil).CreateChannel), ctx, ch, privateMembers, channelType)
 }
 
 // GetChannel mocks base method.

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -135,6 +135,8 @@ func (h *Handlers) CreateThreads(c echo.Context) error {
 			return herror.BadRequest("invalid channel name")
 		case channel.ErrInvalidParentChannel:
 			return herror.BadRequest("invalid parent channel")
+		case channel.ErrChannelThreadParent:
+			return herror.BadRequest("parent channel is a thread channel")
 		case channel.ErrTooDeepChannel:
 			return herror.BadRequest("channel depth limit exceeded")
 		case channel.ErrChannelNameConflicts:

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -73,6 +73,18 @@ func (r PostChannelRequest) Validate() error {
 	)
 }
 
+// PostThreadRequest POST /threads リクエストボディ
+type PostThreadRequest struct {
+	Name   string    `json:"name"`
+	Parent uuid.UUID `json:"parent"`
+}
+
+func (r PostThreadRequest) Validate() error {
+	return vd.ValidateStruct(&r,
+		vd.Field(&r.Name, validator.ThreadNameRuleRequired...),
+	)
+}
+
 // CreateChannels POST /channels
 func (h *Handlers) CreateChannels(c echo.Context) error {
 	ctx := c.Request().Context()
@@ -84,6 +96,37 @@ func (h *Handlers) CreateChannels(c echo.Context) error {
 	}
 
 	ch, err := h.ChannelManager.CreatePublicChannel(ctx, req.Name, req.Parent.V, userID)
+	if err != nil {
+		switch err {
+		case channel.ErrChannelArchived:
+			return herror.BadRequest("parent channel has been archived")
+		case channel.ErrInvalidChannelName:
+			return herror.BadRequest("invalid channel name")
+		case channel.ErrInvalidParentChannel:
+			return herror.BadRequest("invalid parent channel")
+		case channel.ErrTooDeepChannel:
+			return herror.BadRequest("channel depth limit exceeded")
+		case channel.ErrChannelNameConflicts:
+			return herror.Conflict("channel name conflicts")
+		default:
+			return herror.InternalServerError(err)
+		}
+	}
+
+	return c.JSON(http.StatusCreated, formatChannel(ch, make([]uuid.UUID, 0)))
+}
+
+// CreateThreads POST /threads
+func (h *Handlers) CreateThreads(c echo.Context) error {
+	ctx := c.Request().Context()
+	userID := getRequestUserID(c)
+
+	var req PostThreadRequest
+	if err := bindAndValidate(c, &req); err != nil {
+		return err
+	}
+
+	ch, err := h.ChannelManager.CreateThreadChannel(ctx, req.Name, req.Parent, userID)
 	if err != nil {
 		switch err {
 		case channel.ErrChannelArchived:

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -435,6 +435,28 @@ func TestHandlers_CreateThreads(t *testing.T) {
 		assert.Equal(t, parent.ID, thread.ParentID)
 		assert.Equal(t, model.ChannelTypeThread, thread.Type)
 	})
+
+	t.Run("thread parent should be rejected", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+
+		first := e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: "first-thread", Parent: parent.ID}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		threadID, err := uuid.FromString(first.Value("id").String().Raw())
+		require.NoError(t, err)
+
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: "nested-thread", Parent: threadID}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
 }
 
 func TestHandlers_GetChannel(t *testing.T) {

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -274,6 +274,38 @@ func TestPostChannelRequest_Validate(t *testing.T) {
 	}
 }
 
+func TestPostThreadRequest_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		request PostThreadRequest
+		wantErr bool
+	}{
+		{
+			"empty name",
+			PostThreadRequest{},
+			true,
+		},
+		{
+			"日本語スレッド名の許可",
+			PostThreadRequest{Name: "チャンネル", Parent: uuid.Must(uuid.NewV7())},
+			false,
+		},
+		{
+			"success",
+			PostThreadRequest{Name: "po", Parent: uuid.Must(uuid.NewV7())},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.request.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestHandlers_CreateChannels(t *testing.T) {
 	t.Parallel()
 	path := "/api/v3/channels"
@@ -345,6 +377,63 @@ func TestHandlers_CreateChannels(t *testing.T) {
 		if assert.Len(t, ch.ChildrenID, 1) {
 			assert.EqualValues(t, ch.ChildrenID[0].String(), obj.Value("id").String().Raw())
 		}
+	})
+}
+
+func TestHandlers_CreateThreads(t *testing.T) {
+	t.Parallel()
+	path := "/api/v3/threads"
+	env := Setup(t, common1)
+	user := env.CreateUser(t, rand)
+	commonSession := env.S(t, user.GetID())
+	parent := env.CreateChannel(t, rand)
+
+	t.Run("not logged in", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithJSON(&PostThreadRequest{Name: "po", Parent: parent.ID}).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("success(日本語名)", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: "チャンネル", Parent: parent.ID}).
+			Expect().
+			Status(http.StatusCreated)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+		threadName := random.AlphaNumeric(20)
+		obj := e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: threadName, Parent: parent.ID}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		obj.Value("id").String().NotEmpty()
+		obj.Value("parentId").String().IsEqual(parent.ID.String())
+		obj.Value("archived").Boolean().IsFalse()
+		obj.Value("force").Boolean().IsFalse()
+		obj.Value("topic").String().IsEmpty()
+		obj.Value("name").String().IsEqual(threadName)
+		obj.Value("children").Array().Length().IsEqual(0)
+
+		threadID, err := uuid.FromString(obj.Value("id").String().Raw())
+		require.NoError(t, err)
+
+		thread, err := env.CM.GetChannel(context.TODO(), threadID)
+		require.NoError(t, err)
+		assert.Equal(t, parent.ID, thread.ParentID)
+		assert.Equal(t, model.ChannelTypeThread, thread.Type)
 	})
 }
 

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -214,6 +214,10 @@ func (h *Handlers) Setup(e *echo.Group) {
 				apiChannelsCID.GET("/path", h.GetChannelPath, requires(permission.GetChannel))
 			}
 		}
+		apiThreads := api.Group("/threads")
+		{
+			apiThreads.POST("", h.CreateThreads, requires(permission.CreateChannel))
+		}
 		apiMessages := api.Group("/messages")
 		{
 			apiMessages.GET("", h.SearchMessages, requires(permission.GetMessage))

--- a/service/channel/manager.go
+++ b/service/channel/manager.go
@@ -21,6 +21,7 @@ var (
 	ErrChannelArchived      = errors.New("channel archived")
 	ErrForcedNotification   = errors.New("forced notification channel")
 	ErrInvalidChannel       = errors.New("invalid channel")
+	ErrChannelThreadParent  = errors.New("parent channel is a thread channel")
 )
 
 type Manager interface {
@@ -39,6 +40,8 @@ type Manager interface {
 	GetDMChannel(ctx context.Context, user1, user2 uuid.UUID) (*model.Channel, error)
 	GetDMChannelMembers(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error)
 	GetDMChannelMapping(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error)
+
+	CreateThreadChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error)
 
 	IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error)
 	IsPublicChannel(ctx context.Context, id uuid.UUID) bool

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -416,19 +416,27 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 	m.T.Lock()
 	defer m.T.Unlock()
 
-	if parent != pubChannelRootUUID {
-		// 親チャンネルの存在を確認
-		if !m.T.isChannelPresent(parent) {
-			return nil, ErrInvalidParentChannel
-		}
-		// 親チャンネルがスレッドかどうか確認
-		if m.T.isThreadChannel(parent) {
-			return nil, ErrChannelThreadParent
-		}
-		// 親チャンネルがアーカイブされているかどうか確認
-		if m.T.isArchivedChannel(parent) {
-			return nil, ErrChannelArchived
-		}
+	// ルートチャンネルの下にスレッドは作れない
+	if parent == pubChannelRootUUID {
+		return nil, ErrInvalidParentChannel
+	}
+
+	// 既にある名前のスレッドは作れない
+	if m.T.isChildPresent(name, parent) {
+		return nil, ErrChannelNameConflicts
+	}
+
+	// 親チャンネルの存在を確認
+	if !m.T.isChannelPresent(parent) {
+		return nil, ErrInvalidParentChannel
+	}
+	// 親チャンネルがスレッドかどうか確認
+	if m.T.isThreadChannel(parent) {
+		return nil, ErrChannelThreadParent
+	}
+	// 親チャンネルがアーカイブされているかどうか確認
+	if m.T.isArchivedChannel(parent) {
+		return nil, ErrChannelArchived
 	}
 
 	// チャンネル作成

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -422,7 +422,7 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 			return nil, ErrInvalidParentChannel
 		}
 		// 親チャンネルがスレッドかどうか確認
-		if m.T.isThreadChannel(parent){
+		if m.T.isThreadChannel(parent) {
 			return nil, ErrChannelThreadParent
 		}
 		// 親チャンネルがアーカイブされているかどうか確認

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -452,13 +452,11 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
 	m.T.add(ch)
-	if parent != pubChannelRootUUID {
-		// ロギング
-		m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
-			"userId":    ch.CreatorID,
-			"channelId": ch.ID,
-		}, ch.CreatedAt)
-	}
+	// ロギング
+	m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
+		"userId":    ch.CreatorID,
+		"channelId": ch.ID,
+	}, ch.CreatedAt)
 	m.L.Info(fmt.Sprintf("channel #%s was created", m.T.getChannelPath(ch.ID)), zap.Stringer("cid", ch.ID))
 	return ch, nil
 }

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -116,7 +116,7 @@ func (m *managerImpl) CreatePublicChannel(ctx context.Context, name string, pare
 		UpdaterID: creatorID,
 		IsForced:  false,
 		IsVisible: true,
-	}, nil, false)
+	}, nil, model.ChannelTypePublic)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
@@ -379,7 +379,7 @@ func (m *managerImpl) GetDMChannel(ctx context.Context, user1, user2 uuid.UUID) 
 		IsVisible: true,
 	},
 		set.UUIDSetFromArray([]uuid.UUID{user1, user2}),
-		true)
+		model.ChannelTypeDM)
 	if err != nil {
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
@@ -410,6 +410,49 @@ func (m *managerImpl) GetDMChannelMapping(ctx context.Context, userID uuid.UUID)
 		}
 	}
 	return result, nil
+}
+
+func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
+	m.T.Lock()
+	defer m.T.Unlock()
+
+	if parent != pubChannelRootUUID {
+		// 親チャンネルの存在を確認
+		if !m.T.isChannelPresent(parent) {
+			return nil, ErrInvalidParentChannel
+		}
+		// 親チャンネルがスレッドかどうか確認
+		if m.T.isThreadChannel(parent){
+			return nil, ErrChannelThreadParent
+		}
+		// 親チャンネルがアーカイブされているかどうか確認
+		if m.T.isArchivedChannel(parent) {
+			return nil, ErrChannelArchived
+		}
+	}
+
+	// チャンネル作成
+	ch, err := m.R.CreateChannel(ctx, model.Channel{
+		Name:      name,
+		ParentID:  parent,
+		CreatorID: creatorID,
+		UpdaterID: creatorID,
+		IsForced:  false,
+		IsVisible: true,
+	}, nil, model.ChannelTypeThread)
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
+	}
+	m.T.add(ch)
+	if parent != pubChannelRootUUID {
+		// ロギング
+		m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
+			"userId":    ch.CreatorID,
+			"channelId": ch.ID,
+		}, ch.CreatedAt)
+	}
+	m.L.Info(fmt.Sprintf("channel #%s was created", m.T.getChannelPath(ch.ID)), zap.Stringer("cid", ch.ID))
+	return ch, nil
 }
 
 func (m *managerImpl) IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error) {

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -461,7 +461,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Return(nil, mockErr).
 			AnyTimes()
 
-		_, err := cm.CreateThreadChannel(context.TODO(), "test", uuid.Nil, uuid.Nil)
+		_, err := cm.CreateThreadChannel(context.TODO(), "test", cEK, uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -475,7 +475,6 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Parent  uuid.UUID
 			Creator uuid.UUID
 		}{
-			{Name: "test1", Parent: uuid.Nil, Creator: cA},
 			{Name: "test1", Parent: cA, Creator: cAB},
 			{Name: "test2", Parent: cA, Creator: cABC},
 			{Name: "test2", Parent: cEFGJ, Creator: cABCD},

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -384,6 +384,42 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 		}
 	})
 
+	t.Run("RootParentChannel", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "b", Parent: pubChannelRootUUID},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrInvalidParentChannel.Error())
+		}
+	})
+
+	t.Run("ErrThreadNameConflicts", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "l", Parent: cEK},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrChannelNameConflicts.Error())
+		}
+	})
+
 	t.Run("ErrChannelArchived", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -462,7 +498,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 							ParentID:   c.Parent,
 							CreatorID:  c.Creator,
 							UpdaterID:  c.Creator,
-							Type:       model.ChannelTypePublic,
+							Type:       model.ChannelTypeThread,
 							IsForced:   false,
 							IsVisible:  true,
 							CreatedAt:  createdAt,
@@ -472,7 +508,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), model.ChannelTypeThread).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -363,6 +363,141 @@ func TestManagerImpl_CreatePublicChannel(t *testing.T) {
 	})
 }
 
+func TestManagerImpl_CreateThreadChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ErrInvalidParentChannel", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "b", Parent: cNotFound},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrInvalidParentChannel.Error())
+		}
+	})
+
+	t.Run("ErrChannelArchived", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "a", Parent: cABB},
+			{Name: "a", Parent: cABBC},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrChannelArchived.Error())
+		}
+	})
+
+	t.Run("ErrChannelThreadParent", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+		_, err := cm.CreateThreadChannel(context.TODO(), "a", cEKL, uuid.Nil)
+		assert.EqualError(t, err, ErrChannelThreadParent.Error())
+
+	})
+
+	t.Run("repository error", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		mockErr := errors.New("mock error")
+		repo.EXPECT().
+			CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, mockErr).
+			AnyTimes()
+
+		_, err := cm.CreateThreadChannel(context.TODO(), "test", uuid.Nil, uuid.Nil)
+		if assert.Error(t, err) {
+			assert.Equal(t, mockErr, errors.Unwrap(err))
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			Name    string
+			Parent  uuid.UUID
+			Creator uuid.UUID
+		}{
+			{Name: "test1", Parent: uuid.Nil, Creator: cA},
+			{Name: "test1", Parent: cA, Creator: cAB},
+			{Name: "test2", Parent: cA, Creator: cABC},
+			{Name: "test2", Parent: cEFGJ, Creator: cABCD},
+		}
+
+		for _, uuidVersion := range []int{4, 7} {
+			t.Run(fmt.Sprintf("UUIDv%d", uuidVersion), func(t *testing.T) {
+				t.Parallel()
+				for i, c := range cases {
+					t.Run(strconv.Itoa(i), func(t *testing.T) {
+						ctrl := gomock.NewController(t)
+						repo := mock_repository.NewMockChannelRepository(ctrl)
+						cm := initCM(t, repo)
+
+						cid := mustGenerateUUID(uuidVersion)
+						createdAt := time.Now()
+						expected := &model.Channel{
+							ID:         cid,
+							Name:       c.Name,
+							ParentID:   c.Parent,
+							CreatorID:  c.Creator,
+							UpdaterID:  c.Creator,
+							Type:       model.ChannelTypePublic,
+							IsForced:   false,
+							IsVisible:  true,
+							CreatedAt:  createdAt,
+							UpdatedAt:  createdAt,
+							DeletedAt:  gorm.DeletedAt{},
+							ChildrenID: make([]uuid.UUID, 0),
+						}
+
+						repo.EXPECT().
+							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(expected, nil).
+							AnyTimes()
+						if c.Parent != uuid.Nil {
+							repo.EXPECT().
+								RecordChannelEvent(gomock.Any(), c.Parent, model.ChannelEventChildCreated, gomock.Eq(model.ChannelEventDetail{
+									"userId":    c.Creator,
+									"channelId": cid,
+								}), createdAt).
+								Return(nil).
+								Times(1)
+						}
+
+						ch, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, c.Creator)
+						cm.P.Wait()
+						if assert.NoError(t, err) {
+							assert.Equal(t, expected, ch)
+							assert.True(t, cm.PublicChannelTree(context.TODO()).IsChannelPresent(cid))
+						}
+					})
+				}
+			})
+		}
+	})
+}
+
 func TestManagerImpl_UpdateChannel(t *testing.T) {
 	t.Parallel()
 
@@ -970,7 +1105,7 @@ func TestManagerImpl_GetDMChannel(t *testing.T) {
 					Times(1)
 
 				repo.EXPECT().
-					CreateChannel(gomock.Any(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), true).
+					CreateChannel(gomock.Any(), gomock.Any(), set.UUIDSetFromArray([]uuid.UUID{uid1, uid2}), model.ChannelTypeDM).
 					Return(&model.Channel{
 						ID:        uuid.NewV3(uuid.Nil, "c 1-1"),
 						Name:      "dm_" + random.AlphaNumeric(17),

--- a/service/channel/mock_channel/mock_manager.go
+++ b/service/channel/mock_channel/mock_manager.go
@@ -81,6 +81,21 @@ func (mr *MockManagerMockRecorder) CreatePublicChannel(ctx, name, parent, creato
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicChannel", reflect.TypeOf((*MockManager)(nil).CreatePublicChannel), ctx, name, parent, creatorID)
 }
 
+// CreateThreadChannel mocks base method.
+func (m *MockManager) CreateThreadChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateThreadChannel", ctx, name, parent, creatorID)
+	ret0, _ := ret[0].(*model.Channel)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateThreadChannel indicates an expected call of CreateThreadChannel.
+func (mr *MockManagerMockRecorder) CreateThreadChannel(ctx, name, parent, creatorID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateThreadChannel", reflect.TypeOf((*MockManager)(nil).CreateThreadChannel), ctx, name, parent, creatorID)
+}
+
 // GetChannel mocks base method.
 func (m *MockManager) GetChannel(ctx context.Context, id uuid.UUID) (*model.Channel, error) {
 	m.ctrl.T.Helper()

--- a/service/channel/tree_impl.go
+++ b/service/channel/tree_impl.go
@@ -33,6 +33,7 @@ type channelNode struct {
 	force     bool                       // Nodeでロック
 	updaterID uuid.UUID                  // Nodeでロック
 	updatedAt time.Time                  // Nodeでロック
+	thread    bool                       // Nodeでロック
 	sync.RWMutex
 }
 
@@ -97,12 +98,16 @@ func (n *channelNode) getAscendantIDs() []uuid.UUID {
 func (n *channelNode) convertToModel() *model.Channel {
 	n.RLock()
 	defer n.RUnlock()
+	channelType := model.ChannelTypePublic
+	if n.thread {
+		channelType = model.ChannelTypeThread
+	}
 	ch := &model.Channel{
 		ID:         n.id,
 		Name:       n.name,
 		Topic:      n.topic,
 		IsForced:   n.force,
-		Type:       model.ChannelTypePublic,
+		Type:       channelType,
 		IsVisible:  !n.archived,
 		CreatorID:  n.creatorID,
 		UpdaterID:  n.updaterID,
@@ -140,6 +145,7 @@ func constructChannelNode(chMap map[uuid.UUID]*model.Channel, tree *treeImpl, id
 		updaterID: ch.UpdaterID,
 		createdAt: ch.CreatedAt,
 		updatedAt: ch.UpdatedAt,
+		thread:    ch.Type == model.ChannelTypeThread,
 	}
 	if ch.ParentID != uuid.Nil {
 		p, err := constructChannelNode(chMap, tree, ch.ParentID)
@@ -194,6 +200,7 @@ func (ct *treeImpl) add(ch *model.Channel) {
 		updaterID: ch.UpdaterID,
 		createdAt: ch.CreatedAt,
 		updatedAt: ch.UpdatedAt,
+		thread:    ch.Type == model.ChannelTypeThread,
 	}
 	if ch.ParentID == uuid.Nil {
 		// ルート
@@ -473,6 +480,11 @@ func (ct *treeImpl) IsArchivedChannel(id uuid.UUID) bool {
 	defer ct.RUnlock()
 	return ct.isArchivedChannel(id)
 }
+func (ct *treeImpl) IsThreadChannel(id uuid.UUID) bool {
+	ct.RLock()
+	defer ct.RUnlock()
+	return ct.isThreadChannel(id)
+}
 
 func (ct *treeImpl) isArchivedChannel(id uuid.UUID) bool {
 	n, ok := ct.nodes[id]
@@ -482,6 +494,16 @@ func (ct *treeImpl) isArchivedChannel(id uuid.UUID) bool {
 	n.RLock()
 	defer n.RUnlock()
 	return n.archived
+}
+
+func (ct *treeImpl) isThreadChannel(id uuid.UUID) bool {
+	n, ok := ct.nodes[id]
+	if !ok {
+		return false
+	}
+	n.RLock()
+	defer n.RUnlock()
+	return n.thread
 }
 
 // MarshalJSON implements json.Marshaler interface

--- a/service/channel/tree_impl_test.go
+++ b/service/channel/tree_impl_test.go
@@ -52,6 +52,7 @@ e : 6301b259-2a3e-4a30-9ec8-78737c4b539d force
 │ 　 │ └ i : 55339fb1-c3c8-4c52-a053-8af0845c45e9
 │ 　 └ j : 071eefb9-0a77-4cc4-8d38-5c214aca85f0
 └ k : 2636a1e1-5356-4c5f-8822-c52eeb914689
+
 	└ l : d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f thread
 */
 func makeTestChannelTree(t *testing.T) *treeImpl {

--- a/service/channel/tree_impl_test.go
+++ b/service/channel/tree_impl_test.go
@@ -52,7 +52,6 @@ e : 6301b259-2a3e-4a30-9ec8-78737c4b539d force
 │ 　 │ └ i : 55339fb1-c3c8-4c52-a053-8af0845c45e9
 │ 　 └ j : 071eefb9-0a77-4cc4-8d38-5c214aca85f0
 └ k : 2636a1e1-5356-4c5f-8822-c52eeb914689
-
 	└ l : d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f thread
 */
 func makeTestChannelTree(t *testing.T) *treeImpl {

--- a/service/channel/tree_impl_test.go
+++ b/service/channel/tree_impl_test.go
@@ -28,6 +28,7 @@ var (
 	cEFGHI    = uuid.Must(uuid.FromString("55339fb1-c3c8-4c52-a053-8af0845c45e9"))
 	cEFGJ     = uuid.Must(uuid.FromString("071eefb9-0a77-4cc4-8d38-5c214aca85f0"))
 	cEK       = uuid.Must(uuid.FromString("2636a1e1-5356-4c5f-8822-c52eeb914689"))
+	cEKL      = uuid.Must(uuid.FromString("d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f"))
 	cNotFound = uuid.Must(uuid.FromString("44bf0189-e3d5-4946-92e7-a196a2a94f98"))
 )
 
@@ -51,6 +52,8 @@ e : 6301b259-2a3e-4a30-9ec8-78737c4b539d force
 │ 　 │ └ i : 55339fb1-c3c8-4c52-a053-8af0845c45e9
 │ 　 └ j : 071eefb9-0a77-4cc4-8d38-5c214aca85f0
 └ k : 2636a1e1-5356-4c5f-8822-c52eeb914689
+
+	└ l : d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f thread
 */
 func makeTestChannelTree(t *testing.T) *treeImpl {
 	t.Helper()
@@ -72,6 +75,7 @@ func makeTestChannelTree(t *testing.T) *treeImpl {
 		{ID: cEFGHI, Name: "i", ParentID: cEFGH, Topic: "", IsForced: false, Type: model.ChannelTypePublic, IsVisible: true},
 		{ID: cEFGJ, Name: "j", ParentID: cEFG, Topic: "", IsForced: false, Type: model.ChannelTypePublic, IsVisible: true},
 		{ID: cEK, Name: "k", ParentID: cE, Topic: "", IsForced: false, Type: model.ChannelTypePublic, IsVisible: true},
+		{ID: cEKL, Name: "l", ParentID: cEK, Topic: "", IsForced: false, Type: model.ChannelTypeThread, IsVisible: true},
 	})
 	assert.NoError(t, err)
 	return tree
@@ -122,7 +126,7 @@ func TestChannelTreeImpl_GetDescendantIDs(t *testing.T) {
 	t.Parallel()
 	tree := makeTestChannelTree(t)
 
-	assert.ElementsMatch(t, tree.GetDescendantIDs(uuid.Nil), []uuid.UUID{cA, cAB, cABC, cABCD, cABCE, cABF, cABFA, cABB, cABBC, cAD, cE, cEF, cEFG, cEFGH, cEFGHI, cEFGJ, cEK})
+	assert.ElementsMatch(t, tree.GetDescendantIDs(uuid.Nil), []uuid.UUID{cA, cAB, cABC, cABCD, cABCE, cABF, cABFA, cABB, cABBC, cAD, cE, cEF, cEFG, cEFGH, cEFGHI, cEFGJ, cEK, cEKL})
 	assert.ElementsMatch(t, tree.GetDescendantIDs(cA), []uuid.UUID{cAB, cABC, cABCD, cABCE, cABF, cABFA, cABB, cABBC, cAD})
 	assert.ElementsMatch(t, tree.GetDescendantIDs(cAB), []uuid.UUID{cABC, cABCD, cABCE, cABF, cABFA, cABB, cABBC})
 	assert.ElementsMatch(t, tree.GetDescendantIDs(cABCD), []uuid.UUID{})

--- a/testutils/test_repository.go
+++ b/testutils/test_repository.go
@@ -726,9 +726,9 @@ func (repo *TestRepository) GetUserIDsByTagID(_ context.Context, tagID uuid.UUID
 	return users, nil
 }
 
-func (repo *TestRepository) CreateChannel(_ context.Context, ch model.Channel, _ set.UUID, _ bool) (*model.Channel, error) {
+func (repo *TestRepository) CreateChannel(_ context.Context, ch model.Channel, _ set.UUID, channelType model.ChannelType) (*model.Channel, error) {
 	ch.ID = uuid.Must(uuid.NewV7())
-	ch.Type = model.ChannelTypePublic
+	ch.Type = channelType
 	ch.CreatedAt = time.Now()
 	ch.UpdatedAt = time.Now()
 	ch.DeletedAt = gorm.DeletedAt{}

--- a/utils/validator/rules.go
+++ b/utils/validator/rules.go
@@ -39,6 +39,10 @@ var UserNameRuleRequired = append([]vd.Rule{
 	vd.Required,
 }, UserNameRule...)
 
+var ThreadNameRuleRequired = append([]vd.Rule{
+	vd.Required,
+})
+
 // BotUserNameRule BOTユーザー名バリデーションルール
 var BotUserNameRule = []vd.Rule{
 	vd.Match(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)).Error("must contain [a-zA-Z0-9_-] only"),

--- a/utils/validator/rules.go
+++ b/utils/validator/rules.go
@@ -39,9 +39,9 @@ var UserNameRuleRequired = append([]vd.Rule{
 	vd.Required,
 }, UserNameRule...)
 
-var ThreadNameRuleRequired = append([]vd.Rule{
+var ThreadNameRuleRequired = []vd.Rule{
 	vd.Required,
-})
+}
 
 // BotUserNameRule BOTユーザー名バリデーションルール
 var BotUserNameRule = []vd.Rule{


### PR DESCRIPTION
close #3061 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added thread channel creation via `POST /api/v3/threads`.
  * Thread names are validated, and threads can be created under an eligible parent with the correct hierarchy.

* **Improvements**
  * `POST /api/v3/threads` now returns the created thread channel (including correct `parentId` and `type`).
  * Invalid requests are rejected with appropriate HTTP errors, including cases like empty thread names, nested thread parents, and archived or public-root parent channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->