### PR TITLE
feat(ws): WebSocket に `ping` を追加

### DIFF
--- a/docs/v3-api.yaml
+++ b/docs/v3-api.yaml
@@ -2543,6 +2543,10 @@ paths:
 
         `timeline_streaming:(on|off|true|false)`
 
+        ### `ping`コマンド
+        サーバーとの接続を確認する。
+        `ping`を送信すると、`PING`イベント（`{"type":"PING","body":null}`）が返されます。
+
         ## 受信
         TextMessageとして各種イベントが`type`と`body`を持つJSONとして非同期に送られます。
 

--- a/service/ws/handler.go
+++ b/service/ws/handler.go
@@ -126,6 +126,13 @@ Command:
 			s.sendErrorMessage(fmt.Sprintf("invalid args: %s", cmd))
 		}
 
+	case "ping":
+		// ping
+		_ = s.WriteMessage(&rawMessage{
+			t:    websocket.TextMessage,
+			data: makeMessage("PING", nil).toJSON(),
+		})
+
 	default:
 		// 不明なコマンド
 		s.sendErrorMessage(fmt.Sprintf("unknown command: %s", cmd))


### PR DESCRIPTION
## Why
- WebSocket の自動再接続制御 (のための half-open 検出) のために使いたい

## Note
body にタイムスタンプとを乗せてもいいかもしれないけれど、いったん要らないのでなしで


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new `ping` command over WebSocket connections.
  * Sending `ping` now returns a `PING` message response.

* **Documentation**
  * Updated the WebSocket API docs to include the new `ping` command and its response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->