### PR TITLE
patch/threadの実装

### DIFF
--- a/repository/channel.go
+++ b/repository/channel.go
@@ -28,6 +28,13 @@ type UpdateChannelArgs struct {
 	Parent             optional.Of[uuid.UUID]
 }
 
+// UpdateChannelArgs スレッド情報更新引数
+type UpdateThreadArgs struct {
+	UpdaterID  uuid.UUID
+	Name       optional.Of[string]
+	Visibility optional.Of[bool]
+}
+
 // ChannelEventsQuery GetChannelEvents用クエリ
 type ChannelEventsQuery struct {
 	Channel   uuid.UUID
@@ -82,7 +89,7 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// channelType が model.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	// channelType が repository.ChannelTypePublic の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
 	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -89,7 +89,7 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// channelType が repository.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	// channelType が model.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
 	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//

--- a/repository/channel.go
+++ b/repository/channel.go
@@ -89,7 +89,7 @@ type ChannelRepository interface {
 	GetPublicChannels(ctx context.Context) ([]*model.Channel, error)
 	// CreateChannel チャンネルを作成します
 	//
-	// channelType が repository.ChannelTypePublic の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
+	// channelType が repository.ChannelTypeDM の場合、privateMembersに1人または2人のユーザーが入っている必要があります。
 	CreateChannel(ctx context.Context, ch model.Channel, privateMembers set.UUID, channelType model.ChannelType) (*model.Channel, error)
 	// UpdateChannel 指定したチャンネルの情報を変更します
 	//

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -135,8 +135,6 @@ func (h *Handlers) CreateThreads(c echo.Context) error {
 			return herror.BadRequest("invalid channel name")
 		case channel.ErrInvalidParentChannel:
 			return herror.BadRequest("invalid parent channel")
-		case channel.ErrChannelThreadParent:
-			return herror.BadRequest("parent channel is a thread channel")
 		case channel.ErrTooDeepChannel:
 			return herror.BadRequest("channel depth limit exceeded")
 		case channel.ErrChannelNameConflicts:
@@ -147,6 +145,43 @@ func (h *Handlers) CreateThreads(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusCreated, formatChannel(ch, make([]uuid.UUID, 0)))
+}
+
+// PatchThreadChannel Patch /threads/{channelId}
+type PatchThreadRequest struct {
+	Name     optional.Of[string] `json:"name"`
+	Archived optional.Of[bool]   `json:"archived"`
+}
+
+func (h *Handlers) EditThread(c echo.Context) error {
+	ctx := c.Request().Context()
+	userID := getRequestUserID(c)
+	channelID := getParamAsUUID(c, consts.ParamChannelID)
+
+	var req PatchThreadRequest
+	if err := bindAndValidate(c, &req); err != nil {
+		return err
+	}
+	visibility := optional.Of[bool]{
+		V:     !req.Archived.V,
+		Valid: req.Archived.Valid,
+	}
+	args := repository.UpdateThreadArgs{
+		UpdaterID:  userID,
+		Name:       req.Name,
+		Visibility: visibility,
+	}
+	if err := h.ChannelManager.UpdateThread(ctx, channelID, args); err != nil {
+		switch err {
+		case channel.ErrInvalidChannelName:
+			return herror.BadRequest("invalid channel name")
+		case channel.ErrChannelNameConflicts:
+			return herror.Conflict("channel name conflicts")
+		default:
+			return herror.InternalServerError(err)
+		}
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // GetChannel GET /channels/:channelID

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -135,6 +135,8 @@ func (h *Handlers) CreateThreads(c echo.Context) error {
 			return herror.BadRequest("invalid channel name")
 		case channel.ErrInvalidParentChannel:
 			return herror.BadRequest("invalid parent channel")
+		case channel.ErrChannelThreadParent:
+			return herror.BadRequest("parent channel is a thread channel")
 		case channel.ErrTooDeepChannel:
 			return herror.BadRequest("channel depth limit exceeded")
 		case channel.ErrChannelNameConflicts:

--- a/router/v3/channels.go
+++ b/router/v3/channels.go
@@ -179,6 +179,8 @@ func (h *Handlers) EditThread(c echo.Context) error {
 			return herror.BadRequest("invalid channel name")
 		case channel.ErrChannelNameConflicts:
 			return herror.Conflict("channel name conflicts")
+		case channel.ErrInvalidChannelType:
+			return herror.Conflict("invalid channel type")
 		default:
 			return herror.InternalServerError(err)
 		}

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -435,28 +435,6 @@ func TestHandlers_CreateThreads(t *testing.T) {
 		assert.Equal(t, parent.ID, thread.ParentID)
 		assert.Equal(t, model.ChannelTypeThread, thread.Type)
 	})
-
-	t.Run("thread parent should be rejected", func(t *testing.T) {
-		t.Parallel()
-		e := env.R(t)
-
-		first := e.POST(path).
-			WithCookie(session.CookieName, commonSession).
-			WithJSON(&PostThreadRequest{Name: "first-thread", Parent: parent.ID}).
-			Expect().
-			Status(http.StatusCreated).
-			JSON().
-			Object()
-
-		threadID, err := uuid.FromString(first.Value("id").String().Raw())
-		require.NoError(t, err)
-
-		e.POST(path).
-			WithCookie(session.CookieName, commonSession).
-			WithJSON(&PostThreadRequest{Name: "nested-thread", Parent: threadID}).
-			Expect().
-			Status(http.StatusBadRequest)
-	})
 }
 
 func TestHandlers_GetChannel(t *testing.T) {

--- a/router/v3/channels_test.go
+++ b/router/v3/channels_test.go
@@ -435,6 +435,28 @@ func TestHandlers_CreateThreads(t *testing.T) {
 		assert.Equal(t, parent.ID, thread.ParentID)
 		assert.Equal(t, model.ChannelTypeThread, thread.Type)
 	})
+
+	t.Run("thread parent should be rejected", func(t *testing.T) {
+		t.Parallel()
+		e := env.R(t)
+
+		first := e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: "first-thread", Parent: parent.ID}).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().
+			Object()
+
+		threadID, err := uuid.FromString(first.Value("id").String().Raw())
+		require.NoError(t, err)
+
+		e.POST(path).
+			WithCookie(session.CookieName, commonSession).
+			WithJSON(&PostThreadRequest{Name: "nested-thread", Parent: threadID}).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
 }
 
 func TestHandlers_GetChannel(t *testing.T) {

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -217,6 +217,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 		apiThreads := api.Group("/threads")
 		{
 			apiThreads.POST("", h.CreateThreads, requires(permission.CreateChannel))
+			apiThreads.PATCH("/:channelID", h.EditThread, requires(permission.EditChannel))
 		}
 		apiMessages := api.Group("/messages")
 		{

--- a/router/v3/router.go
+++ b/router/v3/router.go
@@ -217,7 +217,7 @@ func (h *Handlers) Setup(e *echo.Group) {
 		apiThreads := api.Group("/threads")
 		{
 			apiThreads.POST("", h.CreateThreads, requires(permission.CreateChannel))
-			apiThreads.PATCH("/:channelID", h.EditThread, requires(permission.EditChannel))
+			apiThreads.PATCH("/:channelID", h.EditThread, requires(permission.GetChannel))
 		}
 		apiMessages := api.Group("/messages")
 		{

--- a/service/channel/manager.go
+++ b/service/channel/manager.go
@@ -16,6 +16,7 @@ var (
 	ErrChannelNameConflicts = errors.New("channel name conflicts")
 	ErrInvalidChannelName   = errors.New("invalid channel name")
 	ErrInvalidChannelPath   = errors.New("invalid channel path")
+	ErrInvalidChannelType   = errors.New("invalid channel type")
 	ErrInvalidParentChannel = errors.New("invalid parent channel")
 	ErrTooDeepChannel       = errors.New("too deep channel")
 	ErrChannelArchived      = errors.New("channel archived")
@@ -42,6 +43,7 @@ type Manager interface {
 	GetDMChannelMapping(ctx context.Context, userID uuid.UUID) (map[uuid.UUID]uuid.UUID, error)
 
 	CreateThreadChannel(ctx context.Context, name string, parent, creatorID uuid.UUID) (*model.Channel, error)
+	UpdateThread(ctx context.Context, id uuid.UUID, args repository.UpdateThreadArgs) error
 
 	IsChannelAccessibleToUser(ctx context.Context, userID, channelID uuid.UUID) (bool, error)
 	IsPublicChannel(ctx context.Context, id uuid.UUID) bool

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -138,6 +138,10 @@ func (m *managerImpl) UpdateChannel(ctx context.Context, id uuid.UUID, args repo
 		return ErrChannelNotFound
 	}
 
+	if ch.Type != model.ChannelTypePublic && ch.Type != model.ChannelTypeDM {
+		return ErrInvalidChannelType
+	}
+
 	// トピックが同じだった場合、トピックの引数自体を無効化
 	if ch.Topic == args.Topic.V {
 		args.Topic = optional.New("", false)
@@ -263,12 +267,13 @@ func (m *managerImpl) UpdateThread(ctx context.Context, id uuid.UUID, args repos
 		return ErrInvalidChannelType
 	}
 
-	m.T.Lock()
-	defer m.T.Unlock()
 	_, err = m.GetChannel(ctx, ch.ParentID)
 	if err != nil {
 		return fmt.Errorf("failed to UpdateThread: %w", err)
 	}
+
+	m.T.Lock()
+	defer m.T.Unlock()
 
 	eventRecords := map[model.ChannelEventType]model.ChannelEventDetail{}
 	if args.Visibility.Valid && ch.IsVisible != args.Visibility.V {
@@ -286,10 +291,6 @@ func (m *managerImpl) UpdateThread(ctx context.Context, id uuid.UUID, args repos
 			}
 		}
 
-		// スレッド名検証
-		if !validator.ChannelRegex.MatchString(args.Name.V) {
-			return ErrInvalidChannelName
-		}
 		eventRecords[model.ChannelEventNameChanged] = model.ChannelEventDetail{
 			"userId": args.UpdaterID,
 			"before": ch.Name,

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -508,13 +508,11 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
 	m.T.add(ch)
-	if parent != pubChannelRootUUID {
-		// ロギング
-		m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
-			"userId":    ch.CreatorID,
-			"channelId": ch.ID,
-		}, ch.CreatedAt)
-	}
+	// ロギング
+	m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
+		"userId":    ch.CreatorID,
+		"channelId": ch.ID,
+	}, ch.CreatedAt)
 	m.L.Info(fmt.Sprintf("channel #%s was created", m.T.getChannelPath(ch.ID)), zap.Stringer("cid", ch.ID))
 	return ch, nil
 }

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -472,19 +472,27 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 	m.T.Lock()
 	defer m.T.Unlock()
 
-	if parent != pubChannelRootUUID {
-		// 親チャンネルの存在を確認
-		if !m.T.isChannelPresent(parent) {
-			return nil, ErrInvalidParentChannel
-		}
-		// 親チャンネルがスレッドかどうか確認
-		if m.T.isThreadChannel(parent) {
-			return nil, ErrChannelThreadParent
-		}
-		// 親チャンネルがアーカイブされているかどうか確認
-		if m.T.isArchivedChannel(parent) {
-			return nil, ErrChannelArchived
-		}
+	// ルートチャンネルの下にスレッドは作れない
+	if parent == pubChannelRootUUID {
+		return nil, ErrInvalidParentChannel
+	}
+
+	// 既にある名前のスレッドは作れない
+	if m.T.isChildPresent(name, parent) {
+		return nil, ErrChannelNameConflicts
+	}
+
+	// 親チャンネルの存在を確認
+	if !m.T.isChannelPresent(parent) {
+		return nil, ErrInvalidParentChannel
+	}
+	// 親チャンネルがスレッドかどうか確認
+	if m.T.isThreadChannel(parent) {
+		return nil, ErrChannelThreadParent
+	}
+	// 親チャンネルがアーカイブされているかどうか確認
+	if m.T.isArchivedChannel(parent) {
+		return nil, ErrChannelArchived
 	}
 
 	// チャンネル作成

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -163,12 +163,6 @@ func (m *managerImpl) UpdateChannel(ctx context.Context, id uuid.UUID, args repo
 			"visibility": args.Visibility.V,
 		}
 	}
-	if args.ForcedNotification.Valid && ch.IsForced != args.ForcedNotification.V {
-		eventRecords[model.ChannelEventForcedNotificationChanged] = model.ChannelEventDetail{
-			"userId": args.UpdaterID,
-			"force":  args.ForcedNotification.V,
-		}
-	}
 	if args.Name.Valid || args.Parent.Valid {
 		// チャンネル名重複を確認
 		{
@@ -244,6 +238,68 @@ func (m *managerImpl) UpdateChannel(ctx context.Context, id uuid.UUID, args repo
 	if args.Name.Valid || args.Parent.Valid {
 		m.T.move(id, args.Parent, args.Name)
 	}
+	m.T.updateSingle(id, ch)
+
+	updated := time.Now()
+	for eventType, detail := range eventRecords {
+		m.recordChannelEvent(id, eventType, detail, updated)
+	}
+	return nil
+}
+
+func (m *managerImpl) UpdateThread(ctx context.Context, id uuid.UUID, args repository.UpdateThreadArgs) error {
+	ch, err := m.GetChannel(ctx, id)
+	if err != nil {
+		return ErrChannelNotFound
+	}
+
+	if ch.Type != model.ChannelTypeThread {
+		return ErrInvalidChannelType
+	}
+
+	m.T.Lock()
+	defer m.T.Unlock()
+	_, err = m.GetChannel(ctx, ch.ParentID)
+	if err != nil {
+		return fmt.Errorf("failed to UpdateThread: %w", err)
+	}
+
+	eventRecords := map[model.ChannelEventType]model.ChannelEventDetail{}
+	if args.Visibility.Valid && ch.IsVisible != args.Visibility.V {
+		eventRecords[model.ChannelEventVisibilityChanged] = model.ChannelEventDetail{
+			"userId":     args.UpdaterID,
+			"visibility": args.Visibility.V,
+		}
+	}
+
+	if args.Name.Valid {
+		// スレッド名重複を確認
+		{
+			if m.T.isChildPresent(args.Name.V, ch.ParentID) {
+				return ErrChannelNameConflicts
+			}
+		}
+
+		// スレッド名検証
+		if !validator.ChannelRegex.MatchString(args.Name.V) {
+			return ErrInvalidChannelName
+		}
+		eventRecords[model.ChannelEventNameChanged] = model.ChannelEventDetail{
+			"userId": args.UpdaterID,
+			"before": ch.Name,
+			"after":  args.Name.V,
+		}
+	}
+
+	ch, err = m.R.UpdateChannel(ctx, id, repository.UpdateChannelArgs{
+		UpdaterID:  args.UpdaterID,
+		Name:       args.Name,
+		Visibility: args.Visibility,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to UpdateChannel: %w", err)
+	}
+
 	m.T.updateSingle(id, ch)
 
 	updated := time.Now()
@@ -416,27 +472,19 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 	m.T.Lock()
 	defer m.T.Unlock()
 
-	// ルートチャンネルの下にスレッドは作れない
-	if parent == pubChannelRootUUID {
-		return nil, ErrInvalidParentChannel
-	}
-
-	// 既にある名前のスレッドは作れない
-	if m.T.isChildPresent(name, parent) {
-		return nil, ErrChannelNameConflicts
-	}
-
-	// 親チャンネルの存在を確認
-	if !m.T.isChannelPresent(parent) {
-		return nil, ErrInvalidParentChannel
-	}
-	// 親チャンネルがスレッドかどうか確認
-	if m.T.isThreadChannel(parent) {
-		return nil, ErrChannelThreadParent
-	}
-	// 親チャンネルがアーカイブされているかどうか確認
-	if m.T.isArchivedChannel(parent) {
-		return nil, ErrChannelArchived
+	if parent != pubChannelRootUUID {
+		// 親チャンネルの存在を確認
+		if !m.T.isChannelPresent(parent) {
+			return nil, ErrInvalidParentChannel
+		}
+		// 親チャンネルがスレッドかどうか確認
+		if m.T.isThreadChannel(parent) {
+			return nil, ErrChannelThreadParent
+		}
+		// 親チャンネルがアーカイブされているかどうか確認
+		if m.T.isArchivedChannel(parent) {
+			return nil, ErrChannelArchived
+		}
 	}
 
 	// チャンネル作成
@@ -452,11 +500,13 @@ func (m *managerImpl) CreateThreadChannel(ctx context.Context, name string, pare
 		return nil, fmt.Errorf("failed to CreateChannel: %w", err)
 	}
 	m.T.add(ch)
-	// ロギング
-	m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
-		"userId":    ch.CreatorID,
-		"channelId": ch.ID,
-	}, ch.CreatedAt)
+	if parent != pubChannelRootUUID {
+		// ロギング
+		m.recordChannelEvent(ch.ParentID, model.ChannelEventChildCreated, model.ChannelEventDetail{
+			"userId":    ch.CreatorID,
+			"channelId": ch.ID,
+		}, ch.CreatedAt)
+	}
 	m.L.Info(fmt.Sprintf("channel #%s was created", m.T.getChannelPath(ch.ID)), zap.Stringer("cid", ch.ID))
 	return ch, nil
 }

--- a/service/channel/manager_impl.go
+++ b/service/channel/manager_impl.go
@@ -163,6 +163,12 @@ func (m *managerImpl) UpdateChannel(ctx context.Context, id uuid.UUID, args repo
 			"visibility": args.Visibility.V,
 		}
 	}
+	if args.ForcedNotification.Valid && ch.IsForced != args.ForcedNotification.V {
+		eventRecords[model.ChannelEventForcedNotificationChanged] = model.ChannelEventDetail{
+			"userId": args.UpdaterID,
+			"force":  args.ForcedNotification.V,
+		}
+	}
 	if args.Name.Valid || args.Parent.Valid {
 		// チャンネル名重複を確認
 		{

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -461,7 +461,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Return(nil, mockErr).
 			AnyTimes()
 
-		_, err := cm.CreateThreadChannel(context.TODO(), "test", uuid.Nil, uuid.Nil)
+		_, err := cm.CreateThreadChannel(context.TODO(), "test", cEK, uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -475,7 +475,6 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Parent  uuid.UUID
 			Creator uuid.UUID
 		}{
-			{Name: "test1", Parent: uuid.Nil, Creator: cA},
 			{Name: "test1", Parent: cA, Creator: cAB},
 			{Name: "test2", Parent: cA, Creator: cABC},
 			{Name: "test2", Parent: cEFGJ, Creator: cABCD},

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -384,42 +384,6 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 		}
 	})
 
-	t.Run("RootParentChannel", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		repo := mock_repository.NewMockChannelRepository(ctrl)
-		cm := initCM(t, repo)
-
-		cases := []struct {
-			Name   string
-			Parent uuid.UUID
-		}{
-			{Name: "b", Parent: pubChannelRootUUID},
-		}
-		for _, c := range cases {
-			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
-			assert.EqualError(t, err, ErrInvalidParentChannel.Error())
-		}
-	})
-
-	t.Run("ErrThreadNameConflicts", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		repo := mock_repository.NewMockChannelRepository(ctrl)
-		cm := initCM(t, repo)
-
-		cases := []struct {
-			Name   string
-			Parent uuid.UUID
-		}{
-			{Name: "l", Parent: cEK},
-		}
-		for _, c := range cases {
-			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
-			assert.EqualError(t, err, ErrChannelNameConflicts.Error())
-		}
-	})
-
 	t.Run("ErrChannelArchived", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -461,7 +425,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Return(nil, mockErr).
 			AnyTimes()
 
-		_, err := cm.CreateThreadChannel(context.TODO(), "test", cEK, uuid.Nil)
+		_, err := cm.CreateThreadChannel(context.TODO(), "test", uuid.Nil, uuid.Nil)
 		if assert.Error(t, err) {
 			assert.Equal(t, mockErr, errors.Unwrap(err))
 		}
@@ -475,6 +439,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 			Parent  uuid.UUID
 			Creator uuid.UUID
 		}{
+			{Name: "test1", Parent: uuid.Nil, Creator: cA},
 			{Name: "test1", Parent: cA, Creator: cAB},
 			{Name: "test2", Parent: cA, Creator: cABC},
 			{Name: "test2", Parent: cEFGJ, Creator: cABCD},
@@ -497,7 +462,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 							ParentID:   c.Parent,
 							CreatorID:  c.Creator,
 							UpdaterID:  c.Creator,
-							Type:       model.ChannelTypeThread,
+							Type:       model.ChannelTypePublic,
 							IsForced:   false,
 							IsVisible:  true,
 							CreatedAt:  createdAt,
@@ -507,7 +472,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), model.ChannelTypeThread).
+							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {

--- a/service/channel/manager_impl_test.go
+++ b/service/channel/manager_impl_test.go
@@ -384,6 +384,42 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 		}
 	})
 
+	t.Run("RootParentChannel", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "b", Parent: pubChannelRootUUID},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrInvalidParentChannel.Error())
+		}
+	})
+
+	t.Run("ErrThreadNameConflicts", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		repo := mock_repository.NewMockChannelRepository(ctrl)
+		cm := initCM(t, repo)
+
+		cases := []struct {
+			Name   string
+			Parent uuid.UUID
+		}{
+			{Name: "l", Parent: cEK},
+		}
+		for _, c := range cases {
+			_, err := cm.CreateThreadChannel(context.TODO(), c.Name, c.Parent, uuid.Nil)
+			assert.EqualError(t, err, ErrChannelNameConflicts.Error())
+		}
+	})
+
 	t.Run("ErrChannelArchived", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -462,7 +498,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 							ParentID:   c.Parent,
 							CreatorID:  c.Creator,
 							UpdaterID:  c.Creator,
-							Type:       model.ChannelTypePublic,
+							Type:       model.ChannelTypeThread,
 							IsForced:   false,
 							IsVisible:  true,
 							CreatedAt:  createdAt,
@@ -472,7 +508,7 @@ func TestManagerImpl_CreateThreadChannel(t *testing.T) {
 						}
 
 						repo.EXPECT().
-							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+							CreateChannel(gomock.Any(), gomock.Any(), gomock.Any(), model.ChannelTypeThread).
 							Return(expected, nil).
 							AnyTimes()
 						if c.Parent != uuid.Nil {

--- a/service/channel/mock_channel/mock_manager.go
+++ b/service/channel/mock_channel/mock_manager.go
@@ -256,6 +256,20 @@ func (mr *MockManagerMockRecorder) UpdateChannel(ctx, id, args interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockManager)(nil).UpdateChannel), ctx, id, args)
 }
 
+// UpdateThread mocks base method.
+func (m *MockManager) UpdateThread(ctx context.Context, id uuid.UUID, args repository.UpdateThreadArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateThread", ctx, id, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateThread indicates an expected call of UpdateThread.
+func (mr *MockManagerMockRecorder) UpdateThread(ctx, id, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateThread", reflect.TypeOf((*MockManager)(nil).UpdateThread), ctx, id, args)
+}
+
 // Wait mocks base method.
 func (m *MockManager) Wait() {
 	m.ctrl.T.Helper()

--- a/service/channel/tree_impl_test.go
+++ b/service/channel/tree_impl_test.go
@@ -52,6 +52,7 @@ e : 6301b259-2a3e-4a30-9ec8-78737c4b539d force
 │ 　 │ └ i : 55339fb1-c3c8-4c52-a053-8af0845c45e9
 │ 　 └ j : 071eefb9-0a77-4cc4-8d38-5c214aca85f0
 └ k : 2636a1e1-5356-4c5f-8822-c52eeb914689
+
 	└ l : d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f thread
 */
 func makeTestChannelTree(t *testing.T) *treeImpl {

--- a/service/channel/tree_impl_test.go
+++ b/service/channel/tree_impl_test.go
@@ -52,7 +52,6 @@ e : 6301b259-2a3e-4a30-9ec8-78737c4b539d force
 │ 　 │ └ i : 55339fb1-c3c8-4c52-a053-8af0845c45e9
 │ 　 └ j : 071eefb9-0a77-4cc4-8d38-5c214aca85f0
 └ k : 2636a1e1-5356-4c5f-8822-c52eeb914689
-
 	└ l : d1c8e5b7-9a1c-4f0b-9c3e-2a1b2c3d4e5f thread
 */
 func makeTestChannelTree(t *testing.T) *treeImpl {


### PR DESCRIPTION
patch/threadの実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated endpoint for editing thread channels.
  - Supports optional thread renaming and archived/unarchived updates in one request.
  - Added a dedicated permission for editing thread channels, included in the write role.

- **Bug Fixes**
  - Added thread-name validation and clearer responses for invalid names and unsupported channel types.
  - Thread channels can no longer be archived or unarchived through standard channel archive actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->